### PR TITLE
Release 1.49.1 — Jishui: allow reserved SQL words as column names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Fixed
+- **`QueryValidator` no longer rejects reserved SQL words used as column names.** In strict mode, `validateColumnName()` previously threw `Column name '<x>' is a reserved SQL keyword` for columns like `from`, `order`, `group`, `key`, or `values` — even though the query builders always emit column identifiers through the driver's `wrapIdentifier()` (`` `from` `` / `"from"`), which is valid SQL. The reserved-word check is removed for *column* names (the SQL-injection character check remains the guard); reserved-word checks for unquoted table/schema/alias names are unchanged. This also resolves a latent inconsistency where `to` was accepted only because `TO` happened to be absent from the keyword list.
+
 ---
 
 ## [1.49.0] - 2026-06-01 — Jishui

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+---
+
+## [1.49.1] - 2026-06-01 — Jishui
+
+> **Theme: Reserved-word column names.** A focused bug fix: column names that are SQL reserved words (`from`, `order`, `group`, `key`, `values`, …) are now accepted by `QueryValidator` — they were always quoted by the query builders anyway, so the rejection blocked valid SQL. Framework-only; no API breaks, no env vars, no migrations.
+
 ### Fixed
 - **`QueryValidator` no longer rejects reserved SQL words used as column names.** In strict mode, `validateColumnName()` previously threw `Column name '<x>' is a reserved SQL keyword` for columns like `from`, `order`, `group`, `key`, or `values` — even though the query builders always emit column identifiers through the driver's `wrapIdentifier()` (`` `from` `` / `"from"`), which is valid SQL. The reserved-word check is removed for *column* names (the SQL-injection character check remains the guard); reserved-word checks for unquoted table/schema/alias names are unchanged. This also resolves a latent inconsistency where `to` was accepted only because `TO` happened to be absent from the keyword list.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,10 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.49.1 — Jishui (Released 2026-06-01)
+- **Reserved-word column names**: `QueryValidator` no longer rejects SQL reserved words used as *column* names (`from`, `order`, `group`, `key`, `values`, …). Column identifiers are always emitted through the driver's `wrapIdentifier()`, so a quoted `from`/`"from"` is valid SQL — the strict-mode keyword check was blocking valid columns and was inconsistent (`to` slipped through only because `TO` was missing from the list). Table/schema/alias keyword checks and the SQL-injection character guard are unchanged.
+- Notes: **Patch release. Framework-only — no API breaks, no env vars, no migrations.** The existing api-skeleton `^1.49.0` constraint already permits 1.49.1.
+
 ### 1.49.0 — Jishui (Released 2026-06-01)
 - **HTTP Basic auth in `Http\Client`**: `Client::transformOptions()` now forwards the `auth_basic` option to Symfony HttpClient (previously dropped), so callers can do `['auth_basic' => [$user, $pass], 'form_params' => [...]]` without hand-building an `Authorization` header.
 - **`whatsapp` notification queue type**: added to `SendNotification::SUPPORTED_TYPES` (+ timeout arm) so phone-messaging extensions registering a `whatsapp` channel can be delivered asynchronously.

--- a/src/Database/Features/QueryValidator.php
+++ b/src/Database/Features/QueryValidator.php
@@ -325,10 +325,11 @@ class QueryValidator implements QueryValidatorInterface
                 continue;
             }
 
-            // Check if it's a reserved keyword
-            if ($this->strictMode && in_array(strtoupper($part), self::RESERVED_KEYWORDS, true)) {
-                throw new \InvalidArgumentException("Column name '$part' is a reserved SQL keyword");
-            }
+            // NOTE: column identifiers are always emitted through the driver's
+            // wrapIdentifier() (e.g. `from` / "from"), so a reserved word used as a
+            // column name is valid SQL and does not need a keyword check here. The
+            // SQL-injection character check above is the real guard. (Reserved-word
+            // checks are still applied to table/schema/alias names below.)
         }
     }
 

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,7 +13,7 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.49.0';
+    public const VERSION = '1.49.1';
 
 
     /** Release code name */

