### PR TITLE
Release v1.63.5 — fully type WebhookController in OpenAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.63.5] - 2026-06-27 — Yildun
+
+> **Theme: the webhook management API is now fully typed in OpenAPI.** 1.63.4 added operation
+> summaries to `WebhookController`; this fills in the schemas — query parameters, request bodies, and
+> response shapes — so an application that mounts the controller gets a precise spec (and a typed
+> client) for subscriptions and deliveries, not just path stubs. **Patch release** — documentation
+> metadata only (new doc-only DTOs + attributes), no behavioral change, no new env, no migrations, no
+> action required.
+
+### Added
+- **Full OpenAPI schemas on `WebhookController`.** Added `#[QueryParam]` for the list/stats query
+  parameters (active / status / subscription / page / per_page / days), `#[ApiRequestBody]` for
+  create/update, and `#[ApiResponse(schema: …)]` for the subscription, delivery, list, and stats
+  responses — backed by new documentation-only DTOs under `Glueful\Api\Webhooks\DTOs`. The
+  controller's runtime behavior is unchanged; the DTOs are reflected for docs only (never hydrated),
+  the same approach the auth controller uses for `login`.
+
 ## [1.63.4] - 2026-06-27 — Yildun
 
 > **Theme: the webhook management API is now self-documenting.** The framework ships a complete

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,15 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.63.5 — Yildun (Patch, Released 2026-06-27)
+- **Webhook management API fully typed in OpenAPI.** Built on 1.63.4 (operation summaries) by adding
+  the schemas: `#[QueryParam]` for the list/stats query params, `#[ApiRequestBody]` for create/update,
+  and `#[ApiResponse(schema: …)]` for the subscription/delivery/list/stats responses, backed by new
+  doc-only DTOs under `Glueful\Api\Webhooks\DTOs`. Applications that mount the controller now get a
+  precise spec + typed client. No behavior change (DTOs reflected for docs only, never hydrated).
+- Notes: **Patch release** — documentation metadata only, no behavioral change, no new env, no
+  migrations, no action required. api-skeleton bumped to `^1.63.5`.
+
 ### 1.63.4 — Yildun (Patch, Released 2026-06-27)
 - **Webhook management API is self-documenting.** The framework's `WebhookController` (subscriptions +
   deliveries) had working routes but no OpenAPI attributes, so applications that mount it got endpoints

--- a/src/Api/Webhooks/DTOs/Responses/PaginationData.php
+++ b/src/Api/Webhooks/DTOs/Responses/PaginationData.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Api\Webhooks\DTOs\Responses;
+
+/**
+ * Documentation-only pagination block shared by the webhook list responses. Doc-only — reflected for
+ * #[ApiResponse], never constructed at runtime.
+ */
+final class PaginationData
+{
+    /** Current page number. */
+    public int $current_page = 1;
+
+    /** Items per page. */
+    public int $per_page = 25;
+
+    /** Total matching rows. */
+    public int $total = 0;
+
+    /** Total number of pages. */
+    public int $total_pages = 1;
+}

--- a/src/Api/Webhooks/DTOs/Responses/WebhookDeliveryData.php
+++ b/src/Api/Webhooks/DTOs/Responses/WebhookDeliveryData.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Api\Webhooks\DTOs\Responses;
+
+/**
+ * Documentation-only shape of one webhook delivery row (list view) as returned by
+ * {@see \Glueful\Api\Webhooks\Http\Controllers\WebhookController}. Doc-only — reflected for
+ * #[ApiResponse].
+ */
+final class WebhookDeliveryData
+{
+    /** Delivery UUID (e.g. wh_del_…). */
+    public string $uuid = '';
+
+    /** Event name that triggered the delivery. */
+    public string $event = '';
+
+    /** Delivery status: pending | delivered | failed | retrying. */
+    public string $status = 'pending';
+
+    /** Number of attempts made. */
+    public int $attempts = 0;
+
+    /** HTTP status returned by the endpoint (null until attempted). */
+    public ?int $response_code = null;
+
+    /** When the delivery succeeded. */
+    public ?string $delivered_at = null;
+
+    /** When the next retry is scheduled. */
+    public ?string $next_retry_at = null;
+
+    /** Creation timestamp. */
+    public ?string $created_at = null;
+}

