### PR TITLE
Add EntityDeletedEvent and protected dispatchEvent method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.63.0] - 2026-06-25 — Yildun
+
+> **Theme: entity-deletion event + subclass domain-event dispatch.** `BaseRepository` now emits an
+> `EntityDeletedEvent` on a successful delete — completing the create/update/delete triplet so audit,
+> cache-invalidation and notification consumers can react to deletes, not just writes. And the
+> repository's event-dispatch helper is now `protected`, so repository subclasses (including those in
+> extensions) can emit their own domain events through the same best-effort, context-guarded path.
+> **Minor release** — additive: a new event (fires only if something subscribes) plus a visibility
+> widening; no breaking changes, no new env, no migrations.
+
+### Added
+- **`Glueful\Events\Database\EntityDeletedEvent`**, dispatched from `BaseRepository::delete()` after a
+  successful delete (`affected_rows > 0`). It carries the **pre-delete** record (read before the delete)
+  so consumers can derive the entity's identity/labels, plus metadata matching the create/update events
+  (`entity_id`, `primary_key`, `affected_rows`, `operation: 'delete'`). Mirrors `EntityCreatedEvent`'s
+  surface (`getEntity()`/`getEntityId()`/`getTable()`/`getCacheTags()`/`isUserRelated()`, with a
+  `getOriginalData()` alias). Completes the entity CRUD event triplet; no-op deletes (missing row / zero
+  affected) emit nothing.
+
+### Changed
+- **`BaseRepository::dispatchEvent()` is now `protected`** (was `private`), so repository subclasses —
+  including those in extensions — can emit their own domain events through the framework's best-effort,
+  context-guarded dispatch helper (it no-ops when the repository was constructed without an
+  `ApplicationContext`). No behavior change to existing repositories.
+
 ## [1.62.0] - 2026-06-24 — Xuange
 
 > **Theme: user-record enrichment seam.** A new core contract lets an authorization (or other)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,18 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.63.0 — Yildun (Minor, Released 2026-06-25)
+- **Entity-deletion event.** `BaseRepository::delete()` now dispatches `Glueful\Events\Database\EntityDeletedEvent`
+  after a successful delete (`affected_rows > 0`), carrying the **pre-delete** record + metadata matching the
+  create/update events (`entity_id`, `primary_key`, `affected_rows`, `operation`). Completes the create/update/delete
+  event triplet so audit/cache-invalidation/notification consumers can react to deletes. Mirrors `EntityCreatedEvent`
+  (`getEntity()`/`getEntityId()`/`getTable()`/`getCacheTags()`/`isUserRelated()`, plus a `getOriginalData()` alias).
+- **Subclass domain-event dispatch.** `BaseRepository::dispatchEvent()` widened `private` → `protected` so repository
+  subclasses (incl. extensions) can emit their own domain events through the framework's best-effort, context-guarded
+  helper (no-ops without an injected `ApplicationContext`).
+- Notes: **Minor release**, additive — a new event (fires only if subscribed) + a visibility widening; no breaking
+  changes, no new env, no migrations. api-skeleton bumped to `^1.63.0`.
+
 ### 1.62.0 — Xuange (Minor, Released 2026-06-24)
 - **User-record enrichment seam.** New `Glueful\Auth\Contracts\UserRecordEnricherInterface` + the
   `users.record_enricher` tag — the read-side symmetric of `identity.claims_provider`. Lets an

