### PR TITLE
Router verb completeness: first-class PATCH/OPTIONS + documented precedence (v1.48.0 — Imai)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ---
 
+## [1.48.0] - 2026-05-31 — Imai
+
+> **Theme: Router Verb Completeness.** `PATCH` and `OPTIONS` become first-class routing verbs (they were previously unreachable through the public API), explicit `OPTIONS` routes now win over the automatic CORS preflight responder, and the route-precedence model is documented and pinned with tests. Purely additive — no breaking changes, no new env vars, no migrations.
+
+### Added
+- **`PATCH` and `OPTIONS` are now first-class HTTP verbs in the router.** New `$router->patch()` / `$router->options()` shortcuts and `#[Patch]` / `#[Options]` attributes, and the `#[Route(methods: [...])]` array form now accepts `PATCH`, `OPTIONS` and `HEAD` (previously it threw `InvalidArgumentException` for anything but GET/POST/PUT/DELETE). `PATCH` and `OPTIONS` were previously unreachable through the public routing API.
+- **Explicit `OPTIONS` routes take precedence over automatic CORS preflight.** Dispatch still answers `OPTIONS` automatically (204 + `Allow`) when no `OPTIONS` route is registered for the path, but a route registered via `$router->options(...)` / `#[Options]` now runs its own handler instead of being shadowed.
+
+### Documentation
+- Documented the route-cache **closure limitation** (closure handlers are never cached; the router skips/discards the cache for them and resolves them live) and the expanded HTTP-method surface in `docs/content/2.essentials/1.routing.md`.
+- Documented the **route-precedence model** (static beats dynamic; literal first segment beats a parameter first segment; within a first-segment group, registration order wins — register the more specific overlapping pattern first) in `docs/content/6.cookbook/1.routing.md`.
+
+### Tests
+- Added `tests/Unit/Routing/RoutePrecedenceTest.php` pinning all three precedence tiers, constraint-based fall-through, single-segment parameter matching, trailing-slash normalization, and method isolation (405 vs match). Corrected a misleading in-code comment in `Router::match()` that claimed a specificity sort the router does not perform.
+
+---
+
 ## [1.47.0] - 2026-05-30 — Hadar
 
 > **Theme: Extension System Re-Architecture.** Extension loading is rebuilt around a single mental model — **Composer discovers, one `enabled` list activates, a pure resolver orders and validates.** The four overlapping discovery sources, the multi-key config files, and the live-resolve/lazy-cache dev↔prod parity hazard are gone. Breaking change to `config/extensions.php` and `config/serviceproviders.php`; see `docs/EXTENSIONS_UPGRADE.md`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,12 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.48.0 — Imai (Released 2026-05-31)
+- **Router Verb Completeness**: `PATCH` and `OPTIONS` become first-class routing verbs. New `$router->patch()` / `$router->options()` shortcuts and `#[Patch]` / `#[Options]` attributes; the `#[Route(methods: [...])]` array form now accepts `PATCH`, `OPTIONS` and `HEAD` (it previously threw for anything but GET/POST/PUT/DELETE). Both verbs were previously unreachable through the public routing API.
+- **Explicit `OPTIONS` beats auto-CORS**: `Router::dispatch()` still answers `OPTIONS` automatically (204 + `Allow`) when no `OPTIONS` route is registered, but an explicitly registered `OPTIONS` route now runs its own handler instead of being silently shadowed by the CORS preflight responder.
+- **Route precedence documented and pinned**: The three-tier precedence model (static beats dynamic; literal first segment beats a parameter first segment; within a first-segment group, registration order wins) is now documented in the cookbook and locked down by `RoutePrecedenceTest`. A misleading in-code comment in `Router::match()` claiming a specificity sort that never existed was corrected.
+- Notes: **Minor release, fully backward compatible.** Framework-only — no migrations, no env vars, no breaking changes. The existing api-skeleton `^1.47.0` constraint already permits 1.48.0; the skeleton constraint is bumped to `^1.48.0` for clarity.
+
 ### 1.47.0 — Hadar (Released 2026-05-30)
 - **Extension System Re-Architecture**: Extension loading is rebuilt around a single model — **Composer discovers, one `enabled` list activates, a pure resolver orders and validates.** The four overlapping discovery sources, the multi-key config files, and the dev↔prod parity hazard (live-resolve in dev, lazy-cache in prod) are gone. `config/extensions.php` and `config/serviceproviders.php` are now a single `enabled` list of plain string FQCNs.
 - **Pure `ExtensionResolver` + shared `ProviderClassResolver`**: A pure resolver selects from `enabled`, validates (missing provider/dependency, framework-version mismatch via `composer/semver`, dependency cycle), and topologically orders providers — reading no environment, so dev and prod resolve identically. `ProviderClassResolver` is the one resolution path used by both `ExtensionManager` and `ContainerFactory` (no drift). `PackageManifest::getCandidates()` reads `installed.json` for the full `extra.glueful` metadata.

