### PR TITLE
Release v1.63.4 — annotate WebhookController for OpenAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.63.4] - 2026-06-27 — Yildun
+
+> **Theme: the webhook management API is now self-documenting.** The framework ships a complete
+> `WebhookController` (subscription + delivery management), but its methods carried no OpenAPI
+> attributes — so an application that mounts these routes got working endpoints that were invisible to
+> `generate:openapi` / the typed client. Added `#[ApiOperation]`/`#[ApiResponse]` to all 11 endpoints.
+> **Patch release** — documentation metadata only, no behavioral change, no new env, no migrations, no
+> action required.
+
+### Added
+- **OpenAPI annotations on `WebhookController`.** All 11 webhook-management methods (subscription
+  list/create/get/update/delete, rotate-secret, test, stats; delivery list/get/retry) now carry
+  `#[ApiOperation]` + `#[ApiResponse]` attributes. Applications that mount the controller (the core
+  doesn't auto-register these routes) now get them in the generated `openapi.json` and typed schema,
+  the same as any annotated controller. No routes, behavior, or signatures changed — only the
+  attributes the docs generator reads.
+
 ## [1.63.3] - 2026-06-26 — Yildun
 
 > **Theme: blob writes are now auditable.** `BlobRepository` was constructed without an

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,15 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.63.4 — Yildun (Patch, Released 2026-06-27)
+- **Webhook management API is self-documenting.** The framework's `WebhookController` (subscriptions +
+  deliveries) had working routes but no OpenAPI attributes, so applications that mount it got endpoints
+  invisible to `generate:openapi` and the typed client. Added `#[ApiOperation]`/`#[ApiResponse]` to all
+  11 methods — they're now documented like any annotated controller. No behavior change; the core still
+  doesn't auto-register these routes.
+- Notes: **Patch release** — documentation metadata only, no behavioral change, no new env, no
+  migrations, no action required. api-skeleton bumped to `^1.63.4`.
+
 ### 1.63.3 — Yildun (Patch, Released 2026-06-26)
 - **Blob writes are auditable.** `BlobRepository` was built without an `ApplicationContext`, so its
   create/update/delete never dispatched entity events — blob uploads emitted no `EntityCreatedEvent` and

--- a/src/Api/Webhooks/Http/Controllers/WebhookController.php
+++ b/src/Api/Webhooks/Http/Controllers/WebhookController.php
@@ -10,6 +10,8 @@ use Glueful\Api\Webhooks\WebhookDelivery;
 use Glueful\Api\Webhooks\WebhookSubscription;
 use Glueful\Controllers\BaseController;
 use Glueful\Http\Response;
+use Glueful\Routing\Attributes\ApiOperation;
+use Glueful\Routing\Attributes\ApiResponse;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -49,6 +51,13 @@ class WebhookController extends BaseController
      * @param Request $request
      * @return \Symfony\Component\HttpFoundation\Response
      */