--- a/src/Events/Database/EntityDeletedEvent.php
+++ b/src/Events/Database/EntityDeletedEvent.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Events\Database;
+
+use Glueful\Events\Contracts\BaseEvent;
+
+/**
+ * Entity Deleted Event
+ *
+ * Dispatched after an entity is deleted from the database (affected rows > 0).
+ * Carries the PRE-DELETE record so consumers can derive identity/labels.
+ *
+ * @package Glueful\Events\Database
+ */
+class EntityDeletedEvent extends BaseEvent
+{
+    /**
+     * @param array<string, mixed>|object $originalData The record as it was before deletion
+     * @param string $table Database table name
+     * @param array<string, mixed> $metadata Additional metadata
+     */
+    public function __construct(
+        private readonly array|object $originalData,
+        private readonly string $table,
+        array $metadata = []
+    ) {
+        parent::__construct();
+        foreach ($metadata as $key => $value) {
+            $this->setMetadata($key, $value);
+        }
+    }
+
+    /** @return array<string, mixed>|object */
+    public function getEntity(): array|object
+    {
+        return $this->originalData;
+    }
+
+    /** @return array<string, mixed>|object */
+    public function getOriginalData(): array|object
+    {
+        return $this->originalData;
+    }
+
+    public function getTable(): string
+    {
+        return $this->table;
+    }
+
+    public function getEntityId(): mixed
+    {
+        if (is_array($this->originalData)) {
+            return $this->originalData['id'] ?? $this->originalData['uuid'] ?? null;
+        }
+        if (is_object($this->originalData)) {
+            return $this->originalData->id ?? $this->originalData->uuid ?? null;
+        }
+        return null;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getCacheTags(): array
+    {
+        $tags = [$this->table];
+
+        $entityId = $this->getEntityId();
+        if ($entityId !== null) {
+            $tags[] = $this->table . ':' . $entityId;
+        }
+
+        return array_merge($tags, $this->getMetadata('cache_tags') ?? []);
+    }
+
+    public function isUserRelated(): bool
+    {
+        return in_array($this->table, ['users', 'user_sessions', 'user_preferences'], true);
+    }
+}

--- a/src/Repository/BaseRepository.php
+++ b/src/Repository/BaseRepository.php
@@ -11,6 +11,7 @@ use Glueful\Repository\Traits\TransactionTrait;
 use Glueful\Helpers\Utils;
 use Glueful\Http\Exceptions\Domain\DatabaseException;
 use Glueful\Events\Database\EntityCreatedEvent;
+use Glueful\Events\Database\EntityDeletedEvent;
 use Glueful\Events\Database\EntityUpdatedEvent;
 use Glueful\Events\EventService;
 
@@ -318,12 +319,19 @@ abstract class BaseRepository implements RepositoryInterface
         $success = $affectedRows > 0;
 
         if ($success) {
+            $this->dispatchEvent(new EntityDeletedEvent($originalData, $this->table, [
+                'entity_id' => $uuid,
+                'timestamp' => time(),
+                'primary_key' => $this->primaryKey,
+                'affected_rows' => $affectedRows,
+                'operation' => 'delete',
+            ]));
         }
 
         return $success;
     }
 