--- a/src/Routing/AttributeRouteLoader.php
+++ b/src/Routing/AttributeRouteLoader.php
@@ -7,7 +7,7 @@ namespace Glueful\Routing;
 use Glueful\Api\RateLimiting\Attributes\RateLimit;
 use Glueful\Api\RateLimiting\Attributes\RateLimitCost;
 use Glueful\Routing\Attributes\RequireScope;
-use Glueful\Routing\Attributes\{Route, Controller, Middleware, Get, Post, Put, Delete, Fields};
+use Glueful\Routing\Attributes\{Route, Controller, Middleware, Get, Post, Put, Patch, Delete, Options, Fields};
 
 class AttributeRouteLoader
 {
@@ -143,7 +143,10 @@ class AttributeRouteLoader
                     'GET' => $this->router->get($fullPath, [$className, $methodName]),
                     'POST' => $this->router->post($fullPath, [$className, $methodName]),
                     'PUT' => $this->router->put($fullPath, [$className, $methodName]),
+                    'PATCH' => $this->router->patch($fullPath, [$className, $methodName]),
                     'DELETE' => $this->router->delete($fullPath, [$className, $methodName]),
+                    'HEAD' => $this->router->head($fullPath, [$className, $methodName]),
+                    'OPTIONS' => $this->router->options($fullPath, [$className, $methodName]),
                     default => throw new \InvalidArgumentException("Unsupported HTTP method: {$httpMethod}")
                 };
 
@@ -198,7 +201,9 @@ class AttributeRouteLoader
             Get::class => 'GET',
             Post::class => 'POST',
             Put::class => 'PUT',
+            Patch::class => 'PATCH',
             Delete::class => 'DELETE',
+            Options::class => 'OPTIONS',
         ];
 
         foreach ($httpMethods as $attributeClass => $httpMethod) {
@@ -210,7 +215,9 @@ class AttributeRouteLoader
                     'GET' => $this->router->get($fullPath, [$className, $methodName]),
                     'POST' => $this->router->post($fullPath, [$className, $methodName]),
                     'PUT' => $this->router->put($fullPath, [$className, $methodName]),
-                    'DELETE' => $this->router->delete($fullPath, [$className, $methodName])
+                    'PATCH' => $this->router->patch($fullPath, [$className, $methodName]),
+                    'DELETE' => $this->router->delete($fullPath, [$className, $methodName]),
+                    'OPTIONS' => $this->router->options($fullPath, [$className, $methodName])
                 };
 
                 if (count($middleware) > 0) {

--- a/src/Routing/Attributes/Options.php
+++ b/src/Routing/Attributes/Options.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Routing\Attributes;
+
+// Shorthand attributes for common HTTP methods
+#[\Attribute(\Attribute::TARGET_METHOD)]
+class Options
+{
+    /**
+     * @param array<string, string> $where
+     */
+    public function __construct(
+        public string $path,
+        public ?string $name = null,
+        public array $where = []
+    ) {
+    }
+}

--- a/src/Routing/Attributes/Patch.php
+++ b/src/Routing/Attributes/Patch.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Routing\Attributes;
+
+// Shorthand attributes for common HTTP methods
+#[\Attribute(\Attribute::TARGET_METHOD)]
+class Patch
+{
+    /**
+     * @param array<string, string> $where
+     */
+    public function __construct(
+        public string $path,
+        public ?string $name = null,
+        public array $where = []
+    ) {
+    }
+}

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -84,6 +84,19 @@ class Router
         return $this->add('HEAD', $path, $handler);
     }
 
