### PR TITLE
Release 1.65.0 — Acrux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,48 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.65.0] - 2026-06-30 — Acrux
+
+### Added
+- **Database: `QueryBuilder::forceDelete()`** — permanently deletes matching rows, bypassing
+  soft-delete even on a soft-deletable table (one with a `deleted_at` column). Previously the only
+  way to hard-delete such a row (e.g. to re-insert the same unique key in an upsert) was raw SQL,
+  since the hard-delete path was reachable only internally from `delete()`. Added to
+  `QueryBuilderInterface`.
+- **Validation: coercion `MutatingRule`s** — `CastToInt`, `CastToBoolean`, `CastToDate`. The
+  `Validator` rule set could validate but not coerce (`filtered()` returned uncoerced input); these
+  cast input before the validating rules run, so a rule pipeline can both normalize and validate.
+- **Validation: `DbUnique` exclude-by-column** — a fifth `$exceptColumn` constructor argument
+  (default `'id'`) so a record keyed by a non-`id` primary column (e.g. `uuid`) can exclude the
+  current row on update. The except-column is identifier-validated like the table/column.
+- **Auth: `api_key_uuid` request attribute** — `ApiKeyAuthenticationProvider` now also sets the
+  acting key's own uuid (alongside `api_key_scopes`), so callers can attribute an action to the
+  specific API key (audit, rate-limit keying) without re-reading the `api_keys` table.
+- **Extensions: `ServiceProvider::resetLoadedRoutes()`** — resets the process-global
+  loaded-routes latch so a fresh `Framework::boot()` in the same process re-registers route files
+  (the latch otherwise silently skips extension routes after the first boot — e.g. across test boots).
+
+### Fixed
+- **Routing: `AuthMiddleware` now always populates `auth.user`.** After a successful auth it
+  synthesises a basic `UserIdentity` (uuid, roles, scopes, email/username/status) when the optional
+  enricher (`auth_to_request`) has not set one, so `auth.user` is never silently null. Previously a
+  route running `auth` without the enricher left `auth.user` unset — silently fail-closing permission
+  gates that read it and dropping actor/audit attribution.
+- **Routing: `RequireScopeMiddleware` now enforces file-defined routes.** It only read the
+  `#[RequireScope]` attribute config and fell **open** when absent, so a route declaring its scope
+  as a middleware param (`->middleware('require_scope:read:content')`) got no enforcement. It now
+  falls back to the middleware params (a single any-of group) and enforces them **fail-closed**.
+- **Database: `TableBuilder` now applies column drops.** `executeAlterations()` did not forward
+  `drop_columns` to the SQL generator, so `dropColumn()` during `alterTable()` was a silent no-op.
+
+### Upgrade Notes
+- **Scope enforcement tightened (`RequireScopeMiddleware`).** A route that declared its required
+  scope as a middleware param — `->middleware('require_scope:read:content')` — was previously **not**
+  enforced (it fell open when no `#[RequireScope]` attribute was present). It now enforces
+  **fail-closed**. If any such route relied on that missing check, requests lacking the scope will now
+  correctly receive `403`. Routes using the `#[RequireScope]` attribute are unaffected.
+- No config defaults changed; no new env vars; no migrations.
+
 ## [1.64.0] - 2026-06-28 — Zosma
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,25 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.65.0 — Acrux (Minor, Released 2026-06-30)
+- **`QueryBuilder::forceDelete()`** permanently deletes matching rows, bypassing soft-delete even on
+  a `deleted_at` table — previously hard-deleting such a row needed raw SQL. Added to
+  `QueryBuilderInterface`.
+- **Validation coercion rules** — `CastToInt`, `CastToBoolean`, `CastToDate` `MutatingRule`s let a
+  validator pipeline both normalize and validate (`filtered()` previously returned uncoerced input).
+- **`DbUnique` exclude-by-column** — a fifth `$exceptColumn` argument (default `'id'`) so a record
+  keyed by a non-`id` column (e.g. `uuid`) can exclude the current row on update.
+- **`api_key_uuid` request attribute** — `ApiKeyAuthenticationProvider` exposes the acting key's own
+  uuid alongside `api_key_scopes`, for per-key attribution (audit, rate-limit keying).
+- **`ServiceProvider::resetLoadedRoutes()`** resets the process-global loaded-routes latch so a fresh
+  `Framework::boot()` in the same process re-registers extension route files (notably across test boots).
+- **Routing/schema fixes.** `AuthMiddleware` now always populates `auth.user` (synthesises a basic
+  `UserIdentity` when no enricher ran, so permission gates never silently fail-closed);
+  `RequireScopeMiddleware` now enforces file-defined `require_scope:` params fail-closed (it previously
+  fell open); `TableBuilder::alterTable()` now applies `dropColumn()` (previously a silent no-op).
+- Notes: **Minor release** — no new env, no migrations, no breaking changes. Scope enforcement
+  tightened (see CHANGELOG Upgrade Notes). api-skeleton bumped to `^1.65.0`.
+
 ### 1.64.0 — Zosma (Minor, Released 2026-06-28)
 - **API key prefix is configurable.** `ApiKeyService` reads the brand from `auth.api_keys.prefix`
   (env `API_KEY_PREFIX`, default `gf`), so apps can rebrand generated keys (`gf_live_…` → `lm_live_…`).