-    private function dispatchEvent(object $event): void
+    protected function dispatchEvent(object $event): void
     {
         if ($this->context === null) {
             return;

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,15 +13,15 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.62.0';
+    public const VERSION = '1.63.0';
 
 
     /** Release code name */
-    public const NAME = 'Xuange';
+    public const NAME = 'Yildun';
 
 
     /** Release date */
-    public const RELEASE_DATE = '2026-06-24';
+    public const RELEASE_DATE = '2026-06-25';
 
     /** Minimum required PHP version */
     public const MIN_PHP_VERSION = '8.3.0';

--- a/tests/Unit/Events/Database/EntityDeletedEventTest.php
+++ b/tests/Unit/Events/Database/EntityDeletedEventTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Events\Database;
+
+use Glueful\Events\Database\EntityDeletedEvent;
+use PHPUnit\Framework\TestCase;
+
+final class EntityDeletedEventTest extends TestCase
+{
+    public function test_get_table_returns_table_name(): void
+    {
+        $event = new EntityDeletedEvent(['uuid' => 'abc'], 'posts');
+
+        $this->assertSame('posts', $event->getTable());
+    }
+
+    public function test_get_entity_id_from_uuid(): void
+    {
+        $event = new EntityDeletedEvent(['uuid' => 'uuid-123', 'name' => 'x'], 'posts');
+
+        $this->assertSame('uuid-123', $event->getEntityId());
+    }
+
+    public function test_get_entity_id_prefers_id_over_uuid(): void
+    {
+        $event = new EntityDeletedEvent(['id' => 42, 'uuid' => 'uuid-123'], 'posts');
+
+        $this->assertSame(42, $event->getEntityId());
+    }
+
+    public function test_get_entity_id_from_object(): void
+    {
+        $record = (object) ['uuid' => 'obj-uuid'];
+        $event = new EntityDeletedEvent($record, 'posts');
+
+        $this->assertSame('obj-uuid', $event->getEntityId());
+    }
+
+    public function test_get_entity_id_returns_null_when_no_identity(): void
+    {
+        $event = new EntityDeletedEvent(['name' => 'no-id'], 'posts');
+
+        $this->assertNull($event->getEntityId());
+    }
+
+    public function test_get_entity_and_get_original_data_return_pre_delete_record(): void
+    {
+        $record = ['uuid' => 'abc', 'name' => 'Original'];
+        $event = new EntityDeletedEvent($record, 'posts');
+
+        $this->assertSame($record, $event->getEntity());
+        $this->assertSame($record, $event->getOriginalData());
+    }
+
+    public function test_metadata_round_trips(): void
+    {
+        $event = new EntityDeletedEvent(['uuid' => 'abc'], 'posts', [
+            'entity_id' => 'abc',
+            'operation' => 'delete',
+            'affected_rows' => 1,
+        ]);
+
+        $this->assertSame('abc', $event->getMetadata('entity_id'));
+        $this->assertSame('delete', $event->getMetadata('operation'));
+        $this->assertSame(1, $event->getMetadata('affected_rows'));
+    }
+
+    public function test_is_user_related_true_for_user_tables(): void
+    {
+        $this->assertTrue((new EntityDeletedEvent(['uuid' => 'a'], 'users'))->isUserRelated());
+        $this->assertTrue((new EntityDeletedEvent(['uuid' => 'a'], 'user_sessions'))->isUserRelated());
+        $this->assertTrue((new EntityDeletedEvent(['uuid' => 'a'], 'user_preferences'))->isUserRelated());
+    }
+
+    public function test_is_user_related_false_for_other_tables(): void
+    {
+        $this->assertFalse((new EntityDeletedEvent(['uuid' => 'a'], 'posts'))->isUserRelated());
+    }
+}

--- a/tests/Unit/Repository/BaseRepositoryDeleteEventTest.php
+++ b/tests/Unit/Repository/BaseRepositoryDeleteEventTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Repository;
+
+use Glueful\Bootstrap\ApplicationContext;
+use Glueful\Database\Connection;
+use Glueful\Events\Database\EntityDeletedEvent;
+use Glueful\Events\EventDispatcher;
+use Glueful\Events\EventService;
+use Glueful\Events\ListenerProvider;
+use Glueful\Repository\BaseRepository;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Verifies BaseRepository::delete() dispatches exactly one EntityDeletedEvent
+ * carrying the pre-delete record, and dispatches none for a missing uuid.
+ */
+final class BaseRepositoryDeleteEventTest extends TestCase
+{
+    private Connection $connection;
+    private ApplicationContext $context;
+    /** @var list<object> */
+    private array $dispatched = [];
+
+    protected function setUp(): void
+    {
+        $this->dispatched = [];
+
+        // Ensure this test owns its own in-memory SQLite PDO rather than reusing a
+        // process-static one cached by the bootstrap or a prior test.
+        $this->resetConnectionInstances();
+
+        // Build the capturing context first, then bind the Connection to it. BaseRepository
+        // rebuilds any context-less shared connection, so the connection must carry the
+        // context for the repository to reuse our seeded in-memory PDO.
+        $this->context = $this->makeContext();
+
+        $this->connection = new Connection([
+            'engine' => 'sqlite',
+            'sqlite' => ['primary' => ':memory:'],
+            'pooling' => ['enabled' => false],
+        ], $this->context);
+
+        $pdo = $this->connection->getPDO();
+        $pdo->exec('CREATE TABLE posts (uuid TEXT PRIMARY KEY, name TEXT)');
+        $pdo->exec("INSERT INTO posts (uuid, name) VALUES ('post-1', 'First Post')");
+    }
+
+    protected function tearDown(): void
+    {
+        // Reset the BaseRepository shared connection static to avoid cross-test leakage.
+        $ref = new \ReflectionProperty(BaseRepository::class, 'sharedConnection');
+        $ref->setAccessible(true);
+        $ref->setValue(null, null);
+
+        $this->resetConnectionInstances();
+    }
+
+    private function resetConnectionInstances(): void
+    {
+        $ref = new \ReflectionProperty(Connection::class, 'instances');
+        $ref->setAccessible(true);
+        $ref->setValue(null, []);
+    }
+
+    private function makeContext(): ApplicationContext
+    {
+        $provider = new ListenerProvider();
+        $dispatcher = new EventDispatcher($provider);
+        $eventService = new EventService($dispatcher, $provider);
+
+        // Capture every EntityDeletedEvent that flows through the dispatcher.
+        $eventService->addListener(EntityDeletedEvent::class, function (object $event): void {
+            $this->dispatched[] = $event;
+        });
+
+        $container = new class ($eventService) implements ContainerInterface {
+            public function __construct(private EventService $eventService)
+            {
+            }
+
+            public function get(string $id): mixed
+            {
+                if ($id === EventService::class) {
+                    return $this->eventService;
+                }
+                throw new \RuntimeException("Unexpected service request: {$id}");
+            }
+
+            public function has(string $id): bool
+            {
+                return $id === EventService::class;
+            }
+        };
+
+        $context = ApplicationContext::forTesting(dirname(__DIR__, 3));
+        $context->setContainer($container);
+
+        return $context;
+    }
+
+    public function test_delete_dispatches_entity_deleted_event_with_pre_delete_data(): void
+    {
+        $repo = new TestPostRepository($this->connection, $this->context);
+
+        $result = $repo->delete('post-1');
+
+        $this->assertTrue($result);
+        $this->assertCount(1, $this->dispatched);
+
+        $event = $this->dispatched[0];
+        $this->assertInstanceOf(EntityDeletedEvent::class, $event);
+        $this->assertSame('posts', $event->getTable());
+        $this->assertSame('post-1', $event->getEntityId());
+
+        $original = $event->getOriginalData();
+        $this->assertIsArray($original);
+        $this->assertSame('First Post', $original['name']);
+        $this->assertSame('delete', $event->getMetadata('operation'));
+        $this->assertSame('post-1', $event->getMetadata('entity_id'));
+        $this->assertSame(1, $event->getMetadata('affected_rows'));
+    }
+
+    public function test_delete_of_missing_uuid_dispatches_no_event(): void
+    {
+        $repo = new TestPostRepository($this->connection, $this->context);
+
+        $result = $repo->delete('does-not-exist');
+
+        $this->assertFalse($result);
+        $this->assertCount(0, $this->dispatched);
+    }
+}
+
+/**
+ * Minimal in-suite repository over the temp `posts` table.
+ */
+final class TestPostRepository extends BaseRepository
+{
+    public function getTableName(): string
+    {
+        return 'posts';
+    }
+}


### PR DESCRIPTION
### Added
- **`Glueful\Events\Database\EntityDeletedEvent`**, dispatched from `BaseRepository::delete()` after a
  successful delete (`affected_rows > 0`). It carries the **pre-delete** record (read before the delete)
  so consumers can derive the entity's identity/labels, plus metadata matching the create/update events
  (`entity_id`, `primary_key`, `affected_rows`, `operation: 'delete'`). Mirrors `EntityCreatedEvent`'s
  surface (`getEntity()`/`getEntityId()`/`getTable()`/`getCacheTags()`/`isUserRelated()`, with a
  `getOriginalData()` alias). Completes the entity CRUD event triplet; no-op deletes (missing row / zero
  affected) emit nothing.

### Changed
- **`BaseRepository::dispatchEvent()` is now `protected`** (was `private`), so repository subclasses —
  including those in extensions — can emit their own domain events through the framework's best-effort,
  context-guarded dispatch helper (it no-ops when the repository was constructed without an
  `ApplicationContext`). No behavior change to existing repositories.