+    public function patch(string $path, mixed $handler): Route
+    {
+        return $this->add('PATCH', $path, $handler);
+    }
+
+    // Registers an explicit OPTIONS handler. Note: by default dispatch() answers
+    // OPTIONS automatically for CORS preflight; an explicit route registered here
+    // takes precedence over that automatic handling for the matched path.
+    public function options(string $path, mixed $handler): Route
+    {
+        return $this->add('OPTIONS', $path, $handler);
+    }
+
     // Core route registration
     private function add(string $method, string $path, mixed $handler): Route
     {
@@ -294,17 +307,24 @@ class Router
             ];
         }
 
-        // 2. Try dynamic routes with first-segment optimization
-        // IMPORTANT: Routes are now pre-sorted by precedence within buckets
-        // This ensures /users/me always wins over /users/{id}
+        // 2. No exact static hit — try dynamic routes, bucketed by first segment.
+        // Precedence is NOT a specificity sort; it comes from two things:
+        //   (a) Static routes already won above (step 1), so e.g. a static
+        //       /users/me beats a dynamic /users/{id} regardless of order.
+        //   (b) Routes whose first segment is a literal live in that segment's
+        //       bucket; routes whose first segment is a parameter live in the
+        //       '*' bucket. We try the literal-segment bucket before '*', so
+        //       /users/{id} beats /{resource}/{id} for a request to /users/5.
+        // WITHIN a single bucket there is NO ranking — routes are tried in
+        // registration order, so for two overlapping dynamic patterns with the
+        // same first segment (e.g. /posts/{id}/edit vs /posts/{id}/{action}),
+        // register the more specific one FIRST or it will not be reached.
         $segments = explode('/', trim($path, '/'));
         $firstSegment = $segments[0] ?? '';
 
-        // Check bucketed routes in precedence order (already sorted)
-        // Static segments get priority over wildcard bucket
         $candidates = array_merge(
             $this->routeBuckets[$method][$firstSegment] ?? [],
-            $this->routeBuckets[$method]['*'] ?? [] // Wildcard bucket
+            $this->routeBuckets[$method]['*'] ?? [] // Parameter-first-segment bucket
         );
 
         foreach ($candidates as $route) {
@@ -361,6 +381,16 @@ class Router
         }
 
         return array_unique($allowed);
+    }
+
+    // Whether an explicit OPTIONS route is registered for this request. When one
+    // exists, dispatch() lets it handle the request instead of returning the
+    // automatic CORS preflight response.
+    private function hasExplicitOptionsRoute(Request $request): bool
+    {
+        $match = $this->match($request);
+
+        return $match !== null && ($match['route'] ?? null) !== null;
     }
 
     // Group support with middleware