--- a/src/Auth/ApiKeyAuthenticationProvider.php
+++ b/src/Auth/ApiKeyAuthenticationProvider.php
@@ -101,6 +101,9 @@ class ApiKeyAuthenticationProvider implements AuthenticationProviderInterface
             $request->attributes->set('user_data', $userData);
             $request->attributes->set('auth_method', 'api_key');
             $request->attributes->set('api_key_scopes', $key->getScopes());
+            // The acting key's own uuid (not the principal's), so callers can attribute actions to
+            // the specific API key (audit, rate-limit keying) without re-reading the api_keys table.
+            $request->attributes->set('api_key_uuid', $key->uuid);
 
             return $userData;
         } catch (ApiKeyExpiredException) {

--- a/src/Database/Query/Interfaces/QueryBuilderInterface.php
+++ b/src/Database/Query/Interfaces/QueryBuilderInterface.php
@@ -229,9 +229,14 @@ interface QueryBuilderInterface
     public function update(array $data): int;
 
     /**
-     * Delete records
+     * Delete records (soft-delete-aware: soft-deletes when the table has a deleted_at column)
      */
     public function delete(): int;
+
+    /**
+     * Permanently delete records, bypassing soft-delete even on a soft-deletable table
+     */
+    public function forceDelete(): int;
 
     /**
      * Execute in transaction

--- a/src/Database/QueryBuilder.php
+++ b/src/Database/QueryBuilder.php
@@ -724,6 +724,24 @@ class QueryBuilder implements QueryBuilderInterface
     }
 
     /**
+     * Permanently delete the matching rows, bypassing soft-delete even when the table is
+     * soft-deletable (has a `deleted_at` column).
+     *
+     * Use when a row must physically go — e.g. to re-insert the same unique key (an upsert),
+     * or to purge. {@see delete()} is the soft-delete-aware default and should be preferred
+     * unless a hard delete is specifically required.
+     */
+    public function forceDelete(): int
+    {
+        $table = $this->state->getTableOrFail();
+        $conditions = $this->whereClause->getConditionsArray();
+
+        $this->queryValidator->validateDelete($table, $conditions);
+
+        return $this->deleteBuilder->forceDelete($table, $conditions);
+    }
+
+    /**
      * Restore soft-deleted records
      */
     public function restore(): int

--- a/src/Database/Schema/Builders/TableBuilder.php
+++ b/src/Database/Schema/Builders/TableBuilder.php
@@ -798,18 +798,17 @@ class TableBuilder implements TableBuilderInterface, TableBuilderContextInterfac
      */
     private function executeAlterations(): void
     {
-        // For now, generate basic alteration SQL
-        // In a full implementation, this would handle all types of alterations
         $tableDefinition = new TableDefinition(
             name: $this->tableName,
             comment: $this->comment
         );
 
         $changes = [
-            'add_columns' => $this->columns,
-            'add_indexes' => $this->indexes,
-            'drop_indexes' => $this->options['_drop_indexes'] ?? [],
-            'add_foreign_keys' => $this->foreignKeys
+            'add_columns'      => $this->columns,
+            'add_indexes'      => $this->indexes,
+            'drop_indexes'     => $this->options['_drop_indexes'] ?? [],
+            'add_foreign_keys' => $this->foreignKeys,
+            'drop_columns'     => $this->options['_drops'] ?? [],
         ];
 
         $sqlStatements = $this->sqlGenerator->alterTable($tableDefinition, $changes);

--- a/src/Extensions/ServiceProvider.php
+++ b/src/Extensions/ServiceProvider.php
@@ -96,6 +96,9 @@ abstract class ServiceProvider
     }
 
     /** Load routes from a file; file will use $router from the container. */
+    /** @var array<string, true> Loaded route files keyed by realpath; reset via resetLoadedRoutes(). */
+    private static array $loadedRoutes = [];
+
     protected function loadRoutesFrom(string $path): void
     {
         // Router must exist to register routes
@@ -109,9 +112,9 @@ abstract class ServiceProvider
             return;
         }
 
-        // Idempotency: avoid loading the same routes file more than once
-        static $loaded = [];
-        if (isset($loaded[$real])) {
+        // Idempotency: avoid loading the same routes file more than once (resettable via
+        // resetLoadedRoutes() so a fresh boot in the same process re-registers routes).
+        if (isset(self::$loadedRoutes[$real])) {
             return;
         }
 
@@ -120,7 +123,7 @@ abstract class ServiceProvider
             /** @var Router $router */
             $router = $this->app->get(Router::class);
             require $real; // executes the routes file
-            $loaded[$real] = true;
+            self::$loadedRoutes[$real] = true;
         } catch (\Throwable $e) {
             // Log and continue in production; rethrow in non‑production for fast feedback
             error_log('[Extensions] Failed to load routes from ' . $real . ': ' . $e->getMessage());
@@ -129,6 +132,16 @@ abstract class ServiceProvider
                 throw $e;
             }
         }
