### PR TITLE
Cache resized blob variants as base64-encoded data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.63.2] - 2026-06-26 — Yildun
+
+> **Theme: image-variant caching fix.** A single bugfix — serving a resized blob variant
+> (`GET /blobs/{uuid}?width=…`) with the variant cache enabled 500'd, because the rendered binary was
+> cached through a JSON-based serializer. **Patch release** — bugfix only, no new env, no migrations,
+> no action required.
+
+### Fixed
+- **On-the-fly image variants no longer 500 when the variant cache is enabled.** `UploadController`'s
+  resized-blob serving (`GET /blobs/{uuid}?width=…`) cached the rendered variant as **raw image bytes**,
+  which a JSON-based cache serializer (e.g. the Redis driver's `SecureSerializer`) cannot encode — raw
+  bytes aren't valid UTF-8 — so every cached resize threw `JsonException: Malformed UTF-8` and returned
+  500 (the un-resized original was unaffected). The variant bytes are now stored **base64-encoded** and
+  decoded on read, so caching works across all serializers. A legacy/corrupt cache entry that fails to
+  decode falls through to a re-render.
+
 ## [1.63.1] - 2026-06-25 — Yildun
 
 > **Theme: resilient event dispatch + dead auth events.** Related fixes that together restore delivery

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,14 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.63.2 — Yildun (Patch, Released 2026-06-26)
+- **Image-variant caching fix.** Serving a resized blob (`GET /blobs/{uuid}?width=…`) with the variant
+  cache enabled 500'd — the rendered binary was cached through a JSON serializer (e.g. the Redis driver's
+  `SecureSerializer`), which can't encode non-UTF-8 bytes. Variants are now cached base64-encoded and
+  decoded on read; a corrupt/legacy entry re-renders. The un-resized original was never affected.
+- Notes: **Patch release** — bugfix only, no new env, no migrations, no action required. api-skeleton
+  bumped to `^1.63.2`.
+
 ### 1.63.1 — Yildun (Patch, Released 2026-06-25)
 - **Resilient event dispatch.** `EventDispatcher::dispatch()` now isolates listener failures — it catches
   each listener's `Throwable`, logs it, and continues — so one broken/misconfigured listener can't abort

--- a/src/Controllers/UploadController.php
+++ b/src/Controllers/UploadController.php
@@ -409,16 +409,20 @@ class UploadController extends BaseController
             }
         }
 
-        // Check server-side cache
+        // Check server-side cache. The variant bytes are stored base64-encoded (see the set below),
+        // so decode before serving; a decode failure (legacy/corrupt entry) falls through to re-render.
         if ($cacheEnabled && $this->cache !== null) {
             $cached = $this->cache->get($cacheKey);
             if (is_array($cached) && isset($cached['data'], $cached['mime']) && is_string($cached['data'])) {
-                return $this->binaryResponse(
-                    $cached['data'],
-                    (string) $cached['mime'],
-                    $cacheTtl,
-                    $etagEnabled ? $etag : null
-                );
+                $decoded = base64_decode($cached['data'], true);
+                if ($decoded !== false) {
+                    return $this->binaryResponse(
+                        $decoded,
+                        (string) $cached['mime'],
+                        $cacheTtl,
+                        $etagEnabled ? $etag : null
+                    );
+                }
             }
         }
 
@@ -446,7 +450,9 @@ class UploadController extends BaseController
             }
 
             if ($cacheEnabled && $this->cache !== null) {
-                $this->cache->set($cacheKey, ['data' => $data, 'mime' => $mime], $cacheTtl);
+                // Store base64-encoded: raw image bytes aren't valid UTF-8 and break JSON-based cache
+                // serializers (e.g. the Redis driver's SecureSerializer -> json_encode).
+                $this->cache->set($cacheKey, ['data' => base64_encode($data), 'mime' => $mime], $cacheTtl);
             }
 
             return $this->binaryResponse($data, $mime, $cacheTtl, $etagEnabled ? $etag : null);

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,7 +13,7 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.63.1';
+    public const VERSION = '1.63.2';
 
 
     /** Release code name */
@@ -21,7 +21,7 @@ final class Version
 
 
     /** Release date */
-    public const RELEASE_DATE = '2026-06-25';
+    public const RELEASE_DATE = '2026-06-26';
 
     /** Minimum required PHP version */
     public const MIN_PHP_VERSION = '8.3.0';


### PR DESCRIPTION
### Fixed
- **On-the-fly image variants no longer 500 when the variant cache is enabled.** `UploadController`'s
  resized-blob serving (`GET /blobs/{uuid}?width=…`) cached the rendered variant as **raw image bytes**,
  which a JSON-based cache serializer (e.g. the Redis driver's `SecureSerializer`) cannot encode — raw
  bytes aren't valid UTF-8 — so every cached resize threw `JsonException: Malformed UTF-8` and returned
  500 (the un-resized original was unaffected). The variant bytes are now stored **base64-encoded** and
  decoded on read, so caching works across all serializers. A legacy/corrupt cache entry that fails to
  decode falls through to a re-render.