### PR TITLE
fix(cache): use UserIdentity::uuid() accessor in ResponseCachingTrait; clear IDE diagnostics

### DIFF
--- a/src/Container/Bootstrap/ContainerFactory.php
+++ b/src/Container/Bootstrap/ContainerFactory.php
@@ -113,7 +113,6 @@ final class ContainerFactory
     /** @return iterable<BaseServiceProvider> */
     private static function providers(TagCollector $tags, ApplicationContext $context): iterable
     {
-        /** @var array<class-string<BaseServiceProvider>> $classes */
         $classes = [
             \Glueful\Container\Providers\CoreProvider::class,
             \Glueful\Container\Providers\ORMProvider::class,

--- a/src/Controllers/Traits/ResponseCachingTrait.php
+++ b/src/Controllers/Traits/ResponseCachingTrait.php
@@ -15,6 +15,17 @@ use Glueful\Cache\Contracts\EdgeCacheInterface;
  * Provides comprehensive caching functionality for controllers.
  * Handles response caching, query caching, cache invalidation, and CDN integration.
  *
+ * Designed for use inside {@see \Glueful\Controllers\BaseController}, which provides the
+ * members consumed here: the `$repositoryFactory` and `$currentUser` properties, plus the
+ * `isAdmin()` / `can()` authorization helpers from the sibling
+ * {@see \Glueful\Controllers\Traits\AuthorizationTrait}. They are declared below so static
+ * analysers resolve them when the trait is viewed in isolation.
+ *
+ * @property \Glueful\Repository\RepositoryFactory $repositoryFactory
+ * @property \Glueful\Auth\UserIdentity|null $currentUser
+ * @method bool isAdmin()
+ * @method bool can(string $permission, string $resource = 'system', array $context = [])
+ *
  * @package Glueful\Controllers\Traits
  */
 trait ResponseCachingTrait
@@ -69,7 +80,7 @@ trait ResponseCachingTrait
             $key,
             md5(serialize([
                 $this->request->query->all(),
-                $this->currentUser?->uuid ?? null,
+                $this->currentUser?->uuid() ?? null,
                 $this->request->headers->get('Accept'),
                 $this->request->headers->get('Accept-Language')
             ]))
@@ -254,7 +265,7 @@ trait ResponseCachingTrait
         int $defaultTtl = 3600
     ): mixed {
         $ttl = $defaultTtl;
-        $tags = ['user:' . ($this->currentUser?->uuid ?? 'anonymous')];
+        $tags = ['user:' . ($this->currentUser?->uuid() ?? 'anonymous')];
 
         // Adjust cache duration based on user type
         if ($this->isAdmin()) {
@@ -398,7 +409,7 @@ trait ResponseCachingTrait
         // Add surrogate keys for targeted purging
         $surrogateKeys = [
             'controller:' . basename(str_replace('\\', '/', static::class)),
-            'user:' . ($this->currentUser?->uuid ?? 'anonymous'),
+            'user:' . ($this->currentUser?->uuid() ?? 'anonymous'),
             'pattern:' . $pattern
         ];
 

--- a/tests/Integration/Cache/EdgeCacheCoreOnlyTest.php
+++ b/tests/Integration/Cache/EdgeCacheCoreOnlyTest.php
@@ -108,10 +108,15 @@ final class EdgeCacheCoreOnlyTest extends TestCase
         // runners, which set xdebug.mode=off), where xdebug_get_headers() exists but
         // returns []. Probe real capture capability so the assertion runs where headers
         // can actually be observed and is a no-op (not a false failure) where they can't.
+        // Reference the optional xdebug function indirectly (as a string callable) so
+        // static analysers don't flag it as undefined when xdebug isn't installed.
+        $xdebugGetHeaders = 'xdebug_get_headers';
         $canCaptureHeaders = false;
-        if (\function_exists('xdebug_get_headers')) {
+        if (\function_exists($xdebugGetHeaders)) {
             @\header('X-Edge-Capture-Probe: 1');
-            foreach (xdebug_get_headers() as $h) {
+            /** @var list<string> $probe */
+            $probe = $xdebugGetHeaders();
+            foreach ($probe as $h) {
                 if (stripos($h, 'X-Edge-Capture-Probe:') === 0) {
                     $canCaptureHeaders = true;
                     break;
@@ -122,7 +127,9 @@ final class EdgeCacheCoreOnlyTest extends TestCase
 
         if ($canCaptureHeaders) {
             $hasSurrogate = false;
-            foreach (xdebug_get_headers() as $h) {
+            /** @var list<string> $emitted */
+            $emitted = $xdebugGetHeaders();
+            foreach ($emitted as $h) {
                 if (stripos($h, 'Surrogate-Key:') === 0) {
                     $hasSurrogate = true;
                 }

--- a/tests/Unit/Console/Commands/Queue/WorkCommandLeanTest.php
+++ b/tests/Unit/Console/Commands/Queue/WorkCommandLeanTest.php
@@ -153,7 +153,9 @@ final class WorkCommandLeanTest extends TestCase
 
     private function testerWithWorker(object $worker): CommandTester
     {
-        $container = $this->app->getContainer()->with([QueueWorker::class => $worker]);
+        /** @var \Glueful\Container\Container $base */
+        $base = $this->app->getContainer();
+        $container = $base->with([QueueWorker::class => $worker]);
         $command = new WorkCommand($container, $this->context);
 
         return new CommandTester($command);

--- a/tests/Unit/Container/Providers/StorageProviderFileUploaderMediaTest.php
+++ b/tests/Unit/Container/Providers/StorageProviderFileUploaderMediaTest.php
@@ -94,7 +94,9 @@ final class StorageProviderFileUploaderMediaTest extends TestCase
 
         $request = new Request();
         $request->attributes->set('user', ['uuid' => 'usr123456789']);
-        $this->context->getContainer()->load([
+        /** @var \Glueful\Container\Container $container */
+        $container = $this->context->getContainer();
+        $container->load([
             'request' => new ValueDefinition('request', $request),
         ]);
     }
@@ -149,7 +151,9 @@ final class StorageProviderFileUploaderMediaTest extends TestCase
         // `$c->has(...) ? $c->get(...) : null` picks it up. load() mutates the
         // booted container's definitions in place — the same mechanism B1 used
         // to inject the `request` service.
-        $this->context->getContainer()->load([
+        /** @var \Glueful\Container\Container $container */
+        $container = $this->context->getContainer();
+        $container->load([
             MediaProcessorInterface::class => new ValueDefinition(MediaProcessorInterface::class, $fake),
         ]);
 

--- a/tests/Unit/Controllers/UploadControllerVariantTest.php
+++ b/tests/Unit/Controllers/UploadControllerVariantTest.php
@@ -102,7 +102,9 @@ final class UploadControllerVariantTest extends TestCase
 
         $request = new Request();
         $request->attributes->set('user', ['uuid' => 'usr123456789']);
-        $this->context->getContainer()->load([
+        /** @var \Glueful\Container\Container $container */
+        $container = $this->context->getContainer();
+        $container->load([
             'request' => new ValueDefinition('request', $request),
         ]);
 

--- a/tests/Unit/Uploader/FileUploaderNoMediaTest.php
+++ b/tests/Unit/Uploader/FileUploaderNoMediaTest.php
@@ -92,7 +92,9 @@ final class FileUploaderNoMediaTest extends TestCase
         // Register a request carrying an authenticated user so the blob row persists.
         $request = new Request();
         $request->attributes->set('user', ['uuid' => 'usr123456789']);
-        $this->context->getContainer()->load([
+        /** @var \Glueful\Container\Container $container */
+        $container = $this->context->getContainer();
+        $container->load([
             'request' => new ValueDefinition('request', $request),
         ]);
 


### PR DESCRIPTION
Real fix: three sites in ResponseCachingTrait read $this->currentUser?->uuid — but UserIdentity::$uuid is private (public accessor is uuid()). They'd fatal at runtime with a non-null currentUser; the sibling sites already used ?->uuid() correctly. Now consistent. The bug was masked because Intelephense saw currentUser as untyped; documenting the trait's host contract surfaced it.

Static-analysis hygiene (Intelephense; composer run analyse was already clean — tests/ isn't even analysed):
- ResponseCachingTrait: @property $repositoryFactory/$currentUser + @method isAdmin()/can() document the BaseController/AuthorizationTrait members the trait consumes (sibling-trait false positives).
- EdgeCacheCoreOnlyTest: call the optional xdebug_get_headers via a string callable so it's not flagged undefined when xdebug is absent.
- FileUploaderNoMedia/UploadControllerVariant/StorageProviderFileUploaderMedia/WorkCommandLean: narrow getContainer() to the concrete Glueful\Container\Container before load()/with().
- ContainerFactory: drop a redundant @var over a sealed provider-list literal (Intelephense P1131; the array_map callback types each as BaseServiceProvider regardless).

Full suite green (1187); analyse + phpcs clean.