+    }
+
+    /**
+     * Reset the loaded-routes latch so a subsequent boot in the SAME process re-registers route
+     * files. Without this the process-global latch silently skips extension routes after the first
+     * boot (notably across multiple framework boots in one test process).
+     */
+    public static function resetLoadedRoutes(): void
+    {
+        self::$loadedRoutes = [];
     }
 
     /**

--- a/src/Routing/Middleware/AuthMiddleware.php
+++ b/src/Routing/Middleware/AuthMiddleware.php
@@ -11,6 +11,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Glueful\Auth\AuthenticationManager;
 use Glueful\Auth\JwtAuthenticationProvider;
 use Glueful\Auth\TokenManager;
+use Glueful\Auth\UserIdentity;
 use Psr\Container\ContainerInterface;
 use Glueful\Http\Exceptions\Domain\AuthenticationException;
 use Glueful\Permissions\Exceptions\UnauthorizedException as PermissionUnauthorizedException;
@@ -145,6 +146,17 @@ class AuthMiddleware implements RouteMiddleware
 
             // Auto-enrich request with auth attributes
             $this->autoEnrichRequest($request);
+
+            // Guarantee auth.user is populated. The enricher only sets it when the identity lives in
+            // the session context; for provider-based auth (API key, etc.) it can be absent, which
+            // silently fail-closes permission gates and drops audit attribution. Synthesise a basic
+            // UserIdentity from the authenticated user data so auth.user is never null after auth.
+            if (!$request->attributes->has('auth.user')) {
+                $identity = $this->identityFromUserArray($user);
+                if ($identity !== null) {
+                    $request->attributes->set('auth.user', $identity);
+                }
+            }
 
             // Log successful authentication
             $this->logAuthSuccess($user, $request, $requestId, $token);
@@ -684,5 +696,48 @@ class AuthMiddleware implements RouteMiddleware
                 ]);
             }
         }
+    }
+
+    /**
+     * Build a basic {@see UserIdentity} from the authenticated user-data array (the shape
+     * {@see UserIdentity::toArray()} produces). Returns null when there is no uuid. Carries the
+     * identity essentials (uuid, roles, scopes, email/username/status, claims); the optional
+     * enricher adds richer context (permissions, tenant) when applied.
+     *
+     * @param array<string, mixed> $user
+     */
+    private function identityFromUserArray(array $user): ?UserIdentity
+    {
+        $uuid = $user['uuid'] ?? $user['id'] ?? null;
+        if (!is_string($uuid) || $uuid === '') {
+            return null;
+        }
+
+        $roles = (isset($user['roles']) && is_array($user['roles']))
+            ? array_values(array_filter($user['roles'], 'is_string'))
+            : [];
+
+        $claims = (isset($user['claims']) && is_array($user['claims'])) ? $user['claims'] : [];
+        $scopesRaw = $claims['scope'] ?? $claims['scopes'] ?? ($user['scopes'] ?? []);
+        $scopes = is_array($scopesRaw) ? array_values(array_filter($scopesRaw, 'is_string')) : [];
+
+        $attributes = [];
+        if (array_key_exists('permissions', $user)) {
+            $attributes['permissions'] = $user['permissions'];
+        }
+
+        $identity = new UserIdentity(
+            uuid: $uuid,
+            roles: $roles,
+            scopes: $scopes,
+            attributes: $attributes,
+            email: is_string($user['email'] ?? null) ? $user['email'] : null,
+            username: is_string($user['username'] ?? null) ? $user['username'] : null,
+            status: is_string($user['status'] ?? null) ? $user['status'] : null,
+            sessionUuid: is_string($user['session_uuid'] ?? null) ? $user['session_uuid'] : null,
+            provider: is_string($user['provider'] ?? null) ? $user['provider'] : null,
+        );
+
+        return $claims !== [] ? $identity->withClaims($claims) : $identity;
     }
 }

