### PR TITLE
Isolate event-listener failures and improve auth event handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.63.1] - 2026-06-25 — Yildun
+
+> **Theme: resilient event dispatch + dead auth events.** Related fixes that together restore delivery
+> of auth/security events (logins, logouts, failed logins, rate-limit/security violations) to their
+> listeners. `ActivityLoggingSubscriber` — the first listener on every auth/security event — was
+> **unresolvable** (it required a `LogManager` the container never registers), so resolving it threw;
+> and the dispatcher did **not** isolate listener failures, so that throw aborted the whole dispatch
+> before any later listener (cache invalidation, an audit extension, …) ran. The session-event
+> dispatcher swallows dispatch errors, so logins silently succeeded with nothing logged. **Patch
+> release** — bugfixes, no new env, no migrations, no action required.
+
+### Fixed
+- **A throwing event listener no longer aborts the dispatch and starves the listeners after it.**
+  `EventDispatcher::dispatch()` now catches each listener's `Throwable`, logs it, and continues to the
+  next listener (on both the hot and traced paths) — a single broken or misconfigured listener can no
+  longer take the rest of the chain down with it. Previously the first listener to throw ended dispatch
+  for that event entirely.
+- **`ActivityLoggingSubscriber` is now resolvable.** It required a non-nullable `LogManager`, which is
+  not a container-registered service, so the autowiring resolver could not construct it — making the
+  subscriber throw on every auth/security event. Its constructor now takes `?LogManager $logger = null`
+  and falls back to `LogManager::getInstance()`. Combined with the dispatcher fix, auth/security events
+  are delivered to all listeners again (the framework's own activity logging, plus any app/extension
+  subscriber such as glueful/audit).
+- **Failed logins now emit `AuthenticationFailedEvent`.** The event was declared and listeners subscribe
+  to it, but nothing ever dispatched it — so failed login attempts were invisible to activity logging and
+  audit consumers. `AuthenticationService::verifyCredentials()` now dispatches it (best-effort,
+  context-guarded, never breaks the login flow) when credentials are rejected (`invalid_credentials`) or
+  the resolved account is disabled (`user_disabled`), carrying the attempted username plus the request's
+  client IP and user-agent when available.
+
 ## [1.63.0] - 2026-06-25 — Yildun
 
 > **Theme: entity-deletion event + subclass domain-event dispatch.** `BaseRepository` now emits an

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,21 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.63.1 — Yildun (Patch, Released 2026-06-25)
+- **Resilient event dispatch.** `EventDispatcher::dispatch()` now isolates listener failures — it catches
+  each listener's `Throwable`, logs it, and continues — so one broken/misconfigured listener can't abort
+  the dispatch and starve the rest of the chain (previously the first throw ended dispatch for that event).
+- **`ActivityLoggingSubscriber` is resolvable again.** It required a non-nullable `LogManager` that the
+  container never registers, so it threw on every auth/security event — and (pre-isolation) that aborted
+  delivery of those events to *all* listeners. Now takes `?LogManager $logger = null` with a
+  `getInstance()` fallback. Together these restore login/logout/security event delivery to listeners
+  (framework activity logging + app/extension subscribers such as glueful/audit).
+- **Failed logins emit `AuthenticationFailedEvent`.** The event existed and had subscribers but was never
+  dispatched; `AuthenticationService::verifyCredentials()` now fires it (best-effort, context-guarded) on
+  rejected credentials (`invalid_credentials`) or a disabled account (`user_disabled`), with the attempted
+  username and request IP/user-agent — making failed login attempts observable to audit/activity logging.
+- Notes: **Patch release** — bugfixes, no new env, no migrations, no action required. api-skeleton bumped to `^1.63.1`.
+
 ### 1.63.0 — Yildun (Minor, Released 2026-06-25)
 - **Entity-deletion event.** `BaseRepository::delete()` now dispatches `Glueful\Events\Database\EntityDeletedEvent`
   after a successful delete (`affected_rows > 0`), carrying the **pre-delete** record + metadata matching the

--- a/src/Auth/AuthenticationService.php
+++ b/src/Auth/AuthenticationService.php
@@ -6,7 +6,10 @@ namespace Glueful\Auth;
 
 use Glueful\Bootstrap\ApplicationContext;
 use Glueful\Cache\Drivers\ArrayCacheDriver;
+use Glueful\Events\Auth\AuthenticationFailedEvent;
+use Glueful\Events\EventService;
 use Glueful\Helpers\CacheHelper;
+use Glueful\Http\RequestContext;
 use Glueful\Auth\Contracts\UserProviderInterface;
 use Glueful\DTOs\{PasswordDTO};
 use Symfony\Component\HttpFoundation\Request;
@@ -227,6 +230,7 @@ class AuthenticationService
             (string) ($credentials['password'] ?? '')
         );
         if ($identity === null) {
+            $this->dispatchAuthFailed((string) $identifier, 'invalid_credentials');
             return null;
         }
 
