### PR TITLE
Release 1.65.2 — FieldSelector tolerates array-valued query params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.65.2] - 2026-07-02 — Acrux
+
+### Fixed
+- **FieldSelection: array-valued `fields`/`expand` query params no longer 500.** `FieldSelector::fromRequest()`
+  and `fromRequestAdvanced()` read `fields`/`expand` via `Request::query->get()`, which — since Symfony
+  HttpFoundation's `InputBag` non-scalar guard — throws a `BadRequestException` when the parameter is sent
+  as an array (e.g. `?fields[]=a&fields[]=b`). On a public endpoint that builds its selector from the
+  request (a delivery/read API), that surfaced as an unhandled **500**. Field selection is inherently a
+  scalar syntax, so both factories now read via `query->all()` and treat any non-string value as absent —
+  landing on the existing "no field selection" fast path instead of throwing. Scalar `fields`/`expand`
+  parse exactly as before.
+
 ## [1.65.1] - 2026-07-01 — Acrux
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,14 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.65.2 — Acrux (Patch, Released 2026-07-02)
+- **Array-valued `fields`/`expand` query params no longer 500.** `FieldSelector::fromRequest()` /
+  `fromRequestAdvanced()` read those params through `query->all()` and treat a non-string value as
+  absent, instead of letting Symfony `InputBag`'s non-scalar guard throw a `BadRequestException`
+  (an unhandled 500 on public read/delivery endpoints when a client sends `?fields[]=a`). Scalar
+  `fields`/`expand` parse exactly as before.
+- Notes: **Patch release** — bugfix only, no new env, no migrations, no behavioral changes.
+
 ### 1.65.1 — Acrux (Patch, Released 2026-07-01)
 - **`extensions:enable`/`disable` no longer leave a trailing-whitespace line** in
   `config/extensions.php`. `ExtensionStateWriter::writeList()` re-emitted a literal indent in front

--- a/src/Support/FieldSelection/FieldSelector.php
+++ b/src/Support/FieldSelection/FieldSelector.php
@@ -40,8 +40,8 @@ final class FieldSelector
         $metrics = FieldSelectionMetrics::getInstance();
         $cache = new FieldTreeCache();
 
