### PR TITLE
Release v1.61.0 — Wezen: OpenAPI tag allow/deny filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.61.0] - 2026-06-20 — Wezen
+
+> **Theme: API-docs tag filtering.** The OpenAPI generator gains a tag allow/deny filter (`documentation.options.tags.include` / `.exclude`, env-driven) so a consumer-facing spec can drop infrastructure groups (e.g. `Health`, `Documentation`, `Security`) without turning off whole route sources (`include_framework_routes` / `include_extensions`). Plus a small config cleanup — the dead `route_definitions` / `extension_definitions` doc-config keys (unread by the reflect generator) are removed. **Minor release** — additive: filtering defaults off (empty lists), no breaking API changes, no new migrations, no behavioral change to existing specs.
+
 ### Added
 - **OpenAPI tag allow/deny filter.** New `documentation.options.tags.include` / `.exclude` (both default empty = no filtering; comma-separated env `API_DOCS_INCLUDE_TAGS` / `API_DOCS_EXCLUDE_TAGS`) drop operations from the generated spec by tag, *before* write — so a consumer-facing spec can exclude infra groups (e.g. `Health`, `Documentation`, `Security`) without turning off whole route sources (`include_framework_routes` / `include_extensions`). Allow-list empty = keep all; deny-list wins over allow; dropped operations take their now-unreferenced tags + schemas with them. The filtering logic is a pure, unit-tested static `DocGenerator::filterPathsByTags()`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Added
+- **OpenAPI tag allow/deny filter.** New `documentation.options.tags.include` / `.exclude` (both default empty = no filtering; comma-separated env `API_DOCS_INCLUDE_TAGS` / `API_DOCS_EXCLUDE_TAGS`) drop operations from the generated spec by tag, *before* write — so a consumer-facing spec can exclude infra groups (e.g. `Health`, `Documentation`, `Security`) without turning off whole route sources (`include_framework_routes` / `include_extensions`). Allow-list empty = keep all; deny-list wins over allow; dropped operations take their now-unreferenced tags + schemas with them. The filtering logic is a pure, unit-tested static `DocGenerator::filterPathsByTags()`.
+
+### Removed
+- **Dead doc-config keys `documentation.paths.route_definitions` and `documentation.paths.extension_definitions`.** They pointed at the removed comment generator's `json-definitions/{routes,extensions}/` output dirs and are unread by the reflect generator, which merges only top-level `docs/json-definitions/*.json` fragments.
+
 ## [1.60.0] - 2026-06-19 — Vega
 
 > **Theme: Engine-agnostic installer + first-run setup seams.** `php glueful install` now configures and migrates **any** database engine (MySQL/PostgreSQL/SQLite), not just SQLite, with reconnected interactive credential prompts. A new `Glueful\Installer\` toolkit (`EnvWriter`, `ConnectionTester`, `Installer`, `DatabaseConfig`, `InstallState`) lets an app drive first-run setup from CLI **or** a UI without shelling out — under two hard invariants: a failed DB test mutates nothing, and the tested credentials are exactly what migrations run on. Plus `.env` writes are now quoted + atomic (one `EnvWriter`, replacing two unsafe copies), and `MigrationManager` accepts an injected `Connection`. **Minor release** — additive (no breaking API changes, no new env, no migrations). **Has `### Upgrade Notes`** (the now-interactive `install`).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,11 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.61.0 — Wezen (Minor, Released 2026-06-20)
