### PR TITLE
Construct BlobRepository with ApplicationContext for event dispatching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.63.3] - 2026-06-26 — Yildun
+
+> **Theme: blob writes are now auditable.** `BlobRepository` was constructed without an
+> `ApplicationContext`, so its create/update/delete never dispatched entity events — meaning blob
+> uploads emitted no `EntityCreatedEvent` and couldn't be audited. **Patch release** — bugfix, no new
+> env, no migrations, no action required.
+
+### Fixed
+- **`BlobRepository` is now constructed with the `ApplicationContext`**, so its create/update/delete
+  dispatch their `Entity{Created,Updated,Deleted}` events (`BaseRepository::dispatchEvent()` no-ops
+  without a context). Blob uploads now emit an `EntityCreatedEvent` and can be recorded by an audit/
+  activity consumer — previously they were silently un-audited.
+
 ## [1.63.2] - 2026-06-26 — Yildun
 
 > **Theme: image-variant caching fix.** A single bugfix — serving a resized blob variant

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,14 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.63.3 — Yildun (Patch, Released 2026-06-26)
+- **Blob writes are auditable.** `BlobRepository` was built without an `ApplicationContext`, so its
+  create/update/delete never dispatched entity events — blob uploads emitted no `EntityCreatedEvent` and
+  couldn't be audited. It's now constructed with the context, so uploads emit events an audit/activity
+  consumer can record.
+- Notes: **Patch release** — bugfix, no new env, no migrations, no action required. api-skeleton bumped
+  to `^1.63.3`.
+
 ### 1.63.2 — Yildun (Patch, Released 2026-06-26)
 - **Image-variant caching fix.** Serving a resized blob (`GET /blobs/{uuid}?width=…`) with the variant
   cache enabled 500'd — the rendered binary was cached through a JSON serializer (e.g. the Redis driver's

--- a/src/Container/Providers/RepositoryProvider.php
+++ b/src/Container/Providers/RepositoryProvider.php
@@ -37,8 +37,14 @@ final class RepositoryProvider extends BaseServiceProvider
         );
         $defs[\Glueful\Repository\BlobRepository::class] = new FactoryDefinition(
             \Glueful\Repository\BlobRepository::class,
+            // Pass the ApplicationContext so create/update/delete dispatch their entity events
+            // (BaseRepository::dispatchEvent() no-ops without a context) — e.g. so blob uploads
+            // are auditable. Without it, uploads silently emit no EntityCreatedEvent.
             fn(\Psr\Container\ContainerInterface $c) => new \Glueful\Repository\BlobRepository(
-                $c->get('database')
+                $c->get('database'),
+                $c->has(\Glueful\Bootstrap\ApplicationContext::class)
+                    ? $c->get(\Glueful\Bootstrap\ApplicationContext::class)
+                    : null
             )
         );
 

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,7 +13,7 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.63.2';
+    public const VERSION = '1.63.3';
 
 
     /** Release code name */


### PR DESCRIPTION
### Fixed
- **`BlobRepository` is now constructed with the `ApplicationContext`**, so its create/update/delete
  dispatch their `Entity{Created,Updated,Deleted}` events (`BaseRepository::dispatchEvent()` no-ops
  without a context). Blob uploads now emit an `EntityCreatedEvent` and can be recorded by an audit/
  activity consumer — previously they were silently un-audited.