--- a/tests/Unit/Database/Query/QueryValidatorReservedColumnTest.php
+++ b/tests/Unit/Database/Query/QueryValidatorReservedColumnTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Database\Query;
+
+use Glueful\Database\Features\QueryValidator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Column identifiers are always emitted through the driver's wrapIdentifier()
+ * (e.g. `from` / "from"), so a reserved word used as a *column* name is valid SQL.
+ * The validator must therefore accept reserved words as column names, while still
+ * rejecting them as unquoted table/schema/alias names.
+ */
+#[CoversClass(QueryValidator::class)]
+final class QueryValidatorReservedColumnTest extends TestCase
+{
+    public function testReservedWordIsAllowedAsColumnName(): void
+    {
+        $validator = new QueryValidator();
+        $this->assertTrue($validator->isStrictMode(), 'strict mode is on by default');
+
+        // No exception => reserved words like FROM/ORDER/GROUP are valid column names.
+        $validator->validateColumnNames(['from', 'to', 'order', 'group', 'key', 'values']);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testInsertWithReservedColumnNamePasses(): void
+    {
+        $validator = new QueryValidator();
+
+        // Previously threw "Column name 'from' is a reserved SQL keyword".
+        $validator->validateInsert('conversa_messages', [
+            'to' => '+15551234567',
+            'from' => '+15550000000',
+            'status' => 'queued',
+        ]);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testReservedWordStillRejectedAsTableName(): void
+    {
+        $validator = new QueryValidator();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $validator->validateTableName('from');
+    }
+
+    public function testSqlInjectionCharactersInColumnStillRejected(): void
+    {
+        $validator = new QueryValidator();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $validator->validateColumnNames(['from"; DROP TABLE x; --']);
+    }
+}


### PR DESCRIPTION
## 1.49.1 — Jishui (patch)
  
  Framework-only bug fix. **No API breaks, no new env vars, no migrations.**
  
  ### Fixed
  - **`QueryValidator` no longer rejects reserved SQL words used as column names.**
    In strict mode, `validateColumnName()` previously threw
    `Column name '<x>' is a reserved SQL keyword` for columns like `from`, `order`,
    `group`, `key`, or `values` — even though `InsertBuilder`/`UpdateBuilder` always
    emit column identifiers through the driver's `wrapIdentifier()` (`` `from` `` /
    `"from"`), which is valid SQL on every driver. The reserved-word check is removed
    for **column** names; the SQL-injection character guard stays, and reserved-word
    checks for unquoted **table/schema/alias** names are unchanged.
    This also fixes a latent inconsistency where `to` was accepted only because `TO`
    happened to be absent from the keyword list.
  
  A column named `from`/`order`/etc. is perfectly valid SQL once quoted (which the
  builders always do), so blocking it at the validator was rejecting legitimate
  schemas — and surfaced concretely while building the Conversa extension, whose
  `conversa_messages` table has a `from` column.
  
  ### Tests
  - New `tests/Unit/Database/Query/QueryValidatorReservedColumnTest.php` (4 cases):
    reserved word OK as a column, INSERT with `from` passes, reserved word **still**
    rejected as a table name, SQL-injection chars **still** rejected. 
  - Full suite green: **971 passed**, 63 skipped (driver-specific). phpcs + PHPStan clean.
  
  ### Release bookkeeping
  - `Version.php` → `1.49.1` (codename **Jishui** retained — patch reuses the parent minor's codename)
  - `CHANGELOG.md` `[Unreleased]` → `[1.49.1]`
  - `ROADMAP.md` milestone added
  
  ### Commits
  - `6f45497` fix(db): allow reserved SQL words as column names in QueryValidator
  - `4106f47` Release 1.49.1: allow reserved column names 
  
  ### Upgrade
  `composer update glueful/framework` — nothing else required.
  
  ### api-skeleton
  No change — the skeleton's existing `^1.49.0` constraint already permits 1.49.1.