### PR TITLE
Release 1.64.0 — Zosma

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,10 @@ TOKEN_SALT=
 # Allowed: HS256, HS384, HS512
 JWT_ALGORITHM=HS256
 
+# API key brand prefix for generated keys (e.g. gf -> gf_live_… / gf_test_…). Only the first 16
+# chars are stored as the indexed lookup prefix, so keep it short. Default: gf.
+API_KEY_PREFIX=gf
+
 # CORS Configuration
 # Development: local origins prefilled for convenience
 # Production: set explicit domains; avoid '*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.64.0] - 2026-06-28 — Zosma
+
+### Added
+- **API key prefix is configurable.** The generated key prefix (`gf_live_…` / `gf_test_…`) is no
+  longer hard-coded — `ApiKeyService` reads the brand from `auth.api_keys.prefix` (env
+  `API_KEY_PREFIX`, default `gf`). Set it to rebrand keys per app (e.g. `lm` → `lm_live_…`). Only the
+  first 16 chars are stored as the indexed lookup prefix, so keep it short. Backward compatible — the
+  default reproduces the existing `gf_*` keys.
+- **API key lifecycle is auditable.** `ApiKeyService::create/rotate/revoke` now emit framework entity
+  events (`EntityCreatedEvent`/`EntityUpdatedEvent` for the `api_keys` table) so an audit consumer can
+  record who minted, rotated, or revoked a key — previously these went through `Model::save()` and
+  emitted nothing. The event payload is **identity only** (uuid, name, key_prefix, scopes, …) and
+  never carries the plaintext or the `key_hash`. Best-effort dispatch — a failed audit never breaks
+  the key operation. Covers every path (HTTP, CLI, any `ApiKeyService` caller).
+
+### Fixed
+- **Webhook list endpoints no longer 500 on the query validator.** `WebhookController::listSubscriptions`
+  and `listDeliveries` chained `->offset()->limit()`, but the strict query validator rejects OFFSET
+  set before LIMIT (`OFFSET requires LIMIT to be set`). Reordered to `->limit()->offset()`.
+- **`WebhookSubscription` inserts no longer fail on PostgreSQL.** The model didn't set
+  `$timestamps = false`, so the ORM bound `DateTimeImmutable` `created_at`/`updated_at` values
+  (DB-defaulted columns) through the string-bind path, throwing on insert. Now disabled like
+  `WebhookDelivery`/`ApiKey`, letting the DB fill the timestamps.
+- **Webhook UUID columns widened to fit the generated ids.** `webhook_subscriptions`/
+  `webhook_deliveries` declared `uuid varchar(12)`, but ids are `wh_sub_`/`wh_del_` + a 16-char nano
+  id (23 chars). SQLite ignores the length so it was never caught; PostgreSQL overflowed every insert.
+  The auto-create path now uses `varchar(32)`.
+
+> These webhook fixes were latent: the framework ships `WebhookController` but does not register its
+> routes, so the endpoints were never exercised against PostgreSQL until an application mounted them.
+
+- **Uploaded blob visibility is now persisted.** `FileUploader::saveBlobRecord()` never wrote the
+  `visibility` column, so every blob fell back to the `private` DB default regardless of the
+  `visibility` requested at upload — the response *echoed* `public` but the row was `private`, so the
+  blob then 401'd on retrieval (`GET /blobs/{uuid}`), breaking any `<img>` use of a "public" upload.
+  `uploadMedia()` now forwards its options to `saveBlobRecord()`, which persists the requested
+  visibility (falling back to `uploads.default_visibility`).
+
 ## [1.63.5] - 2026-06-27 — Yildun
 
 > **Theme: the webhook management API is now fully typed in OpenAPI.** 1.63.4 added operation

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,25 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.64.0 — Zosma (Minor, Released 2026-06-28)
+- **API key prefix is configurable.** `ApiKeyService` reads the brand from `auth.api_keys.prefix`
+  (env `API_KEY_PREFIX`, default `gf`), so apps can rebrand generated keys (`gf_live_…` → `lm_live_…`).
+  Only the first 16 chars are stored as the indexed lookup prefix. Backward compatible — the default
+  reproduces the existing `gf_*` keys.
+- **API key lifecycle is auditable.** `ApiKeyService::create/rotate/revoke` now emit framework entity
+  events for the `api_keys` table (previously they went through `Model::save()` and emitted nothing),
+  so an audit consumer can record who minted/rotated/revoked a key. Identity-only payload (never the
+  plaintext or `key_hash`); best-effort dispatch.
+- **Webhook management fixes.** List endpoints no longer 500 on the strict query validator
+  (`->limit()->offset()` order); `WebhookSubscription` inserts no longer fail on PostgreSQL
+  (`$timestamps = false`); auto-created webhook UUID columns widened to `varchar(32)` to fit the
+  generated ids. These were latent — core ships the controller but doesn't register its routes.
+- **Uploaded blob visibility is now persisted.** `FileUploader::saveBlobRecord()` now writes the
+  requested `visibility` (falling back to `uploads.default_visibility`); previously every blob fell
+  back to the `private` default, so a "public" upload 401'd on retrieval.
+- Notes: **Minor release** — one new optional env (`API_KEY_PREFIX`, default `gf`, backward
+  compatible), no migrations, no breaking changes. api-skeleton bumped to `^1.64.0`.
+
 ### 1.63.5 — Yildun (Patch, Released 2026-06-27)
 - **Webhook management API fully typed in OpenAPI.** Built on 1.63.4 (operation summaries) by adding
   the schemas: `#[QueryParam]` for the list/stats query params, `#[ApiRequestBody]` for create/update,

