### PR TITLE
Release 1.50.2 — Kochab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ---
 
+## [1.50.2] - 2026-06-05 — Kochab
+
+> **Theme: `@queryParam` route-doc tag.** Route docblocks can now document query parameters with an editor-clean `@queryParam name:type="…"` tag that the OpenAPI generator actually parses — avoiding the IDE/Intelephense false positives (P1133) caused by overloading the reserved `@param` tag — and a latent doc-gen bug that dropped path params from any route which *also* declared a parameter is fixed. Framework-only — no env vars, no migrations, no API breaks. The api-skeleton `^1.50.1` constraint already permits 1.50.2.
+
+### Added
+- **`@queryParam` route doc tag.** `CommentsDocGenerator` now parses `@queryParam <name>:<type>="description" [{required}]` in route docblocks, emitting an `in: query` OpenAPI parameter. It's an editor-clean alternative to the positional `@param <name> query <type> <bool> "desc"` form — the reserved `@param` tag makes IDEs/Intelephense mis-read the location/type tokens as undefined PHPDoc types (P1133). The legacy `@param` form still parses unchanged.
+
+### Fixed
+- **Route path parameters are no longer dropped when a query parameter is also documented.** `CommentsDocGenerator` previously auto-derived `{name}` path params from the URL *only* when no parameters were documented at all, so a route declaring a query param plus a `{id}` in its path silently lost the path param from its OpenAPI spec. Path params are now always derived from the URL and merged with documented params (de-duplicated by name; an explicit path-param docblock still wins). Pinned by `tests/Unit/Support/Documentation/CommentsDocGeneratorParamTest.php`.
+
+### Changed
+- **`routes/resource.php` migrated to `@queryParam`.** The `/data/{table}` list endpoint's `page`/`limit`/`sort`/`order` query parameters now use the `@queryParam` tag (so they actually appear in the generated OpenAPI — the previous `@parameter` tag was never parsed), and the redundant `@parameter` path-param docblocks were removed (path params auto-derive from the route URL). No runtime change.
+
+---
+
 ## [1.50.1] - 2026-06-05 — Kochab
 
 > **Theme: Two silent no-op extension points, fixed.** `ServiceProvider::mergeConfig()` now actually applies an extension's config defaults (it delegated to a service that was never registered), and `LoginResponseBuildingEvent` listeners can now actually modify the login response (the shaper discarded their changes). Framework-only — no new env vars, no migrations, no API breaks. The existing api-skeleton `^1.50.0` constraint already permits 1.50.1.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,11 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.50.2 — Kochab (Patch, Released 2026-06-05)
+- **`@queryParam` route-doc tag**: `CommentsDocGenerator` now parses `@queryParam name:type="…" [{required}]` in route docblocks as an `in: query` OpenAPI parameter — an editor-clean alternative to the positional `@param … query …` form, which overloads the reserved `@param` tag and triggers IDE/Intelephense false positives (P1133). The legacy `@param` form still parses.
+- **Doc-gen path-param fix**: URL `{name}` path params were auto-derived only when *no* params were documented, so a route with a query param plus a `{id}` lost its path param from the spec. Path params are now always derived and merged (de-duped by name; explicit docblock wins). `routes/resource.php` migrated to `@queryParam`.
+- Notes: **Patch release. Framework-only — no env vars, no migrations, no API breaks.** The api-skeleton `^1.50.1` constraint already permits 1.50.2.
+
 ### 1.50.1 — Kochab (Released 2026-06-05)
 - **`mergeConfig()` no longer a silent no-op**: `ServiceProvider::mergeConfig()` delegated to an unregistered `config.manager` service, so extension `config/*.php` defaults never reached `config()` (affected all 8 first-party extensions). Now backed by the new `ApplicationContext::mergeConfigDefaults()`, which merges defaults *under* framework/app/env config (app values win) and persists across `clearConfigCache()`.
 - **`LoginResponseBuildingEvent` listeners now affect the response**: `LoginResponseShaper::shape()` dispatched the event but discarded listener mutations; it now reads `$event->getResponse()` back, so listeners can add fields to the login response as documented.

