### PR TITLE
Release 1.49.0 — Jishui (HTTP auth_basic, whatsapp queue type, Intervention v4, security)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ---
 
+## [1.49.0] - 2026-06-01 — Jishui
+
+> **Theme: HTTP Auth, WhatsApp Plumbing & Dependency Hardening.** `Http\Client` now forwards per-request `auth_basic`; the notification queue learns the `whatsapp` type; image processing moves to Intervention Image v4; and all known dependency advisories are patched. No framework API breaks, no new env vars, no migrations; PHP 8.3 floor preserved.
+
+### Added
+- **`Http\Client` now passes `auth_basic` through to Symfony HttpClient.** Per-request HTTP Basic auth (`$client->post($url, ['auth_basic' => [$user, $pass], 'form_params' => [...]])`) previously had no effect — `Client::transformOptions()` mapped `headers/query/json/form_params/body` but silently dropped `auth_basic`. It is now forwarded natively, so callers no longer need to hand-build an `Authorization: Basic …` header.
+- **`whatsapp` is now a supported `SendNotification` queue type.** Added to `SendNotification::SUPPORTED_TYPES` (with a matching timeout arm) so phone-messaging extensions registering a `whatsapp` notification channel can be delivered asynchronously through the framework's notification job. Additive; existing types are unchanged.
+
+### Changed
+- **Upgraded to Intervention Image v4** (`intervention/image: ^4.1`, was `^3.11`). `ImageProcessor` was ported to the v4 API — `read()`→`decode()`, `create()`→`createImage()->fill()`, `place()`→`insert()`, `flop()`/`flip()`→`flip(Direction::HORIZONTAL|VERTICAL)`, and `save()` now passes `quality` as a named option. Public `ImageProcessor`/`image()` API is unchanged.
+- **Refreshed in-range dependencies** to their latest patch/minor: `league/flysystem` (+ `-local`, dev `-memory`), `james-heinrich/getid3`, `phpdocumentor/reflection-docblock`.
+- **Pinned `symfony/event-dispatcher` and `symfony/string` to `^7.4`** so a transitive `composer update` can't pull the Symfony 8.x (PHP 8.4-only) lines and silently raise the PHP floor.
+
+### Security
+- **Patched all known dependency advisories** (within the existing `^7.4` / `^10.5` constraints): updated the Symfony components to `7.4.x` patch releases — fixing HIGH-severity email header / SMTP-command injection in `symfony/mailer`/`symfony/mime` (CVE-2026-45067/45070), `symfony/http-foundation` (CVE-2026-48736), and `symfony/polyfill-intl-idn` — and `phpunit/phpunit` to `10.5.63` (unsafe deserialization in code coverage, dev-only). `composer audit` is now clean. Symfony stays on the 7.x line (PHP 8.3 floor preserved).
+
+### Upgrade Notes
+- **`composer update` is sufficient** for the framework itself — no API changes, env vars, or migrations.
+- **Intervention Image is now `^4`.** If your application code depends on `intervention/image` directly (not just via the framework's `ImageProcessor`/`image()` helper, which is unchanged), move it to the v4 API — see the [v4 upgrade guide](https://image.intervention.io/v4). Apps that only use Glueful's image facade need no changes.
+
 ## [1.48.0] - 2026-05-31 — Imai
 
 > **Theme: Router Verb Completeness.** `PATCH` and `OPTIONS` become first-class routing verbs (they were previously unreachable through the public API), explicit `OPTIONS` routes now win over the automatic CORS preflight responder, and the route-precedence model is documented and pinned with tests. Purely additive — no breaking changes, no new env vars, no migrations.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,13 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.49.0 — Jishui (Released 2026-06-01)
+- **HTTP Basic auth in `Http\Client`**: `Client::transformOptions()` now forwards the `auth_basic` option to Symfony HttpClient (previously dropped), so callers can do `['auth_basic' => [$user, $pass], 'form_params' => [...]]` without hand-building an `Authorization` header.
+- **`whatsapp` notification queue type**: added to `SendNotification::SUPPORTED_TYPES` (+ timeout arm) so phone-messaging extensions registering a `whatsapp` channel can be delivered asynchronously.
+- **Intervention Image v4**: upgraded `intervention/image` to `^4.1` and ported `ImageProcessor` to the v4 API (`decode`/`createImage`/`insert`/`flip(Direction)`/named `save` options). The public `ImageProcessor`/`image()` API is unchanged.
+- **Dependency hardening**: patched all known advisories within the existing `^7.4` / `^10.5` constraints (Symfony 7.4.x — incl. HIGH-severity mailer/mime injection CVEs — and PHPUnit 10.5.63); `composer audit` clean. Pinned `symfony/event-dispatcher` + `symfony/string` to `^7.4` to hold the PHP 8.3 floor.
+- Notes: **Minor release. No framework API breaks, no env vars, no migrations.** `composer update` suffices; only apps using `intervention/image` *directly* need to move to its v4 API. api-skeleton bumped to `^1.49.0`.
+
 ### 1.48.0 — Imai (Released 2026-05-31)
 - **Router Verb Completeness**: `PATCH` and `OPTIONS` become first-class routing verbs. New `$router->patch()` / `$router->options()` shortcuts and `#[Patch]` / `#[Options]` attributes; the `#[Route(methods: [...])]` array form now accepts `PATCH`, `OPTIONS` and `HEAD` (it previously threw for anything but GET/POST/PUT/DELETE). Both verbs were previously unreachable through the public routing API.
 - **Explicit `OPTIONS` beats auto-CORS**: `Router::dispatch()` still answers `OPTIONS` automatically (204 + `Allow`) when no `OPTIONS` route is registered, but an explicitly registered `OPTIONS` route now runs its own handler instead of being silently shadowed by the CORS preflight responder.

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "php": "^8.3",
         "composer/semver": "^3.4",
         "dragonmantank/cron-expression": "^3.4",
-        "intervention/image": "^3.11",
+        "intervention/image": "^4.1",
         "james-heinrich/getid3": "^1.9",
         "league/flysystem": "^3.30",
         "league/flysystem-local": "^3.30",
@@ -39,6 +39,7 @@
         "psr/http-server-middleware": "^1.0",
         "psr/simple-cache": "^3.0",
         "symfony/console": "^7.4",
+        "symfony/event-dispatcher": "^7.4",
         "symfony/finder": "^7.4",
         "symfony/http-client": "^7.4",
         "symfony/http-foundation": "^7.4",
@@ -47,6 +48,7 @@
         "symfony/mime": "^7.4",
         "symfony/process": "^7.4",
         "symfony/psr-http-message-bridge": "^7.4",
+        "symfony/string": "^7.4",
         "vlucas/phpdotenv": "^5.6"
     },
     "require-dev": {

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -255,6 +255,13 @@ class Client
             $symfonyOptions['headers'] = $options['headers'];
         }
 