@@ -234,6 +238,7 @@ class AuthenticationService
         // Null => rejected (e.g. suspended/disabled).
         $identity = $this->identityResolver->resolve($identity);
         if ($identity === null) {
+            $this->dispatchAuthFailed((string) $identifier, 'user_disabled');
             return null;
         }
 
@@ -251,6 +256,38 @@ class AuthenticationService
             'last_login' => date('Y-m-d H:i:s'),
             'remember_me' => $credentials['remember_me'] ?? false,
         ];
+    }
+
+    /**
+     * Emit an {@see AuthenticationFailedEvent} for a rejected username/password login so listeners
+     * (security monitoring, activity logging, an audit extension) can record the attempt. Best-effort
+     * and non-throwing — a failed dispatch must never change the login's outcome. Client IP / user agent
+     * are resolved from the request context when available.
+     */
+    private function dispatchAuthFailed(string $username, string $reason): void
+    {
+        if ($this->context === null) {
+            return;
+        }
+
+        try {
+            $clientIp = null;
+            $userAgent = null;
+            $container = $this->context->getContainer();
+            if ($container->has(RequestContext::class)) {
+                $requestContext = $container->get(RequestContext::class);
+                if ($requestContext instanceof RequestContext) {
+                    $clientIp = $requestContext->getClientIp();
+                    $userAgent = $requestContext->getUserAgent();
+                }
+            }
+
+            app($this->context, EventService::class)->dispatch(
+                new AuthenticationFailedEvent($username, $reason, $clientIp, $userAgent)
+            );
+        } catch (\Throwable) {
+            // Best-effort only — never break the login flow.
+        }
     }
 
     /**

--- a/src/Events/EventDispatcher.php
+++ b/src/Events/EventDispatcher.php
@@ -36,15 +36,23 @@ final class EventDispatcher implements EventDispatcherInterface
                     break;
                 }
 
+                // Fault isolation: a listener that throws (a resolution failure or a runtime
+                // error) must NOT abort the dispatch and starve the listeners after it. Catch,
+                // report, and continue — one broken/misconfigured listener can't take the rest
+                // of the chain (e.g. an audit/cache listener) down with it.
                 if ($this->tracer instanceof NullEventTracer) {
-                    $listener($event);
+                    try {
+                        $listener($event);
+                    } catch (\Throwable $e) {
+                        $this->reportListenerError($event, $e);
+                    }
                 } else {
                     $start = hrtime(true);
                     try {
                         $listener($event);
                     } catch (\Throwable $e) {
                         $this->tracer->listenerError($event::class, $listener, $e);
-                        throw $e;
+                        $this->reportListenerError($event, $e);
                     } finally {
                         $this->tracer->listenerDone($event::class, $listener, hrtime(true) - $start);
                     }
@@ -57,5 +65,16 @@ final class EventDispatcher implements EventDispatcherInterface
         }
 
         return $event;
+    }
+
+    private function reportListenerError(object $event, \Throwable $e): void
+    {
+        error_log(sprintf(
+            'Event listener failed for %s: %s in %s:%d',
+            $event::class,
+            $e->getMessage(),
+            $e->getFile(),
+            $e->getLine()
+        ));
     }
 }

--- a/src/Events/Listeners/ActivityLoggingSubscriber.php
+++ b/src/Events/Listeners/ActivityLoggingSubscriber.php
@@ -30,9 +30,17 @@ use Glueful\Support\SensitiveParamRedactor;
  */
 class ActivityLoggingSubscriber implements EventSubscriberInterface
 {
-    public function __construct(
-        private LogManager $logger
-    ) {
+    private LogManager $logger;
+
+    /**
+     * `LogManager` is not a container-registered service, so the autowiring resolver can't
+     * construct it for a non-nullable param — which made this whole subscriber unresolvable and
+     * silently broke auth/security event delivery. Accept it as optional and fall back to the
+     * process-wide singleton.
+     */
+    public function __construct(?LogManager $logger = null)
+    {
+        $this->logger = $logger ?? LogManager::getInstance();
     }
 
     /**

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,7 +13,7 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.63.0';
+    public const VERSION = '1.63.1';
 
 
     /** Release code name */

--- a/tests/Integration/Auth/AuthenticationServiceSeamTest.php
+++ b/tests/Integration/Auth/AuthenticationServiceSeamTest.php
@@ -9,6 +9,8 @@ use Glueful\Auth\AuthenticationService;
 use Glueful\Auth\IdentityResolver;
 use Glueful\Auth\UserIdentity;
 use Glueful\Bootstrap\ApplicationContext;
+use Glueful\Events\Auth\AuthenticationFailedEvent;
+use Glueful\Events\EventService;
 use Glueful\Framework;
 use Glueful\Routing\RouteManifest;
 use Glueful\Tests\Support\Auth\InMemoryUserProvider;
@@ -68,6 +70,43 @@ final class AuthenticationServiceSeamTest extends TestCase
         self::assertSame('amy@x.test', $userData['email'] ?? null);
 
         self::assertNull($svc->verifyCredentials(['email' => 'amy@x.test', 'password' => 'wrong']));
+    }
+
+    public function test_failed_login_dispatches_authentication_failed_event(): void
+    {
+        $provider = (new InMemoryUserProvider())->add(
+            new UserIdentity('u-amy00000001', email: 'amy@x.test', username: 'amy', status: 'active'),
+            'secret-123',
+            'amy@x.test',
+        );
+
+        /** @var list<AuthenticationFailedEvent> $captured */
+        $captured = [];
+        $events = $this->app->getContainer()->get(EventService::class);
+        $events->addListener(
+            AuthenticationFailedEvent::class,
+            function (AuthenticationFailedEvent $e) use (&$captured): void {
+                $captured[] = $e;
+            }
+        );
+
+        $svc = new AuthenticationService(
+            context: $this->context,
+            userProvider: $provider,
+            identityResolver: new IdentityResolver([]),
+        );
+
+        // A valid-format but wrong password reaches the credential check (a short one would be
+        // rejected earlier by the password-format guard) -> rejected AND one
+        // AuthenticationFailedEvent (invalid_credentials).
+        self::assertNull($svc->verifyCredentials(['email' => 'amy@x.test', 'password' => 'wrongpass-1']));
+        self::assertCount(1, $captured);
+        self::assertSame('amy@x.test', $captured[0]->getUsername());
+        self::assertSame('invalid_credentials', $captured[0]->getReason());
+
+        // A successful login emits nothing further.
+        self::assertNotNull($svc->verifyCredentials(['email' => 'amy@x.test', 'password' => 'secret-123']));
+        self::assertCount(1, $captured);
     }
 
     private function bootFramework(): void

--- a/tests/Unit/Events/EventDispatcherTest.php
+++ b/tests/Unit/Events/EventDispatcherTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Events;
+
+use Glueful\Events\EventDispatcher;
+use Glueful\Events\Listeners\ActivityLoggingSubscriber;
+use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\ListenerProviderInterface;
+
+final class EventDispatcherTest extends TestCase
+{
+    /**
+     * A listener that throws (e.g. an unresolvable container dependency) must not abort the
+     * dispatch and starve the listeners after it — the exact failure that silently broke
+     * auth-event delivery to downstream subscribers (audit, cache invalidation).
+     */
+    public function testAThrowingListenerDoesNotStarveSubsequentListeners(): void
+    {
+        $ran = [];
+        $listeners = [
+            static function (object $e): void {
+                throw new \RuntimeException('listener boom');
+            },
+            function (object $e) use (&$ran): void {
+                $ran[] = 'second';
+            },
+        ];
+
+        $provider = new class ($listeners) implements ListenerProviderInterface {
+            /** @param list<callable> $listeners */
+            public function __construct(private array $listeners)
+            {
+            }
+
+            public function getListenersForEvent(object $event): iterable
+            {
+                return $this->listeners;
+            }
+        };
+
+        $dispatcher = new EventDispatcher($provider);
+        $event = new \stdClass();
+
+        // Must not throw despite the first listener throwing.
+        $result = $dispatcher->dispatch($event);
+
+        self::assertSame($event, $result);
+        self::assertSame(['second'], $ran, 'The listener after the throwing one must still run.');
+    }
+
+    public function testActivityLoggingSubscriberIsConstructibleWithoutAnExplicitLogger(): void
+    {
+        // Was unresolvable: LogManager isn't container-registered, so a non-nullable param made
+        // the whole subscriber fail to build. It now falls back to the singleton.
+        $subscriber = new ActivityLoggingSubscriber();
+        self::assertInstanceOf(ActivityLoggingSubscriber::class, $subscriber);
+    }
+}


### PR DESCRIPTION
### Fixed
- **A throwing event listener no longer aborts the dispatch and starves the listeners after it.**
  `EventDispatcher::dispatch()` now catches each listener's `Throwable`, logs it, and continues to the
  next listener (on both the hot and traced paths) — a single broken or misconfigured listener can no
  longer take the rest of the chain down with it. Previously the first listener to throw ended dispatch
  for that event entirely.
- **`ActivityLoggingSubscriber` is now resolvable.** It required a non-nullable `LogManager`, which is
  not a container-registered service, so the autowiring resolver could not construct it — making the
  subscriber throw on every auth/security event. Its constructor now takes `?LogManager $logger = null`
  and falls back to `LogManager::getInstance()`. Combined with the dispatcher fix, auth/security events
  are delivered to all listeners again (the framework's own activity logging, plus any app/extension
  subscriber such as glueful/audit).
- **Failed logins now emit `AuthenticationFailedEvent`.** The event was declared and listeners subscribe
  to it, but nothing ever dispatched it — so failed login attempts were invisible to activity logging and
  audit consumers. `AuthenticationService::verifyCredentials()` now dispatches it (best-effort,
  context-guarded, never breaks the login flow) when credentials are rejected (`invalid_credentials`) or
  the resolved account is disabled (`user_disabled`), carrying the attempted username plus the request's
  client IP and user-agent when available.