--- a/src/Routing/Middleware/RequireScopeMiddleware.php
+++ b/src/Routing/Middleware/RequireScopeMiddleware.php
@@ -31,6 +31,20 @@ final class RequireScopeMiddleware implements RouteMiddleware
             ? $route->getRequireScopeConfig()
             : [];
 
+        // Fall back to middleware params for file-defined routes that declare their required scope
+        // as a middleware argument (e.g. ->middleware('require_scope:read:content')) rather than a
+        // #[RequireScope] attribute. The listed scopes form a single any-of group; enforcement below
+        // is fail-closed (an unauthenticated request is denied, not waved through).
+        if ($config === []) {
+            $paramScopes = array_values(array_filter(
+                array_map(static fn ($p): string => (string) $p, $params),
+                static fn (string $s): bool => $s !== '',
+            ));
+            if ($paramScopes !== []) {
+                $config = [$paramScopes];
+            }
+        }
+
         if ($config === []) {
             return $next($request);
         }

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,15 +13,15 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.64.0';
+    public const VERSION = '1.65.0';
 
 
     /** Release code name */
-    public const NAME = 'Zosma';
+    public const NAME = 'Acrux';
 
 
     /** Release date */
-    public const RELEASE_DATE = '2026-06-28';
+    public const RELEASE_DATE = '2026-06-30';
 
     /** Minimum required PHP version */
     public const MIN_PHP_VERSION = '8.3.0';

--- a/src/Validation/Rules/CastToBoolean.php
+++ b/src/Validation/Rules/CastToBoolean.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Validation\Rules;
+
+use Glueful\Validation\Contracts\MutatingRule;
+
+/**
+ * Coerces a boolean-like value to a bool: `true`/`"true"`/`"1"`/`"yes"`/`"on"`/`1` → true,
+ * `false`/`"false"`/`"0"`/`"no"`/`"off"`/`0` → false.
+ *
+ * A {@see MutatingRule} coerces, it does not validate: anything else (including `""` and `null`)
+ * is returned UNCHANGED so a paired validating rule can reject it.
+ */
+final class CastToBoolean implements MutatingRule
+{
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function mutate(mixed $value, array $context = []): mixed
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+        if (is_string($value)) {
+            $normalized = strtolower(trim($value));
+            if (in_array($normalized, ['true', '1', 'yes', 'on'], true)) {
+                return true;
+            }
+            if (in_array($normalized, ['false', '0', 'no', 'off'], true)) {
+                return false;
+            }
+        }
+        if ($value === 0 || $value === 1) {
+            return $value === 1;
+        }
+        return $value;
+    }
+}