-        $fields = $request->query->get('fields');
-        $expand = $request->query->get('expand');
+        $fields = self::stringQueryParam($request, 'fields');
+        $expand = self::stringQueryParam($request, 'expand');
 
         // Fast path: no field selection
         if ($fields === null && $expand === null) {
@@ -66,7 +66,7 @@ final class FieldSelector
         // GraphQL style uses nested parentheses like: user(id,name,posts(title))
         // REST style with transformations uses: id,name:format(Y-m-d),price:currency(USD)
         $isGraphQLStyle = $fields !== null && $fields !== '' &&
-                         preg_match('/\w+\s*\([^)]*\s*\w+\s*\([^)]*\)/', (string)$fields);
+                         preg_match('/\w+\s*\([^)]*\s*\w+\s*\([^)]*\)/', $fields);
 
         if ($isGraphQLStyle) {
             // GraphQL-style syntax detected
@@ -122,8 +122,8 @@ final class FieldSelector
         int $maxFields = 200,
         int $maxItems = 1000
     ): self {
-        $fields = $request->query->get('fields');
-        $expand = $request->query->get('expand');
+        $fields = self::stringQueryParam($request, 'fields');
+        $expand = self::stringQueryParam($request, 'expand');
 
         // Fast path: no field selection
         if ($fields === null && $expand === null) {
@@ -132,7 +132,7 @@ final class FieldSelector
 
         // Parse based on syntax detection
         $isGraphQLStyle = $fields !== null && $fields !== '' &&
-                         preg_match('/\w+\s*\([^)]*\s*\w+\s*\([^)]*\)/', (string)$fields);
+                         preg_match('/\w+\s*\([^)]*\s*\w+\s*\([^)]*\)/', $fields);
 
         if ($isGraphQLStyle) {
             $tree = (new GraphQLProjectionParser())->parse((string)$fields);
@@ -146,6 +146,22 @@ final class FieldSelector
         }
 
         return new self($tree, $strict, $maxDepth, $maxFields, $maxItems);
+    }
+
+    /**
+     * Read a query parameter as a string, tolerating malformed array-valued params.
+     *
+     * Symfony's InputBag::get() throws a BadRequestException when a query parameter is sent as an
+     * array (e.g. `?fields[]=a`), which — on an unauthenticated delivery endpoint — surfaces as an
+     * unhandled 500. Field selection is inherently a scalar syntax, so an array value is simply not
+     * a selection: read via all() and treat any non-string value as absent (null), which lands on
+     * the existing "no field selection" fast path rather than throwing.
+     */
+    private static function stringQueryParam(Request $request, string $key): ?string
+    {
+        $value = $request->query->all()[$key] ?? null;
+
+        return is_string($value) ? $value : null;
     }
 
     public function empty(): bool

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,7 +13,7 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.65.1';
+    public const VERSION = '1.65.2';
 
 
     /** Release code name */
@@ -21,7 +21,7 @@ final class Version
 
 
     /** Release date */
-    public const RELEASE_DATE = '2026-07-01';
+    public const RELEASE_DATE = '2026-07-02';
 
     /** Minimum required PHP version */
     public const MIN_PHP_VERSION = '8.3.0';

--- a/tests/Unit/Support/FieldSelection/FieldSelectorRequestTest.php
+++ b/tests/Unit/Support/FieldSelection/FieldSelectorRequestTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Support\FieldSelection;
+
+use Glueful\Support\FieldSelection\FieldSelector;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @covers \Glueful\Support\FieldSelection\FieldSelector
+ */
+final class FieldSelectorRequestTest extends TestCase
+{
+    public function testArrayValuedFieldsParamIsTreatedAsNoSelectionInsteadOfThrowing(): void
+    {
+        // ?fields[]=a&fields[]=b — Symfony's InputBag::get() would throw a BadRequestException here.
+        // Field selection is a scalar syntax, so an array value is simply not a selection.
+        $request = new Request(['fields' => ['a', 'b']]);
+
+        $selector = FieldSelector::fromRequest($request);
+
+        self::assertTrue($selector->empty());
+    }
+
+    public function testArrayValuedExpandParamIsTreatedAsNoSelection(): void
+    {
+        $request = new Request(['expand' => ['posts']]);
+
+        $selector = FieldSelector::fromRequest($request);
+
+        self::assertTrue($selector->empty());
+    }
+
+    public function testArrayValuedParamDoesNotThrowOnAdvancedFactory(): void
+    {
+        $request = new Request(['fields' => ['a'], 'expand' => ['b']]);
+
+        $selector = FieldSelector::fromRequestAdvanced($request);
+
+        self::assertTrue($selector->empty());
+    }
+
+    public function testScalarFieldsParamStillParsesNormally(): void
+    {
+        $request = new Request(['fields' => 'id,name']);
+
+        $selector = FieldSelector::fromRequest($request);
+
+        self::assertFalse($selector->empty());
+        self::assertTrue($selector->requested('id'));
+        self::assertTrue($selector->requested('name'));
+    }
+
+    public function testNoParamsIsEmptySelection(): void
+    {
+        $selector = FieldSelector::fromRequest(new Request());
+
+        self::assertTrue($selector->empty());
+    }
+}


### PR DESCRIPTION
FieldSelector::fromRequest()/fromRequestAdvanced() read fields/expand via query->all() and treat a non-string value as absent, instead of letting Symfony InputBag's non-scalar guard throw a BadRequestException — which, on a public endpoint that builds its selector from the request, surfaced as an unhandled 500 when a client sent ?fields[]=a. Scalar fields/expand parse exactly as before.