+    #[ApiOperation(
+        summary: 'List webhook subscriptions',
+        description: 'Paginated list of webhook subscriptions. Optional `active=true` to return only '
+            . 'active ones, plus `page` and `per_page` (max 100).',
+        tags: ['Webhooks'],
+    )]
+    #[ApiResponse(200, description: 'Subscriptions page.')]
     public function listSubscriptions(Request $request): \Symfony\Component\HttpFoundation\Response
     {
         $page = max(1, (int) $request->query->get('page', 1));
@@ -96,6 +105,15 @@ class WebhookController extends BaseController
      * @param Request $request
      * @return \Symfony\Component\HttpFoundation\Response
      */
+    #[ApiOperation(
+        summary: 'Create a webhook subscription',
+        description: 'Subscribe an endpoint to events. Body: `url` (required, must be a valid URL — '
+            . 'HTTPS when require_https is on), `events` (required, non-empty array; supports `*` and '
+            . '`prefix.*` wildcards), optional `metadata`. The signing `secret` is returned once.',
+        tags: ['Webhooks'],
+    )]
+    #[ApiResponse(201, description: 'Created subscription + signing secret.')]
+    #[ApiResponse(400, description: 'Invalid URL or events.')]
     public function createSubscription(Request $request): \Symfony\Component\HttpFoundation\Response
     {
         $data = $this->getJsonBody($request);
@@ -134,6 +152,9 @@ class WebhookController extends BaseController
      * @param string $id Subscription UUID
      * @return \Symfony\Component\HttpFoundation\Response
      */
+    #[ApiOperation(summary: 'Get a webhook subscription', tags: ['Webhooks'])]
+    #[ApiResponse(200, description: 'Subscription.')]
+    #[ApiResponse(404, description: 'No such subscription.')]
     public function getSubscription(string $id): \Symfony\Component\HttpFoundation\Response
     {
         $subscription = Webhook::findSubscription($id);
@@ -157,6 +178,15 @@ class WebhookController extends BaseController
      * @param string $id Subscription UUID
      * @return \Symfony\Component\HttpFoundation\Response
      */
+    #[ApiOperation(
+        summary: 'Update a webhook subscription',
+        description: 'Partial update. Body may include `url`, `events` (non-empty array), `is_active`, '
+            . '`metadata`; only supplied fields change.',
+        tags: ['Webhooks'],
+    )]
+    #[ApiResponse(200, description: 'Updated subscription.')]
+    #[ApiResponse(400, description: 'Invalid URL or events.')]
+    #[ApiResponse(404, description: 'No such subscription.')]
     public function updateSubscription(Request $request, string $id): \Symfony\Component\HttpFoundation\Response
     {
         $subscription = Webhook::findSubscription($id);
@@ -211,6 +241,9 @@ class WebhookController extends BaseController
      * @param string $id Subscription UUID
      * @return \Symfony\Component\HttpFoundation\Response
      */
+    #[ApiOperation(summary: 'Delete a webhook subscription', tags: ['Webhooks'])]
+    #[ApiResponse(200, description: 'Deleted.')]
+    #[ApiResponse(404, description: 'No such subscription.')]
     public function deleteSubscription(string $id): \Symfony\Component\HttpFoundation\Response
     {
         $subscription = Webhook::findSubscription($id);
@@ -232,6 +265,14 @@ class WebhookController extends BaseController
      * @param string $id Subscription UUID
      * @return \Symfony\Component\HttpFoundation\Response
      */
+    #[ApiOperation(
+        summary: 'Rotate a subscription secret',
+        description: 'Generates a new signing secret and returns it once. Existing signatures using '
+            . 'the old secret stop verifying.',
+        tags: ['Webhooks'],
+    )]
+    #[ApiResponse(200, description: 'New signing secret.')]
+    #[ApiResponse(404, description: 'No such subscription.')]
     public function rotateSecret(string $id): \Symfony\Component\HttpFoundation\Response
     {
         $subscription = Webhook::findSubscription($id);
@@ -256,6 +297,15 @@ class WebhookController extends BaseController
      * @param string $id Subscription UUID
      * @return \Symfony\Component\HttpFoundation\Response
      */
+    #[ApiOperation(
+        summary: 'Send a test webhook',
+        description: 'Delivers a signed `webhook.test` event to the subscription URL synchronously and '
+            . 'returns the endpoint response.',
+        tags: ['Webhooks'],
+    )]
+    #[ApiResponse(200, description: 'Endpoint accepted the test.')]
+    #[ApiResponse(404, description: 'No such subscription.')]
+    #[ApiResponse(502, description: 'Endpoint rejected or failed the test.')]
     public function testSubscription(string $id): \Symfony\Component\HttpFoundation\Response
     {
         $subscription = Webhook::findSubscription($id);
@@ -292,6 +342,13 @@ class WebhookController extends BaseController
      * @param string $id Subscription UUID
      * @return \Symfony\Component\HttpFoundation\Response
      */
+    #[ApiOperation(
+        summary: 'Get subscription delivery stats',
+        description: 'Delivery counts and success rate over a window. Optional `days` query (default 30).',
+        tags: ['Webhooks'],
+    )]
+    #[ApiResponse(200, description: 'Delivery statistics.')]
+    #[ApiResponse(404, description: 'No such subscription.')]
     public function getSubscriptionStats(Request $request, string $id): \Symfony\Component\HttpFoundation\Response
     {
         $subscription = Webhook::findSubscription($id);
@@ -323,6 +380,13 @@ class WebhookController extends BaseController
      * @param Request $request
      * @return \Symfony\Component\HttpFoundation\Response
      */
+    #[ApiOperation(
+        summary: 'List webhook deliveries',
+        description: 'Paginated delivery log. Optional `status` (pending|delivered|failed|retrying), '
+            . '`subscription` (UUID) filters, plus `page` and `per_page` (max 100).',
+        tags: ['Webhooks'],
+    )]
+    #[ApiResponse(200, description: 'Deliveries page.')]
     public function listDeliveries(Request $request): \Symfony\Component\HttpFoundation\Response
     {
         $page = max(1, (int) $request->query->get('page', 1));
@@ -380,6 +444,13 @@ class WebhookController extends BaseController
      * @param string $id Delivery UUID
      * @return \Symfony\Component\HttpFoundation\Response
      */
+    #[ApiOperation(
+        summary: 'Get a webhook delivery',
+        description: 'A single delivery including its request payload and the endpoint response body.',
+        tags: ['Webhooks'],
+    )]
+    #[ApiResponse(200, description: 'Delivery with payload + response.')]
+    #[ApiResponse(404, description: 'No such delivery.')]
     public function getDelivery(string $id): \Symfony\Component\HttpFoundation\Response
     {
         $delivery = Webhook::findDelivery($id);
@@ -402,6 +473,14 @@ class WebhookController extends BaseController
      * @param string $id Delivery UUID
      * @return \Symfony\Component\HttpFoundation\Response
      */
+    #[ApiOperation(
+        summary: 'Retry a webhook delivery',
+        description: 'Re-queues a failed or retrying delivery for another attempt.',
+        tags: ['Webhooks'],
+    )]
+    #[ApiResponse(200, description: 'Delivery re-queued.')]
+    #[ApiResponse(400, description: 'Delivery is not in a retryable state.')]
+    #[ApiResponse(404, description: 'No such delivery.')]
     public function retryDelivery(string $id): \Symfony\Component\HttpFoundation\Response
     {
         $delivery = Webhook::findDelivery($id);

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,7 +13,7 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.63.3';
+    public const VERSION = '1.63.4';
 
 
     /** Release code name */
@@ -21,7 +21,7 @@ final class Version
 
 
     /** Release date */
-    public const RELEASE_DATE = '2026-06-26';
+    public const RELEASE_DATE = '2026-06-27';
 
     /** Minimum required PHP version */
     public const MIN_PHP_VERSION = '8.3.0';


### PR DESCRIPTION
Add #[ApiOperation]/#[ApiResponse] to all 11 WebhookController methods so applications that mount the controller get the webhook-management API in their generated openapi.json and typed client. Documentation metadata only — no routes, behavior, or signatures changed.

Patch release (Yildun). No new env, no migrations, no action required.