--- a/routes/resource.php
+++ b/routes/resource.php
@@ -23,11 +23,10 @@ $router->group(['prefix' => '/data'], function (Router $router) {
      * @summary List Resources
      * @description Retrieves a paginated list of resources from the specified table
      * @tag Data
-     * @parameter table:string="Table/resource name" {required}
-     * @parameter page:integer="Page number for pagination"
-     * @parameter limit:integer="Number of items per page (max 100)"
-     * @parameter sort:string="Field to sort by"
-     * @parameter order:string="Sort order (asc|desc)"
+     * @queryParam page:integer="Page number for pagination"
+     * @queryParam limit:integer="Number of items per page (max 100)"
+     * @queryParam sort:string="Field to sort by"
+     * @queryParam order:string="Sort order (asc|desc)"
      * @response 200 application/json "Resources retrieved successfully" {
      *   success:boolean="true",
      *   message:string="Success message",
@@ -56,8 +55,6 @@ $router->group(['prefix' => '/data'], function (Router $router) {
      * @summary Get Single Resource
      * @description Retrieves a single resource by its UUID
      * @tag Data
-     * @parameter table:string="Table/resource name" {required}
-     * @parameter uuid:string="Resource UUID" {required}
      * @response 200 application/json "Resource retrieved successfully"
      * @response 404 "Resource not found"
      * @response 403 "Insufficient permissions"
@@ -77,7 +74,6 @@ $router->group(['prefix' => '/data'], function (Router $router) {
      * @summary Create Resource
      * @description Creates a new resource in the specified table
      * @tag Data
-     * @parameter table:string="Table/resource name" {required}
      * @requestBody data:object="Resource data to create" {required}
      * @response 201 application/json "Resource created successfully"
      * @response 400 "Invalid input data"
@@ -92,8 +88,6 @@ $router->group(['prefix' => '/data'], function (Router $router) {
      * @summary Update Resource
      * @description Updates an existing resource by UUID
      * @tag Data
-     * @parameter table:string="Table/resource name" {required}
-     * @parameter uuid:string="Resource UUID to update" {required}
      * @requestBody data:object="Updated resource data" {required}
      * @response 200 application/json "Resource updated successfully"
      * @response 404 "Resource not found"
@@ -109,8 +103,6 @@ $router->group(['prefix' => '/data'], function (Router $router) {
      * @summary Delete Resource
      * @description Deletes a resource by UUID
      * @tag Data
-     * @parameter table:string="Table/resource name" {required}
-     * @parameter uuid:string="Resource UUID to delete" {required}
      * @response 200 application/json "Resource deleted successfully"
      * @response 404 "Resource not found"
      * @response 403 "Insufficient permissions"
@@ -128,7 +120,6 @@ if (config($context, 'resource.security.bulk_operations', false)) {
          * @summary Bulk Delete Resources
          * @description Deletes multiple resources by UUIDs
          * @tag Data
-         * @parameter table:string="Table/resource name" {required}
          * @requestBody uuids:array="Array of UUIDs to delete" {required}
          * @response 200 application/json "Resources deleted successfully"
          * @response 400 "Invalid input data"
@@ -143,7 +134,6 @@ if (config($context, 'resource.security.bulk_operations', false)) {
          * @summary Bulk Update Resources
          * @description Updates multiple resources with provided data
          * @tag Data
-         * @parameter table:string="Table/resource name" {required}
          * @requestBody data:object="Bulk update data with UUIDs and fields" {required}
          * @response 200 application/json "Resources updated successfully"
          * @response 400 "Invalid input data"

--- a/src/Support/Documentation/CommentsDocGenerator.php
+++ b/src/Support/Documentation/CommentsDocGenerator.php
@@ -677,12 +677,8 @@ class CommentsDocGenerator
                 $requestBody['_example'] = $example;
             }
         }
-        $pathParams = $this->extractSimplifiedParameters($docComment);
-
-        // Extract path parameters if not explicitly defined
-        if ($pathParams === [] && strpos($routePath, '{') !== false) {
-            $pathParams = $this->extractPathParameters($routePath);
-        }
+        // Path params present in the URL are auto-derived and merged inside the parser.
+        $pathParams = $this->extractSimplifiedParameters($docComment, $routePath);
 
         return [
             'method' => strtoupper($httpMethod),
@@ -742,11 +738,8 @@ class CommentsDocGenerator
                 $requestBody['_example'] = $example;
             }
         }
-        $pathParams = $this->extractSimplifiedParameters($docComment);
-
-        if ($pathParams === [] && strpos($routePath, '{') !== false) {
-            $pathParams = $this->extractPathParameters($routePath);
-        }
+        // Path params present in the URL are auto-derived and merged inside the parser.
+        $pathParams = $this->extractSimplifiedParameters($docComment, $routePath);
 
         return [
             'method' => strtoupper($httpMethod),
@@ -1098,20 +1091,28 @@ class CommentsDocGenerator
     }
 
     /**
-     * Extract simplified parameters from doc comment
-     * Format: @param name location type required "description"
+     * Extract route parameters from a doc comment.
+     *
+     * Two annotation styles are supported:
+     *  - `@param <name> <path|query|header|cookie> <type> <true|false> "description"` (positional, legacy)
+     *  - `@queryParam <name>:<type>="description" [{required}]` — always `in: query`; avoids the
+     *      reserved `@param` tag so IDEs/Intelephense don't mis-read the tokens as PHPDoc types
+     *
+     * Path parameters present in the route URL (`{name}`) are auto-derived and merged in when
+     * not already documented, so explicit path-parameter docblocks are optional.
      *
      * @param string $docComment Doc comment to parse
+     * @param string $routePath  Route path (e.g. /users/{uuid}); used to auto-derive path parameters
      * @return array<int, array<string, mixed>> Parameter definitions
      */
-    private function extractSimplifiedParameters(string $docComment): array
+    private function extractSimplifiedParameters(string $docComment, string $routePath = ''): array
     {
         $params = [];
-        $pattern = '/@param\s+(\w+)\s+(path|query|header|cookie)\s+(string|integer|number|boolean|array|object)'
-            . '\s+(true|false)\s+"([^"]*)"/';
+        $type = 'string|integer|number|boolean|array|object';
 
+        // Style 1 (legacy, positional): @param name location type required "description"
+        $pattern = '/@param\s+(\w+)\s+(path|query|header|cookie)\s+(' . $type . ')\s+(true|false)\s+"([^"]*)"/';
         preg_match_all($pattern, $docComment, $matches, PREG_SET_ORDER);
-
         foreach ($matches as $match) {
             $params[] = [
                 'name' => $match[1],
@@ -1120,6 +1121,29 @@ class CommentsDocGenerator
                 'description' => $match[5],
                 'schema' => ['type' => $match[3]]
             ];
+        }
+
+        // Style 2: @queryParam name:type="description" [{required}] — always a query parameter
+        $pattern = '/@queryParam\s+(\w+):(' . $type . ')="([^"]*)"\s*(\{required\})?/';
+        preg_match_all($pattern, $docComment, $matches, PREG_SET_ORDER);
+        foreach ($matches as $match) {
+            $params[] = [
+                'name' => $match[1],
+                'in' => 'query',
+                'required' => ($match[4] ?? '') !== '',
+                'description' => $match[3],
+                'schema' => ['type' => $match[2]]
+            ];
+        }
+
+        // Merge in any URL path parameters ({name}) not already documented above.
+        if (strpos($routePath, '{') !== false) {
+            $documented = array_column($params, 'name');
+            foreach ($this->extractPathParameters($routePath) as $pathParam) {
+                if (!in_array($pathParam['name'], $documented, true)) {
+                    $params[] = $pathParam;
+                }
+            }
         }
 
         return $params;

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,7 +13,7 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.50.1';
+    public const VERSION = '1.50.2';
 
 
     /** Release code name */

--- a/tests/Unit/Support/Documentation/CommentsDocGeneratorParamTest.php
+++ b/tests/Unit/Support/Documentation/CommentsDocGeneratorParamTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Support\Documentation;
+
+use Glueful\Support\Documentation\CommentsDocGenerator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers route-parameter extraction in CommentsDocGenerator: the legacy positional
+ * `@param` form, the editor-clean `@queryParam name:type="..."` form, and the
+ * auto-derive/merge of URL path parameters.
+ */
+final class CommentsDocGeneratorParamTest extends TestCase
+{
+    /**
+     * Invoke the private, state-free parser directly (no DI bootstrap needed).
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function parse(string $docComment, string $routePath = ''): array
+    {
+        $generator = (new \ReflectionClass(CommentsDocGenerator::class))->newInstanceWithoutConstructor();
+        $method = new \ReflectionMethod($generator, 'extractSimplifiedParameters');
+        $method->setAccessible(true);
+
+        /** @var array<int, array<string, mixed>> $result */
+        $result = $method->invoke($generator, $docComment, $routePath);
+        return $result;
+    }
+
+    public function testParsesQueryParamTag(): void
+    {
+        $params = $this->parse('/** @queryParam ttl:integer="URL lifetime" */', '/blobs/signed-url');
+
+        self::assertCount(1, $params);
+        self::assertSame('ttl', $params[0]['name']);
+        self::assertSame('query', $params[0]['in']);
+        self::assertFalse($params[0]['required']);
+        self::assertSame('URL lifetime', $params[0]['description']);
+        self::assertSame(['type' => 'integer'], $params[0]['schema']);
+    }
+
+    public function testQueryParamRequiredMarkerSetsRequiredTrue(): void
+    {
+        $params = $this->parse('/** @queryParam q:string="Search" {required} */');
+
+        self::assertSame('q', $params[0]['name']);
+        self::assertTrue($params[0]['required']);
+    }
+
+    public function testLegacyPositionalParamStyleStillParses(): void
+    {
+        $params = $this->parse('/** @param page query integer false "Page number" */');
+
+        self::assertSame('page', $params[0]['name']);
+        self::assertSame('query', $params[0]['in']);
+        self::assertFalse($params[0]['required']);
+        self::assertSame('Page number', $params[0]['description']);
+        self::assertSame(['type' => 'integer'], $params[0]['schema']);
+    }
+
+    public function testAutoDerivesPathParamAlongsideQueryParam(): void
+    {
+        // A route with a query param AND a {uuid} in the URL: the path param must still appear.
+        $params = $this->parse('/** @queryParam page:integer="Page" */', '/rbac/users/{uuid}/roles');
+
+        $names = array_column($params, 'name');
+        self::assertContains('page', $names);
+        self::assertContains('uuid', $names);
+
+        $idx = array_search('uuid', $names, true);
+        self::assertNotFalse($idx);
+        self::assertSame('path', $params[$idx]['in']);
+        self::assertTrue($params[$idx]['required']);
+    }
+
+    public function testExplicitPathParamIsNotDuplicatedByAutoDerive(): void
+    {
+        $params = $this->parse('/** @param uuid path string true "Role UUID" */', '/rbac/roles/{uuid}');
+
+        self::assertSame(['uuid'], array_column($params, 'name'), 'path param documented once, no duplicate');
+        self::assertSame('Role UUID', $params[0]['description']);
+    }
+}


### PR DESCRIPTION
Doc-gen: route docblocks gain an editor-clean @queryParam name:type="desc" [{required}] tag that CommentsDocGenerator parses as an in:query OpenAPI parameter — avoiding the reserved-@param IDE/Intelephense false positives (P1133). The legacy positional @param form still parses.

Fix: URL {name} path params were auto-derived only when no params were documented at all, so a route with a query param plus a {id} lost its path param from the spec. Path params are now always derived and merged (de-duped by name; explicit docblock wins). routes/resource.php migrated to @queryParam.

Framework-only — no env vars, no migrations, no API breaks. api-skeleton ^1.50.1 already permits 1.50.2.