--- a/src/Api/Webhooks/DTOs/Responses/WebhookDeliveryDetailData.php
+++ b/src/Api/Webhooks/DTOs/Responses/WebhookDeliveryDetailData.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Api\Webhooks\DTOs\Responses;
+
+/**
+ * Documentation-only shape of a single webhook delivery (detail view) from
+ * {@see \Glueful\Api\Webhooks\Http\Controllers\WebhookController::getDelivery()}, including the
+ * request `payload` and the endpoint `response_body`. Doc-only — reflected for #[ApiResponse].
+ */
+final class WebhookDeliveryDetailData
+{
+    /** Delivery UUID (e.g. wh_del_…). */
+    public string $uuid = '';
+
+    /** Event name that triggered the delivery. */
+    public string $event = '';
+
+    /** Delivery status: pending | delivered | failed | retrying. */
+    public string $status = 'pending';
+
+    /** Number of attempts made. */
+    public int $attempts = 0;
+
+    /** HTTP status returned by the endpoint (null until attempted). */
+    public ?int $response_code = null;
+
+    /** When the delivery succeeded. */
+    public ?string $delivered_at = null;
+
+    /** When the next retry is scheduled. */
+    public ?string $next_retry_at = null;
+
+    /** Creation timestamp. */
+    public ?string $created_at = null;
+
+    /**
+     * The signed JSON payload that was (or will be) POSTed to the endpoint.
+     *
+     * @var array<string,mixed>|null
+     */
+    public ?array $payload = null;
+
+    /** The raw response body returned by the endpoint. */
+    public ?string $response_body = null;
+}

--- a/src/Api/Webhooks/DTOs/Responses/WebhookDeliveryListData.php
+++ b/src/Api/Webhooks/DTOs/Responses/WebhookDeliveryListData.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Api\Webhooks\DTOs\Responses;
+
+/**
+ * Documentation-only list envelope for
+ * {@see \Glueful\Api\Webhooks\Http\Controllers\WebhookController::listDeliveries()}. Doc-only.
+ */
+final class WebhookDeliveryListData
+{
+    /** @var list<WebhookDeliveryData> */
+    public array $deliveries = [];
+
+    public ?PaginationData $pagination = null;
+}

--- a/src/Api/Webhooks/DTOs/Responses/WebhookStatsData.php
+++ b/src/Api/Webhooks/DTOs/Responses/WebhookStatsData.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Api\Webhooks\DTOs\Responses;
+
+/**
+ * Documentation-only delivery-statistics response for
+ * {@see \Glueful\Api\Webhooks\Http\Controllers\WebhookController::getSubscriptionStats()}. Doc-only.
+ */
+final class WebhookStatsData
+{
+    /** Subscription UUID. */
+    public string $uuid = '';
+
+    /** Window the stats cover, in days. */
+    public int $period_days = 30;
+
+    /** Total deliveries in the window. */
+    public int $total_deliveries = 0;
+
+    /** Delivered count. */
+    public int $delivered = 0;
+
+    /** Failed count. */
+    public int $failed = 0;
+
+    /** Pending count. */
+    public int $pending = 0;
+
+    /** Success rate as a percentage (0–100). */
+    public float $success_rate = 0.0;
+}

