### PR TITLE
Release 1.65.3 — RandomStringGenerator buffer overrun + static-asset MIME types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.65.3] - 2026-07-03 — Acrux
+
+### Fixed
+- **Security: `RandomStringGenerator::generate()` could read past its random-byte buffer.** The
+  rejection-sampling inner loop (`while ($idx >= $charsetLength)`) consumes bytes but had no refill
+  guard — only the outer loop refills — so rejections clustering at the buffer end walked past it
+  ("Uninitialized string offset N"). Inherently flaky (~1% per 16-char generate with a 79-char
+  charset), it surfaced as intermittent CI failures in consumers generating passwords
+  (`csv_user_import_failed`). Quieter correctness angle: outside strict error handling, `ord('')`
+  returns 0 — silently biasing generated secrets toward the charset's first character. The inner
+  loop now refills before reading; a regression test hammers the worst-case charset (65 chars,
+  ~49% rejection) with warnings escalated.
+- **Extensions: static assets served via `serveFrontend()` no longer get content-sniffed MIME
+  types.** `frontendAssetServer()` asked Symfony's `MimeTypes::guessMimeType()` first, which
+  content-sniffs via finfo — and CSS/JS carry no magic bytes, so finfo answers `text/plain`. Since
+  the same response sends `X-Content-Type-Options: nosniff`, browsers are REQUIRED to refuse the
+  stylesheet/module script outright (broken theme CSS on any `serveFrontend` mount, including
+  admin SPA bundles). The extension map now wins for known extensions (`css` → `text/css`);
+  sniffing remains the fallback for extensionless files.
+
 ## [1.65.2] - 2026-07-02 — Acrux
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,19 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.65.3 — Acrux (Patch, Released 2026-07-03)
+- **`RandomStringGenerator::generate()` no longer reads past its random-byte buffer.** The
+  rejection-sampling inner loop consumed bytes without a refill guard; rejections clustering at
+  the buffer end walked past it ("Uninitialized string offset N") — an inherently flaky failure
+  in consumers generating passwords, and a quiet bias risk (`ord('')` = 0 favors the charset's
+  first character). The inner loop now refills before reading, with a worst-case-charset
+  regression test.
+- **`serveFrontend()` static assets get extension-mapped MIME types.** Content sniffing called
+  CSS/JS `text/plain` (no magic bytes), and the accompanying `nosniff` header made browsers
+  refuse them outright. Extension map first (`css` → `text/css`); sniffing only for
+  extensionless files.
+- Notes: **Patch release** — bugfix only, no new env, no migrations, no behavioral changes.
+
 ### 1.65.2 — Acrux (Patch, Released 2026-07-02)
 - **Array-valued `fields`/`expand` query params no longer 500.** `FieldSelector::fromRequest()` /
   `fromRequestAdvanced()` read those params through `query->all()` and treat a non-string value as

--- a/src/Extensions/ServiceProvider.php
+++ b/src/Extensions/ServiceProvider.php
@@ -354,8 +354,16 @@ abstract class ServiceProvider
             $etag = md5_file($realPath) !== false ? md5_file($realPath) : sha1($realPath);
 
             $guesser = \Symfony\Component\Mime\MimeTypes::getDefault();
+            // Extension map FIRST: content sniffing cannot identify text formats
+            // (css/js/svg carry no magic bytes — finfo calls them text/plain), and
+            // these responses send X-Content-Type-Options: nosniff, so a wrong
+            // type makes browsers REFUSE stylesheets and module scripts outright.
+            // Sniffing remains the fallback for extensionless files.
+            $ext = strtolower(pathinfo($realPath, PATHINFO_EXTENSION));
+            $byExtension = $ext !== '' ? ($guesser->getMimeTypes($ext)[0] ?? null) : null;
             $mimeGuess = mime_content_type($realPath);
-            $mime = $guesser->guessMimeType($realPath)
+            $mime = $byExtension
+                ?? $guesser->guessMimeType($realPath)
                 ?? ($mimeGuess !== false ? $mimeGuess : 'application/octet-stream');
 
             $resp = new \Symfony\Component\HttpFoundation\BinaryFileResponse($realPath);

--- a/src/Security/RandomStringGenerator.php
+++ b/src/Security/RandomStringGenerator.php
@@ -72,8 +72,15 @@ class RandomStringGenerator
             $idx = ord($bytes[$pos]) & $mask;
             $pos++;
 