--- a/src/Validation/Rules/CastToDate.php
+++ b/src/Validation/Rules/CastToDate.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Validation\Rules;
+
+use Glueful\Validation\Contracts\MutatingRule;
+
+/**
+ * Normalizes a date/datetime-like string to the given format (default `Y-m-d H:i:s`).
+ *
+ * A {@see MutatingRule} coerces, it does not validate: non-string or unparseable values are
+ * returned UNCHANGED so a paired {@see Date} rule can reject them. Pair with {@see Date} when
+ * strict validation (e.g. rejecting overflow dates) is required.
+ */
+final class CastToDate implements MutatingRule
+{
+    public function __construct(private readonly string $format = 'Y-m-d H:i:s')
+    {
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function mutate(mixed $value, array $context = []): mixed
+    {
+        if (!is_string($value) || trim($value) === '') {
+            return $value;
+        }
+        $timestamp = strtotime(trim($value));
+        if ($timestamp === false) {
+            return $value;
+        }
+        return date($this->format, $timestamp);
+    }
+}

--- a/src/Validation/Rules/CastToInt.php
+++ b/src/Validation/Rules/CastToInt.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Validation\Rules;
+
+use Glueful\Validation\Contracts\MutatingRule;
+
+/**
+ * Coerces an integer-like value (`42`, `"42"`, `42.0`) to an int.
+ *
+ * A {@see MutatingRule} coerces, it does not validate: values that are not cleanly integer
+ * (`"abc"`, `"42.5"`, `null`) are returned UNCHANGED so a paired validating rule (e.g.
+ * {@see Numeric} with `integerOnly` or {@see Type}) can reject them.
+ */
+final class CastToInt implements MutatingRule
+{
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function mutate(mixed $value, array $context = []): mixed
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+        if (is_string($value) && preg_match('/^-?\d+$/', trim($value)) === 1) {
+            return (int) trim($value);
+        }
+        if (is_float($value) && floor($value) === $value && is_finite($value)) {
+            return (int) $value;
+        }
+        return $value;
+    }
+}

--- a/src/Validation/Rules/DbUnique.php
+++ b/src/Validation/Rules/DbUnique.php
@@ -27,6 +27,7 @@ final class DbUnique implements Rule
     private string $table;
     private ?string $column;
     private string|int|null $exceptId;