--- a/src/Api/Webhooks/DTOs/Responses/WebhookSubscriptionCreatedData.php
+++ b/src/Api/Webhooks/DTOs/Responses/WebhookSubscriptionCreatedData.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Api\Webhooks\DTOs\Responses;
+
+/**
+ * Documentation-only create response for
+ * {@see \Glueful\Api\Webhooks\Http\Controllers\WebhookController::createSubscription()}: the new
+ * subscription PLUS the signing `secret`, which is returned only here (and on rotate). Doc-only —
+ * reflected for #[ApiResponse], never constructed at runtime.
+ */
+final class WebhookSubscriptionCreatedData
+{
+    /** Subscription UUID (e.g. wh_sub_…). */
+    public string $uuid = '';
+
+    /** Endpoint URL. */
+    public string $url = '';
+
+    /**
+     * Subscribed event patterns.
+     *
+     * @var list<string>
+     */
+    public array $events = [];
+
+    /** Whether the subscription is active. */
+    public bool $is_active = true;
+
+    /**
+     * Arbitrary metadata stored with the subscription.
+     *
+     * @var array<string,mixed>|null
+     */
+    public ?array $metadata = null;
+
+    /** Creation timestamp. */
+    public ?string $created_at = null;
+
+    /** Last-update timestamp. */
+    public ?string $updated_at = null;
+
+    /** The signing secret (e.g. whsec_…) — shown once, used to verify the X-Webhook-Signature. */
+    public string $secret = '';
+}

--- a/src/Api/Webhooks/DTOs/Responses/WebhookSubscriptionData.php
+++ b/src/Api/Webhooks/DTOs/Responses/WebhookSubscriptionData.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Api\Webhooks\DTOs\Responses;
+
+/**
+ * Documentation-only shape of one webhook subscription as returned by
+ * {@see \Glueful\Api\Webhooks\Http\Controllers\WebhookController}. The signing `secret` is NOT
+ * included on reads (only on create/rotate). Doc-only — reflected for #[ApiResponse].
+ */
+final class WebhookSubscriptionData
+{
+    /** Subscription UUID (e.g. wh_sub_…). */
+    public string $uuid = '';
+
+    /** Endpoint URL. */
+    public string $url = '';
+
+    /**
+     * Subscribed event patterns.
+     *
+     * @var list<string>
+     */
+    public array $events = [];
+
+    /** Whether the subscription is active (paused subscriptions receive no deliveries). */
+    public bool $is_active = true;
+
+    /**
+     * Arbitrary metadata stored with the subscription.
+     *
+     * @var array<string,mixed>|null
+     */
+    public ?array $metadata = null;
+
+    /** Creation timestamp. */
+    public ?string $created_at = null;
+
+    /** Last-update timestamp. */
+    public ?string $updated_at = null;
+}

--- a/src/Api/Webhooks/DTOs/Responses/WebhookSubscriptionListData.php
+++ b/src/Api/Webhooks/DTOs/Responses/WebhookSubscriptionListData.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Api\Webhooks\DTOs\Responses;
+
+/**
+ * Documentation-only list envelope for
+ * {@see \Glueful\Api\Webhooks\Http\Controllers\WebhookController::listSubscriptions()}. Doc-only.
+ */
+final class WebhookSubscriptionListData
+{
+    /** @var list<WebhookSubscriptionData> */
+    public array $subscriptions = [];
+
+    public ?PaginationData $pagination = null;
+}

--- a/src/Api/Webhooks/DTOs/WebhookSubscriptionInputData.php
+++ b/src/Api/Webhooks/DTOs/WebhookSubscriptionInputData.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Api\Webhooks\DTOs;
+
+/**
+ * Documentation-only request body for
+ * {@see \Glueful\Api\Webhooks\Http\Controllers\WebhookController::createSubscription()}.
+ *
+ * The controller handles the request manually (Symfony Request), so this DTO is NEVER hydrated at
+ * runtime — it is reflected by {@see \Glueful\Support\Documentation\ClassSchemaReflector} purely to
+ * document the JSON body the route accepts (via #[ApiRequestBody]).
+ */
+final class WebhookSubscriptionInputData
+{
+    /** Endpoint URL to deliver events to (HTTPS required when api.webhooks.require_https is on). */
+    public string $url = '';
+
+    /**
+     * Events to subscribe to. Supports exact names, `*` (all), and `prefix.*` wildcards.
+     *
+     * @var list<string>
+     */
+    public array $events = [];
+
+    /**
+     * Optional arbitrary metadata stored with the subscription.
+     *
+     * @var array<string,mixed>|null
+     */
+    public ?array $metadata = null;
+}