-            // If index is beyond charset length, get another one
+            // If index is beyond charset length, get another one. This loop
+            // consumes bytes too, so it needs its own refill guard: rejections
+            // clustering at the buffer end otherwise read past it
+            // ("Uninitialized string offset" — and ord('') would silently bias
+            // the output toward charset[0]).
             while ($idx >= $charsetLength) {
+                if ($pos >= strlen($bytes)) {
+                    $bytes .= random_bytes(32);
+                }
                 $idx = ord($bytes[$pos]) & $mask;
                 $pos++;
             }

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,7 +13,7 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.65.2';
+    public const VERSION = '1.65.3';
 
 
     /** Release code name */
@@ -21,7 +21,7 @@ final class Version
 
 
     /** Release date */
-    public const RELEASE_DATE = '2026-07-02';
+    public const RELEASE_DATE = '2026-07-03';
 
     /** Minimum required PHP version */
     public const MIN_PHP_VERSION = '8.3.0';

--- a/tests/Integration/Extensions/ServeFrontendTest.php
+++ b/tests/Integration/Extensions/ServeFrontendTest.php
@@ -136,6 +136,23 @@ class ServeFrontendTest extends TestCase
         self::assertStringContainsString('no-cache', (string) $resp->headers->get('Cache-Control'));
     }
 
+    public function testTextAssetsGetExtensionMimeNotSniffedTextPlain(): void
+    {
+        // finfo content-sniffing calls css/js "text/plain" (no magic bytes), and
+        // these responses carry X-Content-Type-Options: nosniff — so a wrong
+        // type makes browsers REFUSE stylesheets/module scripts outright. The
+        // extension map must win for known extensions; sniffing is only the
+        // fallback for extensionless files.
+        [$routes] = $this->mount('/admin', $this->dir);
+        $css = $routes['/admin/{rest}'](Request::create('/admin/style.css'), 'style.css');
+        self::assertSame('text/css', $css->headers->get('Content-Type'));
+        $js = $routes['/admin/{rest}'](
+            Request::create('/admin/assets/app-C5kJ8nQ2.js'),
+            'assets/app-C5kJ8nQ2.js',
+        );
+        self::assertStringContainsString('javascript', (string) $js->headers->get('Content-Type'));
+    }
+
     public function testHashedAssetServedImmutable(): void
     {
         [$routes] = $this->mount('/admin', $this->dir);

--- a/tests/Unit/Security/RandomStringGeneratorTest.php
+++ b/tests/Unit/Security/RandomStringGeneratorTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Security;
+
+use Glueful\Security\RandomStringGenerator;
+use PHPUnit\Framework\TestCase;
+
+class RandomStringGeneratorTest extends TestCase
+{
+    public function testGeneratesRequestedLengthFromCharset(): void
+    {
+        $out = RandomStringGenerator::generate(24, 'abc123');
+        self::assertSame(24, strlen($out));
+        self::assertMatchesRegularExpression('/\A[abc123]{24}\z/', $out);
+    }
+
+    /**
+     * Regression: the rejection-sampling inner loop read past the random-byte
+     * buffer when rejections clustered at its end ("Uninitialized string
+     * offset 32" — flaky, surfaced as csv_user_import_failed in CI). A 65-char
+     * charset maximizes the rejection rate (mask 127 -> ~49% per draw); with
+     * the bug, thousands of short generates trip the overrun essentially
+     * every run. Warnings are escalated so the overrun cannot pass silently
+     * (ord('') would otherwise just bias output toward charset[0]).
+     */
+    public function testRejectionSamplingNeverReadsPastTheByteBuffer(): void
+    {
+        $charset = implode('', array_map('chr', range(48, 112))); // 65 chars
+        set_error_handler(static function (int $severity, string $message): bool {
+            throw new \ErrorException($message, 0, $severity);
+        });
+        try {
+            for ($i = 0; $i < 20000; $i++) {
+                $out = RandomStringGenerator::generate(16, $charset);
+                self::assertSame(16, strlen($out));
+            }
+        } finally {
+            restore_error_handler();
+        }
+    }
+}


### PR DESCRIPTION
RandomStringGenerator::generate()'s rejection-sampling inner loop consumed random bytes without a refill guard: rejections clustering at the buffer end read past it ("Uninitialized string offset N") — an inherently flaky failure in consumers generating passwords, and a quiet bias risk since ord('') returns 0. The inner loop now refills before reading, with a worst-case charset regression test.

serveFrontend() assets asked Symfony's content-sniffing MIME guesser first; CSS/JS have no magic bytes, so finfo answered text/plain — and the nosniff header these responses carry makes browsers refuse such stylesheets and module scripts outright. The extension map now wins for known extensions; sniffing remains the fallback for extensionless files.
