### PR TITLE
Apply CORS to final responses (1.61.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.61.1] - 2026-06-22 — Wezen
+
+> **Theme: CORS on every response.** The framework applied CORS headers only to the OPTIONS preflight, so cross-origin **regular** responses — and especially **error/exception** responses (422, 401, …) — shipped without `Access-Control-Allow-Origin`, and browsers withheld the body. A separately-served frontend (e.g. a Vite dev SPA on another origin) calling the API would therefore get an empty/unreadable body for any validation or error response. `Application::handle()` now applies CORS to the **final** response — in both the dispatch and exception-handler branches — so the headers that were always intended for these responses are actually present. **Patch release** — bugfix, no new env, no migrations, no action required.
+
+### Fixed
+- **Cross-origin error/regular responses are now readable.** `Application::handle()` applies CORS headers to the final response in both the normal **and** exception-handler branches, so a cross-origin client (e.g. a dev SPA on a different origin) can read the body of a `422`/`401`/etc. Previously only the OPTIONS preflight carried CORS headers, leaving regular and error response bodies blocked by the browser. Same-origin requests and disallowed origins are unaffected.
+
+### Added
+- **`Cors::applyToResponse(Request, Response)`** (supporting the fix above). Applies the regular-request CORS headers (`Access-Control-Allow-Origin`, `Vary: Origin`, plus `Access-Control-Expose-Headers` / `Access-Control-Allow-Credentials` per config) to an already-built response. No-op when there is no `Origin`, the origin is not allowed, or the header is already set (e.g. a preflight response), so it never clobbers the router's preflight handling.
+
 ## [1.61.0] - 2026-06-20 — Wezen
 
 > **Theme: API-docs tag filtering.** The OpenAPI generator gains a tag allow/deny filter (`documentation.options.tags.include` / `.exclude`, env-driven) so a consumer-facing spec can drop infrastructure groups (e.g. `Health`, `Documentation`, `Security`) without turning off whole route sources (`include_framework_routes` / `include_extensions`). Plus a small config cleanup — the dead `route_definitions` / `extension_definitions` doc-config keys (unread by the reflect generator) are removed. **Minor release** — additive: filtering defaults off (empty lists), no breaking API changes, no new migrations, no behavioral change to existing specs.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,10 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.61.1 — Wezen (Patch, Released 2026-06-22)
+- **CORS on every response.** `Application::handle()` now applies CORS headers to the final response in both the dispatch and exception-handler branches — previously only the OPTIONS preflight carried them, so cross-origin **regular** and **error** responses (422/401/…) shipped without `Access-Control-Allow-Origin` and browsers withheld the body. New public `Cors::applyToResponse(Request, Response)` supports the fix (no-op without an `Origin`, for disallowed origins, or when already set — never clobbers the preflight responder).
+- Notes: **Patch release** — bugfix, no new env, no migrations, no action required. api-skeleton bumped to `^1.61.1`.
+
 ### 1.61.0 — Wezen (Minor, Released 2026-06-20)
 - **OpenAPI tag allow/deny filter.** The doc generator gains `documentation.options.tags.include` / `.exclude` (env `API_DOCS_INCLUDE_TAGS` / `API_DOCS_EXCLUDE_TAGS`) — drop operations from the generated spec by tag *before* write, so a consumer-facing spec can exclude infra groups (e.g. `Health`/`Documentation`/`Security`) without disabling whole route sources. Allow-list empty = keep all; deny wins; dropped ops take their now-unreferenced tags + schemas with them. Pure static `DocGenerator::filterPathsByTags()`.
 - **Doc-config cleanup.** Removed the dead `documentation.paths.route_definitions` / `extension_definitions` keys (unread by the reflect generator, which merges only top-level `docs/json-definitions/*.json`).

--- a/src/Application.php
+++ b/src/Application.php
@@ -6,6 +6,7 @@ namespace Glueful;
 
 use Psr\Container\ContainerInterface;
 use Glueful\Routing\Router;
+use Glueful\Http\Cors;
 use Glueful\Http\Exceptions\Contracts\ExceptionHandlerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -48,6 +49,13 @@ class Application
             $handler = $this->container->get(ExceptionHandlerInterface::class);
             $response = $handler->handle($e, $request);
         }