+        // Transform HTTP Basic authentication ([username, password] or "user:pass").
+        // Symfony HttpClient supports auth_basic natively; without this passthrough
+        // per-request basic auth would be silently dropped.
+        if (isset($options['auth_basic'])) {
+            $symfonyOptions['auth_basic'] = $options['auth_basic'];
+        }
+
         // Transform query parameters
         if (isset($options['query'])) {
             $symfonyOptions['query'] = $options['query'];

--- a/src/Queue/Jobs/SendNotification.php
+++ b/src/Queue/Jobs/SendNotification.php
@@ -41,6 +41,7 @@ class SendNotification extends Job
     private const SUPPORTED_TYPES = [
         'email',
         'sms',
+        'whatsapp',
         'push',
         'webhook',
         'slack',
@@ -202,6 +203,7 @@ class SendNotification extends Job
             'webhook' => 120, // Webhooks might be slower
             'email' => 90,    // Email sending can take time
             'sms' => 45,      // SMS is usually faster
+            'whatsapp' => 45, // WhatsApp (provider API) similar to SMS
             'push' => 30,     // Push notifications are quick
             default => 60     // Default timeout
         };

--- a/src/Services/ImageProcessor.php
+++ b/src/Services/ImageProcessor.php
@@ -7,6 +7,7 @@ namespace Glueful\Services;
 use Glueful\Bootstrap\ApplicationContext;
 use Intervention\Image\ImageManager;
 use Intervention\Image\Interfaces\ImageInterface;
+use Intervention\Image\Direction;
 use Intervention\Image\Encoders\AutoEncoder;
 use Intervention\Image\Encoders\JpegEncoder;
 use Intervention\Image\Encoders\PngEncoder;
@@ -20,7 +21,7 @@ use Psr\Log\LoggerInterface;
 /**
  * Image Processor
  *
- * Modern image processing implementation using Intervention Image v3.
+ * Modern image processing implementation using Intervention Image v4.
  * Provides fluent API for image transformations, caching, and output.
  */
 class ImageProcessor implements ImageProcessorInterface
@@ -76,7 +77,7 @@ class ImageProcessor implements ImageProcessorInterface
                 $instance->security->validateUrl($source);
             }
 