--- a/src/Api/Webhooks/DTOs/WebhookSubscriptionUpdateData.php
+++ b/src/Api/Webhooks/DTOs/WebhookSubscriptionUpdateData.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Api\Webhooks\DTOs;
+
+/**
+ * Documentation-only request body for
+ * {@see \Glueful\Api\Webhooks\Http\Controllers\WebhookController::updateSubscription()}.
+ *
+ * Partial update — every field is optional; only supplied fields change. Doc-only (never hydrated);
+ * reflected for #[ApiRequestBody].
+ */
+final class WebhookSubscriptionUpdateData
+{
+    /** New endpoint URL. */
+    public ?string $url = null;
+
+    /**
+     * Replacement event list (non-empty when supplied).
+     *
+     * @var list<string>|null
+     */
+    public ?array $events = null;
+
+    /** Pause/resume delivery. */
+    public ?bool $is_active = null;
+
+    /**
+     * Replacement metadata.
+     *
+     * @var array<string,mixed>|null
+     */
+    public ?array $metadata = null;
+}

--- a/src/Api/Webhooks/Http/Controllers/WebhookController.php
+++ b/src/Api/Webhooks/Http/Controllers/WebhookController.php
@@ -5,13 +5,23 @@ declare(strict_types=1);
 namespace Glueful\Api\Webhooks\Http\Controllers;
 
 use Glueful\Api\Webhooks\Contracts\WebhookDispatcherInterface;
+use Glueful\Api\Webhooks\DTOs\Responses\WebhookDeliveryDetailData;
+use Glueful\Api\Webhooks\DTOs\Responses\WebhookDeliveryListData;
+use Glueful\Api\Webhooks\DTOs\Responses\WebhookStatsData;
+use Glueful\Api\Webhooks\DTOs\Responses\WebhookSubscriptionCreatedData;
+use Glueful\Api\Webhooks\DTOs\Responses\WebhookSubscriptionData;
+use Glueful\Api\Webhooks\DTOs\Responses\WebhookSubscriptionListData;
+use Glueful\Api\Webhooks\DTOs\WebhookSubscriptionInputData;
+use Glueful\Api\Webhooks\DTOs\WebhookSubscriptionUpdateData;
 use Glueful\Api\Webhooks\Webhook;
 use Glueful\Api\Webhooks\WebhookDelivery;
 use Glueful\Api\Webhooks\WebhookSubscription;
 use Glueful\Controllers\BaseController;
 use Glueful\Http\Response;
 use Glueful\Routing\Attributes\ApiOperation;
+use Glueful\Routing\Attributes\ApiRequestBody;
 use Glueful\Routing\Attributes\ApiResponse;
+use Glueful\Routing\Attributes\QueryParam;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -57,7 +67,10 @@ class WebhookController extends BaseController
             . 'active ones, plus `page` and `per_page` (max 100).',
         tags: ['Webhooks'],
     )]
-    #[ApiResponse(200, description: 'Subscriptions page.')]
+    #[QueryParam('active', type: 'boolean', description: 'When true, return only active subscriptions.')]
+    #[QueryParam('page', type: 'integer', description: 'Page number (default 1).')]
+    #[QueryParam('per_page', type: 'integer', description: 'Items per page (default 25, max 100).')]
+    #[ApiResponse(200, schema: WebhookSubscriptionListData::class, description: 'Subscriptions page.')]
     public function listSubscriptions(Request $request): \Symfony\Component\HttpFoundation\Response
     {
         $page = max(1, (int) $request->query->get('page', 1));
@@ -112,7 +125,12 @@ class WebhookController extends BaseController
             . '`prefix.*` wildcards), optional `metadata`. The signing `secret` is returned once.',
         tags: ['Webhooks'],
     )]