+    private string $exceptColumn;
 
     /**
      * Create a new DbUnique rule
@@ -40,11 +41,15 @@ final class DbUnique implements Rule
         PDO|string $pdoOrTable,
         ?string $tableOrColumn = null,
         string|int|null $columnOrExceptId = null,
-        string|int|null $exceptId = null
+        string|int|null $exceptId = null,
+        string $exceptColumn = 'id'
     ) {
         // Support both constructor signatures:
         // 1. new DbUnique($pdo, 'table', 'column')  - Original signature
         // 2. new DbUnique('table', 'column', $exceptId)  - String syntax
+        // $exceptColumn (default 'id') is the column the exceptId is matched against, so callers
+        // keyed by a non-'id' primary column (e.g. 'uuid') can exclude the current row on update.
+        $this->exceptColumn = $exceptColumn;
 
         if ($pdoOrTable instanceof PDO) {
             // Original signature with PDO
@@ -111,13 +116,17 @@ final class DbUnique implements Rule
             throw new \InvalidArgumentException('Invalid column name.');
         }
 
+        if (!preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $this->exceptColumn)) {
+            throw new \InvalidArgumentException('Invalid except column name.');
+        }
+
         // Build query
         $sql = "SELECT 1 FROM {$this->table} WHERE {$column} = :value";
         $params = ['value' => $value];
 
         // Exclude specific ID if provided
         if ($this->exceptId !== null && $this->exceptId !== '') {
-            $sql .= " AND id != :except_id";
+            $sql .= " AND {$this->exceptColumn} != :except_id";
             $params['except_id'] = $this->exceptId;
         }
 

--- a/tests/Unit/Auth/AuthMiddlewareAuthUserTest.php
+++ b/tests/Unit/Auth/AuthMiddlewareAuthUserTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Auth;
+
+use Glueful\Auth\UserIdentity;
+use Glueful\Bootstrap\ApplicationContext;
+use Glueful\Routing\Middleware\AuthMiddleware;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * AuthMiddleware synthesises a basic auth.user {@see UserIdentity} from the authenticated user
+ * array, so auth.user is never null after auth even when the optional enricher is not applied.
+ */
+final class AuthMiddlewareAuthUserTest extends TestCase
+{
+    /**
+     * @param array<string, mixed> $user
+     */
+    private function build(array $user): ?UserIdentity
+    {
+        $middleware = new AuthMiddleware(context: ApplicationContext::forTesting(dirname(__DIR__, 3)));
+        $method = new ReflectionMethod($middleware, 'identityFromUserArray');
+        $method->setAccessible(true);
+
+        $identity = $method->invoke($middleware, $user);
+
+        return $identity instanceof UserIdentity ? $identity : null;
+    }
+
+    public function test_builds_identity_from_user_array(): void
+    {
+        $identity = $this->build([
+            'uuid' => 'u-123',
+            'email' => 'amy@example.test',
+            'username' => 'amy',
+            'status' => 'active',
+            'roles' => ['admin', 'editor'],
+            'claims' => ['scopes' => ['read', 'write']],
+            'permissions' => ['posts.edit'],
+        ]);
+
+        self::assertInstanceOf(UserIdentity::class, $identity);
+        self::assertSame('u-123', $identity->uuid());
+        self::assertSame('amy@example.test', $identity->email());
+        self::assertSame('amy', $identity->username());
+        self::assertSame('active', $identity->status());
+        self::assertSame(['admin', 'editor'], $identity->roles());
+        self::assertSame(['read', 'write'], $identity->scopes());
+    }
+
+    public function test_returns_null_without_a_uuid(): void
+    {
+        self::assertNull($this->build(['email' => 'no@uuid.test']));
+    }
+
+    public function test_tolerates_minimal_array(): void
+    {
+        $identity = $this->build(['uuid' => 'u-9']);
+
+        self::assertInstanceOf(UserIdentity::class, $identity);
+        self::assertSame('u-9', $identity->uuid());
+        self::assertSame([], $identity->roles());
+        self::assertNull($identity->email());
+    }
+}

--- a/tests/Unit/Database/Features/ForceDeleteTest.php
+++ b/tests/Unit/Database/Features/ForceDeleteTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Database\Features;
+
+use Glueful\Database\Connection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * QueryBuilder::forceDelete() physically removes rows even on a soft-deletable table (one with a
+ * deleted_at column), where delete() would otherwise soft-delete.
+ */
+final class ForceDeleteTest extends TestCase
+{
+    private function connectionWithSoftDeletableDocs(): Connection
+    {
+        $conn = new Connection([
+            'engine' => 'sqlite',
+            'sqlite' => ['primary' => ':memory:'],
+            'pooling' => ['enabled' => false],
+        ]);
+        $conn->getSchemaBuilder()->createTable('docs', function ($table) {
+            $table->bigInteger('id')->primary()->autoIncrement();
+            $table->string('name', 50);
+            $table->timestamp('deleted_at')->nullable();
+        });
+
+        return $conn;
+    }
+
+    public function test_force_delete_physically_removes_rows_on_a_soft_deletable_table(): void
+    {
+        $conn = $this->connectionWithSoftDeletableDocs();
+        $conn->table('docs')->insert(['name' => 'a']);
+
+        $conn->table('docs')->where('id', '>', 0)->forceDelete();
+
+        // Gone for good — not even present withTrashed (contrast: delete() would keep the row).
+        self::assertSame(0, $conn->table('docs')->withTrashed()->count());
+    }
+
+    public function test_delete_soft_deletes_but_force_delete_purges(): void
+    {
+        $conn = $this->connectionWithSoftDeletableDocs();
+        $conn->table('docs')->insert(['name' => 'a']);
+
+        // delete() soft-deletes: hidden from default reads, still physically present.
+        $conn->table('docs')->where('id', '>', 0)->delete();
+        self::assertSame(0, $conn->table('docs')->count());
+        self::assertSame(1, $conn->table('docs')->withTrashed()->count());
+
+        // forceDelete() then purges the soft-deleted row.
+        $conn->table('docs')->where('id', '>', 0)->forceDelete();
+        self::assertSame(0, $conn->table('docs')->withTrashed()->count());
+    }
+}