-            $instance->image = $instance->manager->read($source);
+            $instance->image = $instance->manager->decode($source);
             $instance->validateImage();
 
             $instance->logger->debug('Image loaded successfully', [
@@ -116,7 +117,13 @@ class ImageProcessor implements ImageProcessorInterface
                 ], $options)
             ]);
 
-            $instance->image = $instance->manager->read($url, context: $context);
+            // Intervention v4's decode() has no stream-context parameter, so fetch
+            // the remote image with the configured context first, then decode the bytes.
+            $contents = @file_get_contents($url, false, $context);
+            if ($contents === false) {
+                throw new \RuntimeException("Unable to fetch remote image: {$url}");
+            }
+            $instance->image = $instance->manager->decode($contents);
             $instance->validateImage();
 
             $instance->logger->info('Remote image loaded', [
@@ -154,7 +161,7 @@ class ImageProcessor implements ImageProcessorInterface
         $instance->security->validateFormat($extension, $file->getClientMediaType());
 
         try {
-            $instance->image = $instance->manager->read($file->getStream()->getContents());
+            $instance->image = $instance->manager->decode($file->getStream()->getContents());
             $instance->validateImage();
 
             return $instance;
@@ -178,7 +185,7 @@ class ImageProcessor implements ImageProcessorInterface
         $instance->security->validateDimensions($width, $height);
 
         try {
-            $instance->image = $instance->manager->create($width, $height, $background);
+            $instance->image = $instance->manager->createImage($width, $height)->fill($background);
 
             $instance->logger->debug('Blank canvas created', [
                 'width' => $width,
@@ -301,7 +308,7 @@ class ImageProcessor implements ImageProcessorInterface
     {
         $this->operations[] = ['flipHorizontal', []];
 
-        $this->image = $this->image->flop();
+        $this->image = $this->image->flip(Direction::HORIZONTAL);
 
         return $this;
     }
@@ -310,7 +317,7 @@ class ImageProcessor implements ImageProcessorInterface
     {
         $this->operations[] = ['flipVertical', []];
 
-        $this->image = $this->image->flip();
+        $this->image = $this->image->flip(Direction::VERTICAL);
 
         return $this;
     }
@@ -327,7 +334,7 @@ class ImageProcessor implements ImageProcessorInterface
         $this->operations[] = ['watermark', compact('watermarkPath', 'position', 'opacity')];
 
         try {
-            $watermark = $this->manager->read($watermarkPath);
+            $watermark = $this->manager->decode($watermarkPath);
 
             // Apply opacity
             if ($opacity < 100) {
@@ -338,7 +345,7 @@ class ImageProcessor implements ImageProcessorInterface
             // Position calculation
             $positions = $this->calculateWatermarkPosition($position, $watermark);
 
-            $this->image = $this->image->place($watermark, 'top-left', $positions['x'], $positions['y']);
+            $this->image = $this->image->insert($watermark, $positions['x'], $positions['y'], 'top-left');
 
             return $this;
         } catch (\Exception $e) {
@@ -358,7 +365,7 @@ class ImageProcessor implements ImageProcessorInterface
         try {
             $quality = $this->config['current_quality'] ?? $this->getDefaultQuality();
 
-            $this->image->save($path, $quality);
+            $this->image->save($path, quality: $quality);
 
             $this->logger->info('Image saved successfully', [
                 'path' => $path,

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,15 +13,15 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.48.0';
+    public const VERSION = '1.49.0';
 
 
     /** Release code name */
-    public const NAME = 'Imai';
+    public const NAME = 'Jishui';
 
 
     /** Release date */
-    public const RELEASE_DATE = '2026-05-31';
+    public const RELEASE_DATE = '2026-06-01';
 
     /** Minimum required PHP version */
     public const MIN_PHP_VERSION = '8.3.0';

--- a/tests/Unit/Api/RateLimiting/Attributes/RateLimitTest.php
+++ b/tests/Unit/Api/RateLimiting/Attributes/RateLimitTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Api\RateLimiting\Attributes;
+namespace Glueful\Tests\Unit\Api\RateLimiting\Attributes;
 
 use Glueful\Api\RateLimiting\Attributes\RateLimit;
 use Glueful\Api\RateLimiting\Attributes\RateLimitCost;

--- a/tests/Unit/Api/RateLimiting/Limiters/FixedWindowLimiterTest.php
+++ b/tests/Unit/Api/RateLimiting/Limiters/FixedWindowLimiterTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Api\RateLimiting\Limiters;
+namespace Glueful\Tests\Unit\Api\RateLimiting\Limiters;
 
 use Glueful\Api\RateLimiting\Limiters\FixedWindowLimiter;
 use Glueful\Api\RateLimiting\Storage\MemoryStorage;

--- a/tests/Unit/Api/RateLimiting/Limiters/SlidingWindowLimiterTest.php
+++ b/tests/Unit/Api/RateLimiting/Limiters/SlidingWindowLimiterTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Api\RateLimiting\Limiters;
+namespace Glueful\Tests\Unit\Api\RateLimiting\Limiters;
 
 use Glueful\Api\RateLimiting\Limiters\SlidingWindowLimiter;
 use Glueful\Api\RateLimiting\Storage\MemoryStorage;

--- a/tests/Unit/Api/RateLimiting/Limiters/TokenBucketLimiterTest.php
+++ b/tests/Unit/Api/RateLimiting/Limiters/TokenBucketLimiterTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Api\RateLimiting\Limiters;
+namespace Glueful\Tests\Unit\Api\RateLimiting\Limiters;
 
 use Glueful\Api\RateLimiting\Limiters\TokenBucketLimiter;
 use Glueful\Api\RateLimiting\Storage\MemoryStorage;

--- a/tests/Unit/Api/RateLimiting/TierManagerTest.php
+++ b/tests/Unit/Api/RateLimiting/TierManagerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Api\RateLimiting;
+namespace Glueful\Tests\Unit\Api\RateLimiting;
 
 use Glueful\Api\RateLimiting\TierManager;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Database/ORM/CastsTest.php
+++ b/tests/Unit/Database/ORM/CastsTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Database\ORM;
+namespace Glueful\Tests\Unit\Database\ORM;
 
 use ArrayObject;
 use BackedEnum;

--- a/tests/Unit/Database/ORM/ModelTest.php
+++ b/tests/Unit/Database/ORM/ModelTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Database\ORM;
+namespace Glueful\Tests\Unit\Database\ORM;
 
 use Glueful\Database\ORM\Contracts\Scope;
 use Glueful\Database\ORM\Model;
@@ -206,7 +206,7 @@ class ModelTest extends TestCase
  * Basic test model
  */
 // phpcs:ignore PSR1.Classes.ClassDeclaration.MultipleClasses
-class TestModel extends Model
+class ModelTestFixture extends Model
 {
     protected string $table = 'test_models';
     protected string $primaryKey = 'id';
@@ -228,7 +228,7 @@ class FillableModel extends Model
  * Model with hidden attributes
  */
 // phpcs:ignore PSR1.Classes.ClassDeclaration.MultipleClasses
-class HiddenModel extends Model
+class ModelHiddenFixture extends Model
 {
     protected string $table = 'hidden_models';
     protected array $hidden = ['password'];

--- a/tests/Unit/Database/ORM/RelationsTest.php
+++ b/tests/Unit/Database/ORM/RelationsTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Database\ORM;
+namespace Glueful\Tests\Unit\Database\ORM;
 
 use Glueful\Database\ORM\Builder;
 use Glueful\Database\ORM\Collection;

--- a/tests/Unit/Database/ORM/SoftDeletesTest.php
+++ b/tests/Unit/Database/ORM/SoftDeletesTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Database\ORM;
+namespace Glueful\Tests\Unit\Database\ORM;
 
 use Glueful\Database\ORM\Builder;
 use Glueful\Database\ORM\Concerns\SoftDeletes;

--- a/tests/Unit/Http/ClientTransformOptionsTest.php
+++ b/tests/Unit/Http/ClientTransformOptionsTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Http;
+
+use Glueful\Http\Client;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\HttpClient\ResponseStreamInterface;
+
+/**
+ * Verifies Client::transformOptions() maps Glueful's per-request options onto the
+ * Symfony HttpClient options — in particular that auth_basic is passed through
+ * (regression: it was previously dropped) alongside form_params.
+ */
+final class ClientTransformOptionsTest extends TestCase
+{
+    public function testAuthBasicAndFormParamsArePassedThrough(): void
+    {
+        $fake = $this->capturingClient();
+        $client = new Client($fake, new NullLogger());
+
+        $client->post('https://example.test/oauth/token', [
+            'auth_basic' => ['user', 'pass'],
+            'form_params' => ['grant_type' => 'client_credentials'],
+        ]);
+
+        $this->assertSame(['user', 'pass'], $fake->captured['auth_basic'] ?? null);
+        $this->assertSame('grant_type=client_credentials', $fake->captured['body'] ?? null);
+        $this->assertSame(
+            'application/x-www-form-urlencoded',
+            $fake->captured['headers']['Content-Type'] ?? null
+        );
+    }
+
+    public function testNoAuthBasicKeyWhenNotProvided(): void
+    {
+        $fake = $this->capturingClient();
+        $client = new Client($fake, new NullLogger());
+
+        $client->get('https://example.test/ping', ['headers' => ['X-Test' => '1']]);
+
+        $this->assertArrayNotHasKey('auth_basic', $fake->captured);
+    }
+
+    /**
+     * A Symfony HttpClientInterface that records the (already Glueful-transformed)
+     * options and returns a trivial 200 response so Client::request() can read the
+     * status without performing real I/O.
+     */
+    private function capturingClient(): HttpClientInterface
+    {
+        return new class implements HttpClientInterface {
+            /** @var array<string,mixed> */
+            public array $captured = [];
+
+            public function request(string $method, string $url, array $options = []): ResponseInterface
+            {
+                $this->captured = $options;
+
+                return new class implements ResponseInterface {
+                    public function getStatusCode(): int
+                    {
+                        return 200;
+                    }
+                    public function getHeaders(bool $throw = true): array
+                    {
+                        return [];
+                    }
+                    public function getContent(bool $throw = true): string
+                    {
+                        return '{}';
+                    }
+                    /** @return array<int|string,mixed> */
+                    public function toArray(bool $throw = true): array
+                    {
+                        return [];
+                    }
+                    public function cancel(): void
+                    {
+                    }
+                    public function getInfo(?string $type = null): mixed
+                    {
+                        return null;
+                    }
+                };
+            }
+
+            public function stream($responses, ?float $timeout = null): ResponseStreamInterface
+            {
+                throw new \BadMethodCallException('stream() is not used in this test');
+            }
+
+            public function withOptions(array $options): static
+            {
+                return $this;
+            }
+        };
+    }
+}

--- a/tests/Unit/Queue/SendNotificationTypesTest.php
+++ b/tests/Unit/Queue/SendNotificationTypesTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Queue;
+
+use Glueful\Queue\Jobs\SendNotification;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Ensures the framework notification job accepts the 'whatsapp' type so the
+ * Conversa extension's whatsapp channel can be delivered asynchronously.
+ */
+final class SendNotificationTypesTest extends TestCase
+{
+    public function testWhatsappIsASupportedType(): void
+    {
+        $ref = new \ReflectionClass(SendNotification::class);
+        $supported = $ref->getConstant('SUPPORTED_TYPES');
+
+        $this->assertIsArray($supported);
+        $this->assertContains('whatsapp', $supported);
+        $this->assertContains('sms', $supported); // existing types unchanged
+        $this->assertContains('email', $supported);
+    }
+}


### PR DESCRIPTION
## Summary

  Ships **framework 1.49.0 "Jishui"** — a maintenance + hardening release: `Http\Client`
  image processing moves to Intervention Image v4, and all known dependency advisories are
  patched. No framework API breaks, no env vars, no migrations; PHP 8.3 floor preserved.
  
  ## What's in this PR
  
  **Release (1.49.0):**
  - **`Http\Client` passes `auth_basic` through** to Symfony HttpClient — `Client::transformOptions()`
    silently dropped it before, so per-request Basic auth (`['auth_basic' => [...], 'form_params' => [...]]`)
    had no effect. (+ unit test.)
  - **`whatsapp` added to `SendNotification::SUPPORTED_TYPES`** (+ timeout arm) so phone-messaging
    extensions registering a `whatsapp` channel can be queued. (+ unit test.)
  - **Intervention Image v4** (`^4.1`): `ImageProcessor` ported to the v4 API
    (`decode`/`createImage->fill`/`insert`/`flip(Direction)`/named `save` options). Public
    `ImageProcessor`/`image()` API unchanged.
  - **Dependency hardening**: in-range minor refresh (flysystem, getid3, reflection-docblock);
    pinned `symfony/event-dispatcher` + `symfony/string` to `^7.4` to hold the PHP 8.3 floor.
  - **Security**: patched all advisories within `^7.4`/`^10.5` (Symfony 7.4.x incl. HIGH-severity
    mailer/mime injection CVEs; PHPUnit 10.5.63). `composer audit` clean.
    
  **Also included:**
  - `test:` aligned 9 test files from `Tests\…` to `Glueful\Tests\…` (PSR-4) so composer stops
    skipping them from the classmap; renamed two `ModelTest` fixtures to avoid a namespace collision.
  - `chore:` docs URL tweak in `composer.json`.
  
  ## Verification
  - 859 unit tests pass; `composer audit` clean; phpstan + phpcs clean on changed files.
  
  ## Upgrade
  `composer update` is sufficient. Only apps depending on `intervention/image` **directly**
  (not via Glueful's `image()`/`ImageProcessor`) need to move to the v4 API.