-    #[ApiResponse(201, description: 'Created subscription + signing secret.')]
+    #[ApiRequestBody(schema: WebhookSubscriptionInputData::class)]
+    #[ApiResponse(
+        201,
+        schema: WebhookSubscriptionCreatedData::class,
+        description: 'Created subscription + signing secret.',
+    )]
     #[ApiResponse(400, description: 'Invalid URL or events.')]
     public function createSubscription(Request $request): \Symfony\Component\HttpFoundation\Response
     {
@@ -153,7 +171,7 @@ class WebhookController extends BaseController
      * @return \Symfony\Component\HttpFoundation\Response
      */
     #[ApiOperation(summary: 'Get a webhook subscription', tags: ['Webhooks'])]
-    #[ApiResponse(200, description: 'Subscription.')]
+    #[ApiResponse(200, schema: WebhookSubscriptionData::class, description: 'Subscription.')]
     #[ApiResponse(404, description: 'No such subscription.')]
     public function getSubscription(string $id): \Symfony\Component\HttpFoundation\Response
     {
@@ -184,7 +202,8 @@ class WebhookController extends BaseController
             . '`metadata`; only supplied fields change.',
         tags: ['Webhooks'],
     )]
-    #[ApiResponse(200, description: 'Updated subscription.')]
+    #[ApiRequestBody(schema: WebhookSubscriptionUpdateData::class)]
+    #[ApiResponse(200, schema: WebhookSubscriptionData::class, description: 'Updated subscription.')]
     #[ApiResponse(400, description: 'Invalid URL or events.')]
     #[ApiResponse(404, description: 'No such subscription.')]
     public function updateSubscription(Request $request, string $id): \Symfony\Component\HttpFoundation\Response
@@ -347,7 +366,8 @@ class WebhookController extends BaseController
         description: 'Delivery counts and success rate over a window. Optional `days` query (default 30).',
         tags: ['Webhooks'],
     )]
-    #[ApiResponse(200, description: 'Delivery statistics.')]
+    #[QueryParam('days', type: 'integer', description: 'Window in days (default 30).')]
+    #[ApiResponse(200, schema: WebhookStatsData::class, description: 'Delivery statistics.')]
     #[ApiResponse(404, description: 'No such subscription.')]
     public function getSubscriptionStats(Request $request, string $id): \Symfony\Component\HttpFoundation\Response
     {
@@ -386,7 +406,11 @@ class WebhookController extends BaseController
             . '`subscription` (UUID) filters, plus `page` and `per_page` (max 100).',
         tags: ['Webhooks'],
     )]
-    #[ApiResponse(200, description: 'Deliveries page.')]
+    #[QueryParam('status', type: 'string', description: 'Filter by status (pending|delivered|failed|retrying).')]
+    #[QueryParam('subscription', type: 'string', description: 'Filter by subscription UUID.')]
+    #[QueryParam('page', type: 'integer', description: 'Page number (default 1).')]
+    #[QueryParam('per_page', type: 'integer', description: 'Items per page (default 25, max 100).')]
+    #[ApiResponse(200, schema: WebhookDeliveryListData::class, description: 'Deliveries page.')]
     public function listDeliveries(Request $request): \Symfony\Component\HttpFoundation\Response
     {
         $page = max(1, (int) $request->query->get('page', 1));
@@ -449,7 +473,7 @@ class WebhookController extends BaseController
         description: 'A single delivery including its request payload and the endpoint response body.',
         tags: ['Webhooks'],
     )]
-    #[ApiResponse(200, description: 'Delivery with payload + response.')]
+    #[ApiResponse(200, schema: WebhookDeliveryDetailData::class, description: 'Delivery with payload + response.')]
     #[ApiResponse(404, description: 'No such delivery.')]
     public function getDelivery(string $id): \Symfony\Component\HttpFoundation\Response
     {

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,7 +13,7 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.63.4';
+    public const VERSION = '1.63.5';
 
 
     /** Release code name */


### PR DESCRIPTION
Build on 1.63.4 (operation summaries) by adding the schemas: #[QueryParam] for the list/stats query params, #[ApiRequestBody] for create/update, and #[ApiResponse(schema:)] for the subscription/delivery/list/stats responses, backed by new documentation-only DTOs under Glueful\Api\Webhooks\DTOs. Applications that mount the controller now get a precise spec + typed client.

Runtime behavior is unchanged — the DTOs are reflected for docs only, never hydrated (the same approach AuthController uses for login).

Patch release (Yildun). No new env, no migrations, no action required.