--- a/config/auth.php
+++ b/config/auth.php
@@ -9,6 +9,14 @@
  */
 
 return [
+    'api_keys' => [
+        // Brand segment of generated API keys: <prefix>_live_<random> in production,
+        // <prefix>_test_<random> elsewhere. Defaults to 'gf' (Glueful); set API_KEY_PREFIX to
+        // rebrand (e.g. 'lm' → lm_live_… / lm_test_…). Keep it short — only the first 16 chars of a
+        // key are stored as the indexed lookup prefix.
+        'prefix' => env('API_KEY_PREFIX', 'gf'),
+    ],
+
     'two_factor' => [
         // Master switch. When false, TwoFactorService::isEnabled() short-circuits
         // before any DB read and the /2fa/* routes are not registered.

--- a/src/Api/Webhooks/Http/Controllers/WebhookController.php
+++ b/src/Api/Webhooks/Http/Controllers/WebhookController.php
@@ -91,7 +91,7 @@ class WebhookController extends BaseController
         $offset = ($page - 1) * $perPage;
 
         // Get paginated results
-        $results = $query->offset($offset)->limit($perPage)->get();
+        $results = $query->limit($perPage)->offset($offset)->get();
 
         $subscriptions = [];
         /** @var WebhookSubscription $subscription */
@@ -441,7 +441,7 @@ class WebhookController extends BaseController
         $offset = ($page - 1) * $perPage;
 
         // Get paginated results
-        $results = $query->offset($offset)->limit($perPage)->get();
+        $results = $query->limit($perPage)->offset($offset)->get();
 
         $deliveries = [];
         /** @var WebhookDelivery $delivery */

--- a/src/Api/Webhooks/WebhookDispatcher.php
+++ b/src/Api/Webhooks/WebhookDispatcher.php
@@ -190,7 +190,7 @@ class WebhookDispatcher implements WebhookDispatcherInterface
 
         // Define columns
         $table->bigInteger('id')->unsigned()->primary()->autoIncrement();
-        $table->string('uuid', 12)->unique();
+        $table->string('uuid', 32)->unique();
         $table->string('url', 2048);
         $table->json('events');
         $table->string('secret', 255);
@@ -220,7 +220,7 @@ class WebhookDispatcher implements WebhookDispatcherInterface
 
         // Define columns
         $table->bigInteger('id')->unsigned()->primary()->autoIncrement();
-        $table->string('uuid', 12)->unique();
+        $table->string('uuid', 32)->unique();
         $table->bigInteger('subscription_id')->unsigned();
         $table->string('event', 255);
         $table->json('payload');

--- a/src/Api/Webhooks/WebhookSubscription.php
+++ b/src/Api/Webhooks/WebhookSubscription.php
@@ -28,6 +28,13 @@ class WebhookSubscription extends Model
 {
     protected string $table = 'webhook_subscriptions';
 
+    /**
+     * created_at / updated_at are filled by the DB (DEFAULT CURRENT_TIMESTAMP). Disabling the ORM's
+     * automatic timestamp population avoids binding DateTimeImmutable objects through the
+     * QueryBuilder's string-bind path (which throws on insert). Matches WebhookDelivery + ApiKey.
+     */
+    public bool $timestamps = false;
+
     /** @var array<string> */
     protected array $fillable = [
         'uuid',

--- a/src/Auth/ApiKey/ApiKeyService.php
+++ b/src/Auth/ApiKey/ApiKeyService.php
@@ -8,6 +8,9 @@ use Glueful\Auth\ApiKey\Exceptions\ApiKeyExpiredException;
 use Glueful\Auth\ApiKey\Exceptions\InvalidApiKeyException;
 use Glueful\Auth\ApiKey\Support\CidrMatcher;
 use Glueful\Bootstrap\ApplicationContext;
+use Glueful\Events\Database\EntityCreatedEvent;
+use Glueful\Events\Database\EntityUpdatedEvent;
+use Glueful\Events\EventService;
 use Glueful\Helpers\Utils;
 
 /**
@@ -26,9 +29,10 @@ final class ApiKeyService
 
     // ── Pure helpers (no DB I/O) ──
 
-    public static function generatePlainKey(string $environment): string
+    public static function generatePlainKey(string $environment, string $brand = 'gf'): string
     {
-        $prefix = $environment === 'production' ? 'gf_live_' : 'gf_test_';
+        $env = $environment === 'production' ? 'live' : 'test';
+        $prefix = $brand . '_' . $env . '_';
         $random = '';
         $alphabetLength = strlen(self::ALPHABET);
         for ($i = 0; $i < self::RANDOM_LENGTH; $i++) {
@@ -84,7 +88,7 @@ final class ApiKeyService
     public static function create(ApplicationContext $context, array $attrs): array
     {
         $env = $context->getEnvironment();
-        $plain = self::generatePlainKey($env);
+        $plain = self::generatePlainKey($env, self::brand($context));
 
         $scopes = $attrs['scopes'] ?? null;
         $allowed = $attrs['allowed_ips'] ?? null;
@@ -101,6 +105,10 @@ final class ApiKeyService
         ], $context);
 
         $key->save();
+
+        // Audit trail: emit a generic entity event (the audit extension records it). Identity only —
+        // never the plaintext or key_hash. See self::auditView().
+        self::dispatchEvent($context, new EntityCreatedEvent(self::auditView($key), 'api_keys'));
 
         return ['plain' => $plain, 'key' => $key];
     }
@@ -179,7 +187,7 @@ final class ApiKeyService
         int $graceHours = 24
     ): array {
         $env = $context->getEnvironment();
-        $newPlain = self::generatePlainKey($env);
+        $newPlain = self::generatePlainKey($env, self::brand($context));
 
         $newKey = new ApiKey([
             'uuid'            => Utils::generateNanoID(),
@@ -198,6 +206,14 @@ final class ApiKeyService
         $existing->expires_at = $newExpiry;
         $existing->save();
 
+        // Audit: the successor key is created, and the old key's expiry is shortened to the grace window.
+        self::dispatchEvent($context, new EntityCreatedEvent(self::auditView($newKey), 'api_keys'));
+        self::dispatchEvent($context, new EntityUpdatedEvent(
+            self::auditView($existing),
+            'api_keys',
+            ['expires_at' => $newExpiry],
+        ));
+
         return [
             'old_uuid'       => $existing->uuid,
             'new_plain'      => $newPlain,
@@ -207,8 +223,53 @@ final class ApiKeyService
 
     public static function revoke(ApplicationContext $context, ApiKey $key): void
     {
-        $key->revoked_at = date('Y-m-d H:i:s');
+        $revokedAt = date('Y-m-d H:i:s');
+        $key->revoked_at = $revokedAt;
         $key->save();
+
+        self::dispatchEvent($context, new EntityUpdatedEvent(
+            self::auditView($key),
+            'api_keys',
+            ['revoked_at' => $revokedAt],
+        ));
+    }
+
+    /** Brand segment of generated keys (auth.api_keys.prefix; default 'gf'). */
+    private static function brand(ApplicationContext $context): string
+    {
+        $brand = config($context, 'auth.api_keys.prefix', 'gf');
+
+        return is_string($brand) && $brand !== '' ? $brand : 'gf';
+    }
+
+    /**
+     * Identity-only view of a key for audit/event payloads. NEVER includes the plaintext or the
+     * key_hash — a key lifecycle event must not leak the credential or its hash into the audit log.
+     *
+     * @return array<string,mixed>
+     */
+    private static function auditView(ApiKey $key): array
+    {
+        return [
+            'uuid'        => $key->uuid,
+            'user_uuid'   => $key->user_uuid,
+            'name'        => $key->name,
+            'key_prefix'  => $key->key_prefix,
+            'scopes'      => $key->scopes,
+            'allowed_ips' => $key->allowed_ips,
+            'expires_at'  => $key->expires_at,
+            'revoked_at'  => $key->revoked_at,
+        ];
+    }
+
+    /** Best-effort event dispatch — auditing must never break a key lifecycle operation. */
+    private static function dispatchEvent(ApplicationContext $context, object $event): void
+    {
+        try {
+            app($context, EventService::class)->dispatch($event);
+        } catch (\Throwable) {
+            // Swallow: the key was already persisted; a failed audit dispatch must not surface.
+        }
     }
 
     /** @return array<int, ApiKey> */

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,15 +13,15 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.63.5';
+    public const VERSION = '1.64.0';
 
 
     /** Release code name */
-    public const NAME = 'Yildun';
+    public const NAME = 'Zosma';
 
 
     /** Release date */
-    public const RELEASE_DATE = '2026-06-27';
+    public const RELEASE_DATE = '2026-06-28';
 
     /** Minimum required PHP version */
     public const MIN_PHP_VERSION = '8.3.0';

--- a/src/Uploader/FileUploader.php
+++ b/src/Uploader/FileUploader.php
@@ -159,7 +159,7 @@ final class FileUploader
 
         // Save to database if requested
         if ((bool) ($options['save_to_blobs'] ?? true)) {
-            $result['blob_uuid'] = $this->saveBlobRecord($file, $mime, $fullPath);
+            $result['blob_uuid'] = $this->saveBlobRecord($file, $mime, $fullPath, $options);
         }
 
         return $result;
@@ -657,10 +657,17 @@ final class FileUploader
 
     /**
      * @param array<string, mixed> $file
+     * @param array<string, mixed> $options
      */
-    private function saveBlobRecord(array $file, string $mime, string $path): string
+    private function saveBlobRecord(array $file, string $mime, string $path, array $options = []): string
     {
         $user = Utils::getUser();
+
+        // Persist the requested visibility so public blobs are actually servable without auth;
+        // without this the column falls back to its 'private' default regardless of the request.
+        $visibility = isset($options['visibility']) && is_string($options['visibility'])
+            ? $options['visibility']
+            : (string) $this->getConfig('uploads.default_visibility', 'private');
 
         return $this->blobRepository->create([
             'name' => $file['name'] ?? basename($path),
@@ -670,6 +677,7 @@ final class FileUploader
             'created_by' => $user['uuid'] ?? null,
             'size' => $file['size'] ?? 0,
             'status' => 'active',
+            'visibility' => $visibility,
             'created_at' => date('Y-m-d H:i:s'),
         ]);
     }


### PR DESCRIPTION
Added:
- Configurable API key prefix (auth.api_keys.prefix / API_KEY_PREFIX, default gf).
- Auditable API key lifecycle — create/rotate/revoke emit identity-only api_keys entity events.

Fixed:
- Webhook list endpoints (limit before offset), PostgreSQL inserts (timestamps=false), and auto-created UUID column widths.
- FileUploader now persists the requested blob visibility (public uploads no longer 401).