+
+        // Cross-origin clients must be able to read EVERY response — including error/exception
+        // responses, which bypass the router's preflight CORS handling and would otherwise ship
+        // without Access-Control-Allow-Origin (so the browser withholds the body). Apply regular
+        // CORS headers to the final response here, the single chokepoint that sees both the
+        // dispatch and the exception-handler branches. No-op for same-origin or when already set.
+        (new Cors([], $this->context))->applyToResponse($request, $response);
 
         $totalTime = round((microtime(true) - $startTime) * 1000, 2);
         $this->logger->info(

--- a/src/Http/Cors.php
+++ b/src/Http/Cors.php
@@ -6,6 +6,7 @@ namespace Glueful\Http;
 
 use Glueful\Bootstrap\ApplicationContext;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 /**
  * Configurable CORS Handler - Developer-Friendly
@@ -338,6 +339,30 @@ class Cors
         }
 
         return $headers;
+    }
+
+    /**
+     * Apply regular (non-preflight) CORS headers to an already-built response.
+     *
+     * This lets cross-origin clients read the response BODY — including error/exception responses,
+     * which bypass the router's preflight handling and would otherwise ship without
+     * Access-Control-Allow-Origin (so the browser withholds the body). It is a no-op when there is
+     * no Origin, the origin is not allowed, or the response already carries the header (e.g. a
+     * preflight response). Sets headers on the Response object rather than via header(), so they
+     * travel with the response regardless of how/when it is sent.
+     */
+    public function applyToResponse(Request $request, SymfonyResponse $response): void
+    {
+        $origin = $request->headers->get('Origin', '');
+        if ($origin === '' || $response->headers->has('Access-Control-Allow-Origin')) {
+            return;
+        }
+        if (!$this->isOriginAllowed($origin)) {
+            return;
+        }
+        foreach ($this->responseCorsHeaders($origin) as $name => $value) {
+            $response->headers->set($name, $value);
+        }
     }
 
     /**

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,7 +13,7 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.61.0';
+    public const VERSION = '1.61.1';
 
 
     /** Release code name */
@@ -21,7 +21,7 @@ final class Version
 
 
     /** Release date */
-    public const RELEASE_DATE = '2026-06-20';
+    public const RELEASE_DATE = '2026-06-22';
 
     /** Minimum required PHP version */
     public const MIN_PHP_VERSION = '8.3.0';

--- a/tests/Unit/Http/CorsTest.php
+++ b/tests/Unit/Http/CorsTest.php
@@ -6,6 +6,8 @@ namespace Glueful\Tests\Unit\Http;
 
 use Glueful\Http\Cors;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Regression: the standalone CORS handler's no-config default was permissive and its
@@ -122,6 +124,63 @@ final class CorsTest extends TestCase
 
         $preflight = $this->invoke($cors, 'preflightCorsHeaders', ['https://app.example']);
         self::assertSame('Origin', $preflight['Vary'] ?? null);
+    }
+
+    public function test_applyToResponse_sets_cors_headers_on_error_response_for_allowed_origin(): void
+    {
+        $cors = new Cors(['allowedOrigins' => ['https://app.example']]);
+        $request = Request::create('/admin/setup', 'POST');
+        $request->headers->set('Origin', 'https://app.example');
+        // An error response — exactly the case the router's preflight handling doesn't cover.
+        $response = new Response('{"errors":{}}', 422);
+
+        $cors->applyToResponse($request, $response);
+
+        self::assertSame(
+            'https://app.example',
+            $response->headers->get('Access-Control-Allow-Origin'),
+            'cross-origin error responses must carry Access-Control-Allow-Origin so the browser exposes the body'
+        );
+        self::assertSame('Origin', $response->headers->get('Vary'));
+    }
+
+    public function test_applyToResponse_is_noop_for_disallowed_origin(): void
+    {
+        $cors = new Cors(['allowedOrigins' => ['https://app.example']]);
+        $request = Request::create('/x', 'POST');
+        $request->headers->set('Origin', 'https://evil.example');
+        $response = new Response('', 422);
+
+        $cors->applyToResponse($request, $response);
+
+        self::assertFalse($response->headers->has('Access-Control-Allow-Origin'));
+    }
+
+    public function test_applyToResponse_is_noop_without_an_origin(): void
+    {
+        $cors = new Cors(['allowedOrigins' => ['https://app.example']]);
+        $response = new Response('', 200);
+
+        $cors->applyToResponse(Request::create('/x', 'GET'), $response);
+
+        self::assertFalse($response->headers->has('Access-Control-Allow-Origin'));
+    }
+
+    public function test_applyToResponse_does_not_overwrite_an_existing_header(): void
+    {
+        $cors = new Cors(['allowedOrigins' => ['https://app.example']]);
+        $request = Request::create('/x', 'OPTIONS');
+        $request->headers->set('Origin', 'https://app.example');
+        $response = new Response('', 204);
+        $response->headers->set('Access-Control-Allow-Origin', 'https://preflight.example');
+
+        $cors->applyToResponse($request, $response);
+
+        self::assertSame(
+            'https://preflight.example',
+            $response->headers->get('Access-Control-Allow-Origin'),
+            'an already-set header (e.g. from the preflight responder) must not be clobbered'
+        );
     }
 
     private function configValue(Cors $cors, string $key): mixed


### PR DESCRIPTION
Fix missing CORS on non-preflight responses: previously only OPTIONS preflight carried Access-Control-Allow-Origin, causing regular and error responses (422/401/etc.) to be unreadable by cross-origin browsers. Application::handle now applies CORS to the final Response in both the dispatch and exception-handler branches. Added Cors::applyToResponse(Request, Response) which sets regular-request CORS headers (no-op when no Origin, origin disallowed, or header already present). Added unit tests for applyToResponse and bumped version to 1.61.1; updated CHANGELOG and ROADMAP. Patch release: bugfix, no new env or migrations, no action required.
your changes -->


