### PR TITLE
Enhance FileCacheDriver with sharding and stats cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # framework
 Glueful API Framework - High-performance PHP API framework
+
+## File Cache Enhancements
+
+- Sharding: To avoid large flat directories for file cache, you can shard cache files by enabling hashed subdirectories.
+
+```php
+use Glueful\Cache\Drivers\FileCacheDriver;
+use Glueful\Services\FileManager;
+use Glueful\Services\FileFinder;
+
+$cache = new FileCacheDriver(__DIR__ . '/storage/cache', new FileManager(), new FileFinder());
+$cache->setShardDirectories(true); // creates paths like cache/ab/<hash>.cache
+```
+
+- Stats Cache: For large caches, enable a lightweight in-process stats cache to avoid full directory scans on every `getStats()`.
+
+```php
+$cache->setStatsCacheEnabled(true); // lazily initializes and keeps counters updated on set/del
+```
+
+- Remember + null values: `remember()` now correctly handles cached nulls. If a key exists with a null value, `remember()` returns null instead of recomputing.

--- a/src/Services/FileFinder.php
+++ b/src/Services/FileFinder.php
@@ -332,7 +332,7 @@ class FileFinder
             $finder->ignoreDotFiles(true);
         }
 
-        if (!(bool)($this->config['follow_links'] ?? false)) {
+        if ((bool)($this->config['follow_links'] ?? false)) {
             $finder->followLinks();
         }
 


### PR DESCRIPTION
Added support for sharding cache files into hashed subdirectories and an in-process stats cache to improve performance for large caches. Improved handling of null values in remember(), atomic operations with file locks, and more robust pattern matching for key operations. Also fixed symlink following logic in FileFinder.