--- a/tests/Unit/Routing/Middleware/RequireScopeMiddlewareTest.php
+++ b/tests/Unit/Routing/Middleware/RequireScopeMiddlewareTest.php
@@ -75,4 +75,48 @@ final class RequireScopeMiddlewareTest extends TestCase
         $response = $this->dispatch([], null);
         self::assertSame('OK', $response->getContent());
     }
+
+    /**
+     * Dispatch a file-defined route (EMPTY #[RequireScope] attribute config) that declares its
+     * required scope(s) as middleware params, so the middleware falls back to the params.
+     *
+     * @param array<int, string>|null $grantedScopes  null = the api_key_scopes attribute is absent
+     */
+    private function dispatchWithParams(?array $grantedScopes, string ...$params): Response
+    {
+        $request = Request::create('/x');
+        $route = new class {
+            /** @return array<int, array<int, string>> */
+            public function getRequireScopeConfig(): array
+            {
+                return [];
+            }
+        };
+        $request->attributes->set('_route', $route);
+        if ($grantedScopes !== null) {
+            $request->attributes->set('api_key_scopes', $grantedScopes);
+        }
+
+        return (new RequireScopeMiddleware())
+            ->handle($request, static fn(Request $r): Response => new Response('OK'), ...$params);
+    }
+
+    public function test_param_scope_denies_when_scopes_attribute_absent(): void
+    {
+        // File-defined route requires a scope via param, but the request carries no scopes -> deny.
+        $this->expectException(InsufficientScopeException::class);
+        $this->dispatchWithParams(null, 'read:content');
+    }
+
+    public function test_param_scope_allows_matching_grant(): void
+    {
+        $response = $this->dispatchWithParams(['read:content'], 'read:content');
+        self::assertSame('OK', $response->getContent());
+    }
+
+    public function test_param_scope_denies_insufficient_grant(): void
+    {
+        $this->expectException(InsufficientScopeException::class);
+        $this->dispatchWithParams(['read:other'], 'read:content');
+    }
 }