@@ -563,8 +593,10 @@ class Router
     {
         $originalMethod = $request->getMethod();
 
-        // Handle OPTIONS for CORS (before any processing)
-        if ($originalMethod === 'OPTIONS') {
+        // Handle OPTIONS for CORS (before any processing). An explicitly
+        // registered OPTIONS route takes precedence: if one matches this path,
+        // skip the automatic CORS responder and let the route's handler run.
+        if ($originalMethod === 'OPTIONS' && !$this->hasExplicitOptionsRoute($request)) {
             $path = '/' . ltrim(rawurldecode($request->getPathInfo()), '/');
             $path = rtrim($path, '/');
             $path = $path !== '' ? $path : '/';

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,15 +13,15 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.47.0';
+    public const VERSION = '1.48.0';
 
 
     /** Release code name */
-    public const NAME = 'Hadar';
+    public const NAME = 'Imai';
 
 
     /** Release date */
-    public const RELEASE_DATE = '2026-05-30';
+    public const RELEASE_DATE = '2026-05-31';
 
     /** Minimum required PHP version */
     public const MIN_PHP_VERSION = '8.3.0';

--- a/tests/Unit/Routing/AttributeRouteLoaderTest.php
+++ b/tests/Unit/Routing/AttributeRouteLoaderTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Glueful\Bootstrap\ApplicationContext;
 use Glueful\Routing\Router;
 use Glueful\Routing\AttributeRouteLoader;
-use Glueful\Routing\Attributes\{Controller, Get, Post, Put, Delete, Middleware, Route};
+use Glueful\Routing\Attributes\{Controller, Get, Post, Put, Patch, Delete, Options, Middleware, Route};
 use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -119,11 +119,44 @@ class AttributeRouteLoaderTest extends TestCase
         $this->assertNotNull($putMatch);
         $this->assertEquals([TestApiController::class, 'update'], $putMatch['route']->getHandler());
 
+        // Test PATCH
+        $patchRequest = Request::create('/api/test/users/123', 'PATCH');
+        $patchMatch = $this->router->match($patchRequest);
+        $this->assertNotNull($patchMatch);
+        $this->assertEquals([TestApiController::class, 'patchUser'], $patchMatch['route']->getHandler());
+
         // Test DELETE
         $deleteRequest = Request::create('/api/test/users/123', 'DELETE');
         $deleteMatch = $this->router->match($deleteRequest);
         $this->assertNotNull($deleteMatch);
         $this->assertEquals([TestApiController::class, 'destroy'], $deleteMatch['route']->getHandler());
+
+        // Test OPTIONS (explicit route registered via #[Options])
+        $optionsRequest = Request::create('/api/test/users', 'OPTIONS');
+        $optionsMatch = $this->router->match($optionsRequest);
+        $this->assertNotNull($optionsMatch);
+        $this->assertEquals([TestApiController::class, 'preflight'], $optionsMatch['route']->getHandler());
+    }
+
+    /**
+     * The #[Route(methods: [...])] form must accept PATCH/OPTIONS/HEAD, not just
+     * the original GET/POST/PUT/DELETE (which previously threw).
+     */
+    public function testRouteAttributeAcceptsExtendedMethods(): void
+    {
+        $this->loader->processClass(TestVerbController::class);
+
+        $patchMatch = $this->router->match(Request::create('/verbs/item/5', 'PATCH'));
+        $this->assertNotNull($patchMatch);
+        $this->assertEquals([TestVerbController::class, 'patch'], $patchMatch['route']->getHandler());
+
+        $optionsMatch = $this->router->match(Request::create('/verbs/item', 'OPTIONS'));
+        $this->assertNotNull($optionsMatch);
+        $this->assertEquals([TestVerbController::class, 'meta'], $optionsMatch['route']->getHandler());
+
+        $headMatch = $this->router->match(Request::create('/verbs/item', 'HEAD'));
+        $this->assertNotNull($headMatch);
+        $this->assertEquals([TestVerbController::class, 'meta'], $headMatch['route']->getHandler());
     }
 
     /**
@@ -251,11 +284,44 @@ class TestApiController
         return new JsonResponse(['updated' => $id]);
     }
 
+    #[Patch('/users/{id}', name: 'users.patch', where: ['id' => '\d+'])]
+    #[Middleware('auth:admin')]
+    public function patchUser(int $id): JsonResponse
+    {
+        return new JsonResponse(['patched' => $id]);
+    }
+
     #[Delete('/users/{id}', name: 'users.destroy', where: ['id' => '\d+'])]
     #[Middleware('auth:admin')]
     public function destroy(int $id): JsonResponse
     {
         return new JsonResponse(['deleted' => $id]);
+    }
+
+    #[Options('/users')]
+    public function preflight(): JsonResponse
+    {
+        return new JsonResponse(['options' => true]);
+    }
+}
+
+/**
+ * Test controller exercising the #[Route(methods: [...])] array form with the
+ * extended verb set (PATCH/OPTIONS/HEAD).
+ */
+#[Controller(prefix: '/verbs')]
+class TestVerbController
+{
+    #[Route('/item/{id}', methods: ['PATCH'], where: ['id' => '\d+'])]
+    public function patch(int $id): JsonResponse
+    {
+        return new JsonResponse(['patched' => $id]);
+    }
+
+    #[Route('/item', methods: ['OPTIONS', 'HEAD'])]
+    public function meta(): JsonResponse
+    {
+        return new JsonResponse(['ok' => true]);
     }
 }
 

--- a/tests/Unit/Routing/RoutePrecedenceTest.php
+++ b/tests/Unit/Routing/RoutePrecedenceTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Routing;
+
+use PHPUnit\Framework\TestCase;
+use Glueful\Bootstrap\ApplicationContext;
+use Glueful\Routing\Router;
+use Glueful\Routing\RouteCache;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Pins the router's route-precedence model so refactors can't silently change
+ * it. The model has three tiers (see Router::match()):
+ *   1. Exact static routes win first.
+ *   2. A literal-first-segment bucket is tried before the parameter ('*')
+ *      bucket, so /users/{id} beats /{resource}/{id} — independent of order.
+ *   3. WITHIN a bucket there is no specificity ranking: first registered that
+ *      matches wins. Register the more specific overlapping pattern first.
+ */
+class RoutePrecedenceTest extends TestCase
+{
+    private function newRouter(): Router
+    {
+        $context = new ApplicationContext(sys_get_temp_dir() . '/route_precedence_' . uniqid());
+        (new RouteCache($context))->clear();
+
+        $container = new class implements ContainerInterface {
+            /** @var array<string,mixed> */
+            private array $services = [];
+            public function has(string $id): bool
+            {
+                return array_key_exists($id, $this->services);
+            }
+            public function get(string $id): mixed
+            {
+                if ($this->has($id)) {
+                    return $this->services[$id];
+                }
+                throw new class ("Service '" . $id . "' not found") extends \RuntimeException implements
+                    \Psr\Container\NotFoundExceptionInterface {
+                };
+            }
+            public function set(string $id, mixed $service): void
+            {
+                $this->services[$id] = $service;
+            }
+        };
+        $container->set(ApplicationContext::class, $context);
+
+        return new Router($container);
+    }
+
+    private function matchedPath(Router $router, string $path, string $method = 'GET'): ?string
+    {
+        $match = $router->match(Request::create($path, $method));
+        if ($match === null || ($match['route'] ?? null) === null) {
+            return null;
+        }
+        return $match['route']->getPath();
+    }
+
+    /**
+     * Tier 1: a static route beats an overlapping dynamic route regardless of
+     * the order they were registered in.
+     */
+    public function testStaticBeatsDynamicEitherRegistrationOrder(): void
+    {
+        // Dynamic registered first
+        $a = $this->newRouter();
+        $a->get('/users/{id}', fn($id) => "dynamic $id");
+        $a->get('/users/me', fn() => 'static');
+        $this->assertSame('/users/me', $this->matchedPath($a, '/users/me'));
+
+        // Static registered first
+        $b = $this->newRouter();
+        $b->get('/users/me', fn() => 'static');
+        $b->get('/users/{id}', fn($id) => "dynamic $id");
+        $this->assertSame('/users/me', $this->matchedPath($b, '/users/me'));
+
+        // The dynamic route still serves everything else
+        $this->assertSame('/users/{id}', $this->matchedPath($b, '/users/42'));
+    }
+
+    /**
+     * Tier 2: a route with a literal first segment is tried before one whose
+     * first segment is a parameter ('*' bucket) — independent of order.
+     */
+    public function testLiteralFirstSegmentBeatsParameterBucketEitherOrder(): void
+    {
+        // Parameter-first-segment route registered first
+        $a = $this->newRouter();
+        $a->get('/{resource}/{id}', fn($resource, $id) => 'generic');
+        $a->get('/users/{id}', fn($id) => 'users');
+        $this->assertSame('/users/{id}', $this->matchedPath($a, '/users/5'));
+        // A first segment with no literal bucket still falls through to '*'
+        $this->assertSame('/{resource}/{id}', $this->matchedPath($a, '/posts/5'));
+
+        // Literal-first-segment route registered first (order must not matter)
+        $b = $this->newRouter();
+        $b->get('/users/{id}', fn($id) => 'users');
+        $b->get('/{resource}/{id}', fn($resource, $id) => 'generic');
+        $this->assertSame('/users/{id}', $this->matchedPath($b, '/users/5'));
+    }
+
+    /**
+     * Tier 3 (the footgun, pinned intentionally): two overlapping dynamic
+     * patterns in the SAME bucket are resolved by registration order, NOT by
+     * specificity. Whichever is registered first wins for the overlapping path.
+     */
+    public function testWithinBucketResolvesByRegistrationOrder(): void
+    {
+        // Specific registered first → specific wins (the recommended ordering)
+        $a = $this->newRouter();
+        $a->get('/posts/{id}/edit', fn($id) => 'edit');
+        $a->get('/posts/{id}/{action}', fn($id, $action) => 'action');
+        $this->assertSame('/posts/{id}/edit', $this->matchedPath($a, '/posts/5/edit'));
+        $this->assertSame('/posts/{id}/{action}', $this->matchedPath($a, '/posts/5/delete'));
+
+        // Generic registered first → generic shadows the specific route. This
+        // documents that the router does NOT rank by specificity; it is a
+        // deliberate assertion of current behavior, not desired behavior.
+        $b = $this->newRouter();
+        $b->get('/posts/{id}/{action}', fn($id, $action) => 'action');
+        $b->get('/posts/{id}/edit', fn($id) => 'edit');
+        $this->assertSame('/posts/{id}/{action}', $this->matchedPath($b, '/posts/5/edit'));
+    }
+
+    /**
+     * Parameter constraints participate in matching: a constrained route that
+     * fails its constraint falls through to the next candidate in the bucket.
+     */
+    public function testConstraintCausesFallthroughWithinBucket(): void
+    {
+        $router = $this->newRouter();
+        $router->get('/users/{id}', fn($id) => 'numeric')->where('id', '\d+');
+        $router->get('/users/{slug}', fn($slug) => 'slug');
+
+        $this->assertSame('/users/{id}', $this->matchedPath($router, '/users/42'));
+        $this->assertSame('/users/{slug}', $this->matchedPath($router, '/users/me'));
+    }
+
+    /**
+     * Parameters match exactly one segment (default constraint [^/]+), so
+     * routes of different segment counts never cross-match.
+     */
+    public function testParametersMatchSingleSegmentOnly(): void
+    {
+        $router = $this->newRouter();
+        $router->get('/files/{name}', fn($name) => 'one');
+        $router->get('/files/{dir}/{name}', fn($dir, $name) => 'two');
+
+        $this->assertSame('/files/{name}', $this->matchedPath($router, '/files/report'));
+        $this->assertSame('/files/{dir}/{name}', $this->matchedPath($router, '/files/2026/report'));
+        // Three segments match neither
+        $this->assertNull($this->matchedPath($router, '/files/2026/q2/report'));
+    }
+
+    /**
+     * Trailing slashes are normalized before matching, for both static and
+     * dynamic routes, and the root path resolves.
+     */
+    public function testTrailingSlashNormalization(): void
+    {
+        $router = $this->newRouter();
+        $router->get('/', fn() => 'root');
+        $router->get('/users', fn() => 'list');
+        $router->get('/users/{id}', fn($id) => 'show');
+
+        $this->assertSame('/', $this->matchedPath($router, '/'));
+        $this->assertSame('/users', $this->matchedPath($router, '/users/'));
+        $this->assertSame('/users/{id}', $this->matchedPath($router, '/users/5/'));
+    }
+
+    /**
+     * Precedence never crosses HTTP methods: a path registered only for GET
+     * yields a 405 (route null + allowed_methods) for POST, not a match.
+     */
+    public function testPrecedenceDoesNotCrossMethods(): void
+    {
+        $router = $this->newRouter();
+        $router->get('/users/{id}', fn($id) => 'get');
+
+        $getMatch = $router->match(Request::create('/users/5', 'GET'));
+        $this->assertNotNull($getMatch);
+        $this->assertNotNull($getMatch['route']);
+
+        $postMatch = $router->match(Request::create('/users/5', 'POST'));
+        $this->assertNotNull($postMatch);
+        $this->assertNull($postMatch['route']);
+        $this->assertArrayHasKey('allowed_methods', $postMatch);
+        $this->assertContains('GET', $postMatch['allowed_methods']);
+    }
+}

--- a/tests/Unit/Routing/RouterTest.php
+++ b/tests/Unit/Routing/RouterTest.php
@@ -326,15 +326,48 @@ class RouterTest extends TestCase
         $this->router->get('/resource', fn() => 'GET');
         $this->router->post('/resource', fn() => 'POST');
         $this->router->put('/resource', fn() => 'PUT');
+        $this->router->patch('/resource', fn() => 'PATCH');
         $this->router->delete('/resource', fn() => 'DELETE');
 
-        $methods = ['GET', 'POST', 'PUT', 'DELETE'];
+        $methods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'];
 
         foreach ($methods as $method) {
             $request = Request::create('/resource', $method);
             $response = $this->router->dispatch($request);
             $this->assertEquals($method, $response->getContent());
         }
+    }
+
+    /**
+     * An explicitly registered OPTIONS route must be dispatched to its handler
+     * rather than being shadowed by the automatic CORS preflight response.
+     */
+    public function testExplicitOptionsRouteIsDispatched(): void
+    {
+        $this->router->options('/widgets', fn() => 'custom options');
+
+        $request = Request::create('/widgets', 'OPTIONS');
+        $response = $this->router->dispatch($request);
+
+        $this->assertEquals('custom options', $response->getContent());
+    }
+
+    /**
+     * Without an explicit OPTIONS route, OPTIONS still falls back to the
+     * automatic CORS preflight responder (204 + Allow header).
+     */
+    public function testOptionsFallsBackToCorsWhenNoExplicitRoute(): void
+    {
+        $this->router->get('/widgets', fn() => 'list');
+        $this->router->post('/widgets', fn() => 'create');
+
+        $request = Request::create('/widgets', 'OPTIONS');
+        $response = $this->router->dispatch($request);
+
+        $this->assertEquals(204, $response->getStatusCode());
+        $allow = (string) $response->headers->get('Allow');
+        $this->assertStringContainsString('GET', $allow);
+        $this->assertStringContainsString('POST', $allow);
     }
 
     /**


### PR DESCRIPTION
## Summary
  
  Makes `PATCH` and `OPTIONS` first-class routing verbs, lets explicit `OPTIONS`
  routes win over automatic CORS preflight, and documents + pins the router's
  route-precedence model. Ships as **v1.48.0 "Imai"** — purely additive, no
  breaking changes, no new env vars, no migrations.

  ## What changed
  
  ### PATCH & OPTIONS are now reachable through the public API
  Previously `PATCH` and `OPTIONS` had **no public route-registration path**:
  there were no `$router->patch()`/`options()` shortcuts, no `#[Patch]`/`#[Options]`
  attributes, and the `#[Route(methods: [...])]` array form threw
  `InvalidArgumentException` for anything but GET/POST/PUT/DELETE (it didn't even
  handle HEAD).

  - Added `$router->patch()` and `$router->options()` shortcuts.
  - Added `#[Patch]` and `#[Options]` attributes (mirroring the existing four).
  - The `#[Route(methods: [...])]` form now accepts `PATCH`, `OPTIONS` and `HEAD`.

  ### Explicit OPTIONS routes beat auto-CORS
  `Router::dispatch()` short-circuited *every* OPTIONS request to the automatic
  CORS responder, so an explicitly registered `OPTIONS` handler could never run.
  and only falls back to the automatic 204 + `Allow` preflight when none exists.
  Existing CORS behavior is unchanged when no OPTIONS route is registered.
  
  ### Route precedence: documented and pinned
  `Router::match()` carried a comment claiming routes were "pre-sorted by precedence
  within buckets" — **that sort never existed**. Corrected the comment to describe
  the real three-tier model:
  1. Static routes win first (exact hash hit).
  2. A literal first-segment bucket is tried before the parameter (`*`) bucket.
  3. Within a bucket there is no specificity ranking — registration order wins, so
     the more specific overlapping pattern must be registered first.
     
  Added `tests/Unit/Routing/RoutePrecedenceTest.php` locking down all three tiers,
  constraint-based fall-through, single-segment parameter matching, trailing-slash
  normalization, and method isolation (405 vs match).
  
  ## Release
  
  Bundles the 1.48.0 release: `Version.php`, `CHANGELOG.md` (`[Unreleased]` →
  `[1.48.0] — Imai`), and `ROADMAP.md` milestone.
  
  ## Verification
  
  - 41 routing/route-cache tests pass (130 assertions).
  - `composer run phpcs` clean; PHPStan (level 6 gate) clean on changed `src/` files.
  
  ## Files
  - `src/Routing/Router.php` — `patch()`/`options()`, OPTIONS precedence, corrected comment
  - `src/Routing/Attributes/Patch.php`, `Options.php` — new
  - `src/Routing/AttributeRouteLoader.php` — wire PATCH/OPTIONS/HEAD into both match paths
  - `tests/Unit/Routing/RoutePrecedenceTest.php` — new; `RouterTest.php`, `AttributeRouteLoaderTest.php` — extended
  - `src/Support/Version.php`, `CHANGELOG.md`, `ROADMAP.md` — 1.48.0 release