### PR TITLE
Update docs URL in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "support": {
         "issues": "https://github.com/glueful/framework/issues",
         "source": "https://github.com/glueful/framework",
-        "docs": "https://glueful.com/docs/getting-started"
+        "docs": "https://glueful.com/getting-started"
     },
     "funding": [
         {


### PR DESCRIPTION
Change support.docs URL to the new location by replacing https://glueful.com/docs/getting-started with https://glueful.com/getting-started.