--- a/tests/Unit/Validation/CastRulesTest.php
+++ b/tests/Unit/Validation/CastRulesTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Validation;
+
+use Glueful\Validation\Rules\CastToBoolean;
+use Glueful\Validation\Rules\CastToDate;
+use Glueful\Validation\Rules\CastToInt;
+use PHPUnit\Framework\TestCase;
+
+final class CastRulesTest extends TestCase
+{
+    public function test_cast_to_int_coerces_int_like_values(): void
+    {
+        $rule = new CastToInt();
+        self::assertSame(42, $rule->mutate('42'));
+        self::assertSame(42, $rule->mutate(42));
+        self::assertSame(-7, $rule->mutate(' -7 '));
+        self::assertSame(5, $rule->mutate(5.0));
+    }
+
+    public function test_cast_to_int_leaves_non_int_unchanged(): void
+    {
+        $rule = new CastToInt();
+        self::assertSame('abc', $rule->mutate('abc'));
+        self::assertSame('42.5', $rule->mutate('42.5'));
+        self::assertSame(3.5, $rule->mutate(3.5));
+        self::assertNull($rule->mutate(null));
+    }
+
+    public function test_cast_to_boolean_coerces_bool_like_values(): void
+    {
+        $rule = new CastToBoolean();
+        foreach (['true', '1', 'yes', 'on', 'TRUE', ' On '] as $truthy) {
+            self::assertTrue($rule->mutate($truthy), $truthy);
+        }
+        foreach (['false', '0', 'no', 'off'] as $falsy) {
+            self::assertFalse($rule->mutate($falsy), $falsy);
+        }
+        self::assertTrue($rule->mutate(true));
+        self::assertTrue($rule->mutate(1));
+        self::assertFalse($rule->mutate(0));
+    }
+
+    public function test_cast_to_boolean_leaves_ambiguous_unchanged(): void
+    {
+        $rule = new CastToBoolean();
+        self::assertSame('maybe', $rule->mutate('maybe'));
+        self::assertSame('', $rule->mutate(''));
+        self::assertSame(2, $rule->mutate(2));
+    }
+
+    public function test_cast_to_date_normalizes_to_format(): void
+    {
+        self::assertSame('2024-02-29 00:00:00', (new CastToDate())->mutate('2024-02-29'));
+        self::assertSame('2024-02-29', (new CastToDate('Y-m-d'))->mutate('29 Feb 2024'));
+    }
+
+    public function test_cast_to_date_leaves_unparseable_unchanged(): void
+    {
+        $rule = new CastToDate();
+        self::assertSame('not-a-date', $rule->mutate('not-a-date'));
+        self::assertSame('', $rule->mutate(''));
+        self::assertNull($rule->mutate(null));
+    }
+}


### PR DESCRIPTION
### Added
- **Database: `QueryBuilder::forceDelete()`** — permanently deletes matching rows, bypassing
  soft-delete even on a soft-deletable table (one with a `deleted_at` column). Previously the only
  way to hard-delete such a row (e.g. to re-insert the same unique key in an upsert) was raw SQL,
  since the hard-delete path was reachable only internally from `delete()`. Added to
  `QueryBuilderInterface`.
- **Validation: coercion `MutatingRule`s** — `CastToInt`, `CastToBoolean`, `CastToDate`. The
  `Validator` rule set could validate but not coerce (`filtered()` returned uncoerced input); these
  cast input before the validating rules run, so a rule pipeline can both normalize and validate.
- **Validation: `DbUnique` exclude-by-column** — a fifth `$exceptColumn` constructor argument
  (default `'id'`) so a record keyed by a non-`id` primary column (e.g. `uuid`) can exclude the
  current row on update. The except-column is identifier-validated like the table/column.
- **Auth: `api_key_uuid` request attribute** — `ApiKeyAuthenticationProvider` now also sets the
  acting key's own uuid (alongside `api_key_scopes`), so callers can attribute an action to the
  specific API key (audit, rate-limit keying) without re-reading the `api_keys` table.
- **Extensions: `ServiceProvider::resetLoadedRoutes()`** — resets the process-global
  loaded-routes latch so a fresh `Framework::boot()` in the same process re-registers route files
  (the latch otherwise silently skips extension routes after the first boot — e.g. across test boots).

### Fixed
- **Routing: `AuthMiddleware` now always populates `auth.user`.** After a successful auth it
  synthesises a basic `UserIdentity` (uuid, roles, scopes, email/username/status) when the optional
  enricher (`auth_to_request`) has not set one, so `auth.user` is never silently null. Previously a
  route running `auth` without the enricher left `auth.user` unset — silently fail-closing permission
  gates that read it and dropping actor/audit attribution.
- **Routing: `RequireScopeMiddleware` now enforces file-defined routes.** It only read the
  `#[RequireScope]` attribute config and fell **open** when absent, so a route declaring its scope
  as a middleware param (`->middleware('require_scope:read:content')`) got no enforcement. It now
  falls back to the middleware params (a single any-of group) and enforces them **fail-closed**.
- **Database: `TableBuilder` now applies column drops.** `executeAlterations()` did not forward
  `drop_columns` to the SQL generator, so `dropColumn()` during `alterTable()` was a silent no-op.