+- **OpenAPI tag allow/deny filter.** The doc generator gains `documentation.options.tags.include` / `.exclude` (env `API_DOCS_INCLUDE_TAGS` / `API_DOCS_EXCLUDE_TAGS`) — drop operations from the generated spec by tag *before* write, so a consumer-facing spec can exclude infra groups (e.g. `Health`/`Documentation`/`Security`) without disabling whole route sources. Allow-list empty = keep all; deny wins; dropped ops take their now-unreferenced tags + schemas with them. Pure static `DocGenerator::filterPathsByTags()`.
+- **Doc-config cleanup.** Removed the dead `documentation.paths.route_definitions` / `extension_definitions` keys (unread by the reflect generator, which merges only top-level `docs/json-definitions/*.json`).
+- Notes: **Minor release**, additive — filtering defaults off, no breaking API changes, no new migrations. api-skeleton bumped to `^1.61.0`.
+
 ### 1.60.0 — Vega (Minor, Released 2026-06-19)
 - **Engine-agnostic installer (`php glueful install`).** Install now configures + migrates **any** engine (MySQL/PostgreSQL/SQLite), not just SQLite — the DB step's SQLite-only guard is gone, replaced by a connection test + `migrate:run` against the configured engine, and the previously-orphaned interactive credential prompts are reconnected. The command is a thin wrapper (710 → 238 lines) over the new orchestrator.
 - **`Glueful\Installer\` first-run setup seams.** Reusable services an app can drive from CLI **or** a UI without shelling out: `EnvWriter` (atomic, quoted `.env` writes — the single writer now, replacing two unsafe copies in `install`/`generate:key`), `ConnectionTester` (transient probe of explicit creds with a short connect timeout + typed result), `Installer` (preflight-first pipeline, step-based result), `DatabaseConfig`, `InstallState`. Two hard invariants: a failed DB test mutates nothing, and the tested credentials are exactly the connection migrations run on (`MigrationManager` gains an optional injected `Connection`). PostgreSQL `sslmode`/`connect_timeout` now reach the DSN.

--- a/config/documentation.php
+++ b/config/documentation.php
@@ -106,11 +106,6 @@ return [
         // Final OpenAPI specification file location
         'openapi' => $root . '/docs/openapi.json',
 
-        // JSON definitions for route-based documentation
-        'route_definitions' => $root . '/docs/json-definitions/routes',
-
-        // JSON definitions for extension documentation
-        'extension_definitions' => $root . '/docs/json-definitions/extensions',
     ],
 
     /*
@@ -234,6 +229,22 @@ return [
         // Default false: the built-in defaults are kept for backward compatibility.
         // Explicitly-documented schemas (from route/extension fragments) are always kept.
         'prune_unreferenced_schemas' => env('API_DOCS_PRUNE_UNREFERENCED_SCHEMAS', false),
+
+        // Tag allow/deny filter applied to the assembled spec before write. `include` is an
+        // allow-list (empty = keep all tags); `exclude` is a deny-list and WINS over include.
+        // Lets a consumer-facing spec drop infra groups (e.g. Health, Documentation) without
+        // turning off whole route sources. Both default empty (no filtering). Comma-separated
+        // env overrides, e.g. API_DOCS_EXCLUDE_TAGS="Health,Documentation,Security".
+        'tags' => [
+            'include' => array_values(array_filter(array_map(
+                'trim',
+                explode(',', (string) env('API_DOCS_INCLUDE_TAGS', ''))
+            ), static fn(string $v): bool => $v !== '')),
+            'exclude' => array_values(array_filter(array_map(
+                'trim',
+                explode(',', (string) env('API_DOCS_EXCLUDE_TAGS', ''))
+            ), static fn(string $v): bool => $v !== '')),
+        ],
     ],
 
     /*

--- a/src/Support/Documentation/DocGenerator.php
+++ b/src/Support/Documentation/DocGenerator.php
@@ -797,6 +797,15 @@ class DocGenerator
      */
     public function getSwaggerJson(): string
     {
+        // Apply the configured tag allow/deny filter before anything downstream reads the paths
+        // (schema prune, transformPaths, and the tag list all derive from $this->paths), so
+        // dropped operations take their now-unreferenced tags + schemas with them.
+        $this->paths = self::filterPathsByTags(
+            $this->paths,
+            $this->configList('documentation.options.tags.include'),
+            $this->configList('documentation.options.tags.exclude'),
+        );
+
         $baseUrl = '';
         if ($this->context !== null && function_exists('api_url')) {
             $baseUrl = api_url($this->context);
@@ -853,6 +862,101 @@ class DocGenerator
         }
 
         return json_encode($swagger, JSON_PRETTY_PRINT);
+    }
+
+    /**
+     * Read a config value as a clean list of non-empty, trimmed strings.
+     *
+     * @return list<string>
+     */
+    private function configList(string $key): array
+    {
+        $raw = $this->getConfig($key, []);
+        if (!is_array($raw)) {
+            return [];
+        }
+        return array_values(array_filter(
+            array_map(static fn($v): string => is_scalar($v) ? trim((string) $v) : '', $raw),
+            static fn(string $v): bool => $v !== ''
+        ));
+    }
+
+    /**
+     * Filter operations by their tags using allow/deny lists, dropping any path item left with no
+     * operations. Pure + static so it can be unit-tested directly, independent of config/context.
+     *
+     * Keep rule per operation: (include empty OR its tags intersect include) AND (its tags do not
+     * intersect exclude). Deny WINS. An untagged operation passes an empty include-list but fails a
+     * non-empty one. Path-item-level keys (`parameters`, `$ref`, `summary`, `servers`, …) are
+     * preserved as-is; a path left with only such keys (no operations) is dropped.
+     *
+     * @param array<string, mixed> $paths    path => (verb|key) => operation
+     * @param list<string>         $include   allow-list (empty = all tags allowed)
+     * @param list<string>         $exclude   deny-list (takes precedence)
+     * @return array<string, mixed>
+     */
+    public static function filterPathsByTags(array $paths, array $include, array $exclude): array
+    {
+        if ($include === [] && $exclude === []) {
+            return $paths;
+        }
+
+        $methods = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
+        $includeSet = array_flip($include);
+        $excludeSet = array_flip($exclude);
+
+        $out = [];
+        foreach ($paths as $path => $item) {
+            if (!is_array($item)) {
+                $out[$path] = $item;
+                continue;
+            }
+            $kept = [];
+            foreach ($item as $key => $operation) {
+                // Preserve non-operation keys on the path item (parameters, $ref, summary, …).
+                if (!in_array(strtolower((string) $key), $methods, true)) {
+                    $kept[$key] = $operation;
+                    continue;
+                }
+                $tags = (is_array($operation) && isset($operation['tags']) && is_array($operation['tags']))
+                    ? array_map('strval', $operation['tags'])
+                    : [];
+                if (self::tagsPass($tags, $includeSet, $excludeSet)) {
+                    $kept[$key] = $operation;
+                }
+            }
+            // Keep the path only if at least one operation survived.
+            foreach (array_keys($kept) as $key) {
+                if (in_array(strtolower((string) $key), $methods, true)) {
+                    $out[$path] = $kept;
+                    break;
+                }
+            }
+        }
+        return $out;
+    }
+
+    /**
+     * @param list<string>          $tags
+     * @param array<string, int>    $includeSet
+     * @param array<string, int>    $excludeSet
+     */
+    private static function tagsPass(array $tags, array $includeSet, array $excludeSet): bool
+    {
+        foreach ($tags as $t) {
+            if (isset($excludeSet[$t])) {
+                return false; // deny wins
+            }
+        }
+        if ($includeSet === []) {
+            return true; // no allow-list => allow
+        }
+        foreach ($tags as $t) {
+            if (isset($includeSet[$t])) {
+                return true;
+            }
+        }
+        return false; // allow-list set but nothing matched
     }
 
     /**

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,15 +13,15 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.60.0';
+    public const VERSION = '1.61.0';
 
 
     /** Release code name */
-    public const NAME = 'Vega';
+    public const NAME = 'Wezen';
 
 
     /** Release date */
-    public const RELEASE_DATE = '2026-06-19';
+    public const RELEASE_DATE = '2026-06-20';
 
     /** Minimum required PHP version */
     public const MIN_PHP_VERSION = '8.3.0';

--- a/tests/Unit/Support/Documentation/DocGeneratorTagFilterTest.php
+++ b/tests/Unit/Support/Documentation/DocGeneratorTagFilterTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Support\Documentation;
+
+use Glueful\Support\Documentation\DocGenerator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers the tag allow/deny filter (config `documentation.options.tags.include` /
+ * `.exclude`, both default empty = no filtering) applied to the assembled paths.
+ */
+final class DocGeneratorTagFilterTest extends TestCase
+{
+    /** @return array<string, mixed> */
+    private function paths(): array
+    {
+        return [
+            '/content' => [
+                'get' => ['tags' => ['Content']],
+                'post' => ['tags' => ['Content']],
+            ],
+            '/health' => [
+                'get' => ['tags' => ['Health']],
+            ],
+            '/mixed' => [
+                // path-item-level key (not an operation) — must be preserved as-is
+                'parameters' => [['name' => 'id', 'in' => 'path']],
+                'get' => ['tags' => ['Content', 'Internal']],
+            ],
+            '/untagged' => [
+                'get' => [], // no tags key
+            ],
+        ];
+    }
+
+    public function testEmptyListsAreAPassthrough(): void
+    {
+        $paths = $this->paths();
+        self::assertSame($paths, DocGenerator::filterPathsByTags($paths, [], []));
+    }
+
+    public function testExcludeDropsMatchingOperationsAndEmptiedPaths(): void
+    {
+        $out = DocGenerator::filterPathsByTags($this->paths(), [], ['Health']);
+
+        self::assertArrayNotHasKey('/health', $out, 'a path whose only op is Health-tagged is dropped');
+        self::assertArrayHasKey('/content', $out);
+        self::assertArrayHasKey('/untagged', $out, 'untagged op passes an exclude-only filter');
+        // /mixed keeps its Content+Internal op (Internal not excluded) and its parameters key.
+        self::assertArrayHasKey('/mixed', $out);
+        self::assertArrayHasKey('get', $out['/mixed']);
+        self::assertArrayHasKey('parameters', $out['/mixed'], 'non-operation path-item keys are preserved');
+    }
+
+    public function testDenyWinsAndPathWithOnlyNonOpKeysIsDropped(): void
+    {
+        // Excluding "Internal" drops /mixed's only op, leaving just `parameters` -> path removed.
+        $out = DocGenerator::filterPathsByTags($this->paths(), [], ['Internal']);
+
+        self::assertArrayNotHasKey('/mixed', $out, 'a path left with only non-op keys is dropped');
+        self::assertArrayHasKey('/content', $out);
+        self::assertArrayHasKey('/health', $out);
+    }
+
+    public function testIncludeKeepsOnlyMatchingTags(): void
+    {
+        $out = DocGenerator::filterPathsByTags($this->paths(), ['Content'], []);
+
+        self::assertArrayHasKey('/content', $out);
+        self::assertCount(2, $out['/content'], 'both Content ops kept');
+        self::assertArrayNotHasKey('/health', $out, 'Health not in the allow-list');
+        self::assertArrayHasKey('/mixed', $out, '/mixed has the allowed Content tag');
+        self::assertArrayHasKey('get', $out['/mixed']);
+        self::assertArrayNotHasKey('/untagged', $out, 'untagged op fails a non-empty allow-list');
+    }
+
+    public function testIncludePlusExcludeDenyTakesPrecedence(): void
+    {
+        // /mixed's op is tagged both Content (allowed) and Internal (denied) -> denied.
+        $out = DocGenerator::filterPathsByTags($this->paths(), ['Content'], ['Internal']);
+
+        self::assertArrayNotHasKey('/mixed', $out, 'exclude wins even when an allowed tag is present');
+        self::assertArrayHasKey('/content', $out);
+    }
+
+    public function testNonArrayPathItemsArePreserved(): void
+    {
+        $paths = ['/x' => ['get' => ['tags' => ['A']]], '/ref' => '#/paths/x'];
+        $out = DocGenerator::filterPathsByTags($paths, [], ['A']);
+
+        self::assertArrayNotHasKey('/x', $out);
+        self::assertSame('#/paths/x', $out['/ref'], 'non-array path entries pass through untouched');
+    }
+
+    public function testConfigDefaultsToNoFiltering(): void
+    {
+        $config = require dirname(__DIR__, 4) . '/config/documentation.php';
+
+        self::assertArrayHasKey('tags', $config['options']);
+        self::assertSame([], $config['options']['tags']['include']);
+        self::assertSame([], $config['options']['tags']['exclude']);
+    }
+
+    public function testGetSwaggerJsonDoesNotFilterByDefault(): void
+    {
+        // Null context => config returns the empty defaults => filter is a passthrough.
+        $generator = new DocGenerator(openApiVersion: '3.1.0');
+        $generator->mergePaths([
+            '/keep' => ['get' => ['tags' => ['Health'], 'responses' => []]],
+        ]);
+
+        $spec = json_decode($generator->getSwaggerJson(), true);
+        self::assertIsArray($spec);
+        self::assertArrayHasKey('/keep', $spec['paths'], 'no filtering when tag lists are empty');
+    }
+}


### PR DESCRIPTION
 Minor, additive release. The OpenAPI generator can now drop operations from the generated spec
  **by tag**, so a consumer-facing spec can hide infrastructure groups (`Health` / `Documentation` /
  `Security`) without turning off whole route sources. No migrations, no breaking API changes.
  
  ## Added
  - **OpenAPI tag allow/deny filter** — `documentation.options.tags.include` / `.exclude` (env
    `API_DOCS_INCLUDE_TAGS` / `API_DOCS_EXCLUDE_TAGS`). The allow-list keeps only matching tags (empty =
    keep all); the deny-list removes matching tags and **wins over** the allow-list. Operations are
    filtered **before** the spec is written, so dropped operations take their now-unreferenced tags
    **and** schemas with them. This is finer-grained than the all-or-nothing `include_framework_routes`
    / `include_extensions` source switches. The core is a pure, unit-tested static
    `DocGenerator::filterPathsByTags()`.
    
  ## Removed
  - **Dead doc-config keys `documentation.paths.route_definitions` and `extension_definitions`** — they
    pointed at the removed comment generator's `json-definitions/{routes,extensions}/` output dirs and
    were never read by the reflect generator (which merges only top-level `docs/json-definitions/*.json`
    fragments). Safe to delete if copied into an app config.
    
  ## Upgrade Notes
  - **None.** Filtering is **off by default** (both lists empty) — existing specs are byte-for-byte
    unchanged until you set the env. To use it: `API_DOCS_EXCLUDE_TAGS="Health,Documentation,Security"`
    then regenerate.
    
  ## Testing
  - New `DocGeneratorTagFilterTest` — 8 tests / 25 assertions covering allow-only, deny-wins, untagged
    behavior, path-item-key preservation, emptied-path dropping, and the off-by-default config.
  - Full suite green: **1658 tests, 4031 assertions** (63 skipped); `composer phpcs` clean; PHPStan
    clean on the changed generator; no Documentation-suite regression.
    
  ## Companion
  - api-skeleton bumps `glueful/framework` to `^1.61.0` and mirrors the doc-config change (tag block +
    dead-key removal). 