### PR TITLE
Release 1.62.0 — Xuange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.62.0] - 2026-06-24 — Xuange
+
+> **Theme: user-record enrichment seam.** A new core contract lets an authorization (or other)
+> extension attach fields to the user *records* an identity store returns — the read-side symmetric
+> of the existing `identity.claims_provider` seam (which enriches the one authenticated identity at
+> login). It exists so glueful/users can surface a user's `roles` on `/users`, `/users/{uuid}` and
+> `/me` without depending on glueful/aegis, and so a future extension can attach teams/etc. the same
+> way. **Minor release** — additive contract, no behavior change unless an extension registers an
+> enricher, no new env, no migrations.
+
+### Added
+- **`Glueful\Auth\Contracts\UserRecordEnricherInterface`** + the `users.record_enricher` container
+  tag. An implementation receives a batch of user UUIDs and returns additive fields to merge per
+  record (e.g. `{roles: […]}`); a consumer (the identity store's read endpoints) collects every
+  tagged service and folds their output into each record. Implementations must be batch-friendly
+  (one query, no N+1) and additive (they cannot change identity facts). Mirrors
+  `IdentityClaimsProviderInterface` for read payloads rather than the authenticated principal.
+
 ## [1.61.2] - 2026-06-23 — Wezen
 
 > **Theme: permission gate fail-closed fix.** Every `#[RequiresPermission]` / `gate_permissions` route returned **403 for fully authorized users** because the `auth.user` principal the gate reads was never populated — `AuthMiddleware`'s enricher lookup used a leading-backslash container id that never matched, so the enricher silently never ran. The gate then saw a null principal and denied. Plus a companion cache-key fix so file/Memcached backends accept the framework's colon-namespaced keys (login could fail on those drivers). **Patch release** — bugfixes, no new env, no migrations, no action required.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,14 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.62.0 — Xuange (Minor, Released 2026-06-24)
+- **User-record enrichment seam.** New `Glueful\Auth\Contracts\UserRecordEnricherInterface` + the
+  `users.record_enricher` tag — the read-side symmetric of `identity.claims_provider`. Lets an
+  authorization extension (glueful/aegis) attach a user's `roles` to the records an identity store
+  (glueful/users) returns on `/users`, `/users/{uuid}` and `/me`, with no dependency between the two.
+- Notes: **Minor release**, additive — no behavior change unless an extension registers an enricher,
+  no new env, no migrations. api-skeleton bumped to `^1.62.0`.
+
 ### 1.61.2 — Wezen (Patch, Released 2026-06-23)
 - **Permission gate no longer fail-closes (403) for authorized users.** `AuthMiddleware::autoEnrichRequest()` resolved the `auth.user` enricher by a leading-backslash container id (`'\Glueful\…\AuthToRequestAttributesMiddleware'`) that never matched the `::class` registration key, so `Container::has()` returned false, the enricher never ran, and `GateAttributeMiddleware` saw a null principal — returning 403 on every `#[RequiresPermission]` / `gate_permissions` route even for fully authorized users. Lookup now uses the `::class` constant.
 - **File/Memcached cache drivers accept colon-namespaced keys**, matching Redis — login no longer fails on those backends when `SessionCacheManager` stores `session:`-prefixed keys.

--- a/src/Auth/Contracts/UserRecordEnricherInterface.php
+++ b/src/Auth/Contracts/UserRecordEnricherInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Auth\Contracts;
+
+/**
+ * Decorates user *records* (read payloads) with extra fields owned by another extension.
+ *
+ * The symmetric counterpart to {@see IdentityClaimsProviderInterface}: where that enriches the one
+ * AUTHENTICATED identity with claims at login, this enriches an arbitrary BATCH of user records that
+ * a read endpoint (e.g. the identity store's `/users` list, `/users/{uuid}`, `/me`) is about to
+ * return. It lets an authorization extension (e.g. glueful/aegis) attach a user's `roles` — or a
+ * future extension attach teams/departments — without the identity store ever depending on it.
+ *
+ * Register implementations with the container tag **`users.record_enricher`**; the consumer collects
+ * every tagged service and merges their output into each record. Implementations MUST:
+ *  - be batch-friendly (resolve all UUIDs in one query — never N+1),
+ *  - return ONLY additive fields (they cannot change identity facts), and
+ *  - omit users they have nothing for (a missing key means "no extra fields").
+ */
+interface UserRecordEnricherInterface
+{
+    /**
+     * @param list<string> $userUuids the user UUIDs in the batch being returned
+     * @return array<string, array<string, mixed>> uuid => extra fields to merge into that record
+     */
+    public function enrich(array $userUuids): array;
+}

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,15 +13,15 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.61.2';
+    public const VERSION = '1.62.0';
 
 
     /** Release code name */
-    public const NAME = 'Wezen';
+    public const NAME = 'Xuange';
 
 
     /** Release date */
-    public const RELEASE_DATE = '2026-06-23';
+    public const RELEASE_DATE = '2026-06-24';
 
     /** Minimum required PHP version */
     public const MIN_PHP_VERSION = '8.3.0';


### PR DESCRIPTION
Add UserRecordEnricherInterface + the users.record_enricher container tag: the read-side symmetric of identity.claims_provider. Lets an authorization extension attach fields (e.g. a user's roles) to the records an identity store returns on /users, /users/{uuid} and /me, with no dependency between the two. Additive — no behavior change unless an extension registers an enricher.
