### PR TITLE
Release 1.66.0 — Adhara: extension installer + SVG upload fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -127,6 +127,12 @@ CACHE_DRIVER=file    # file, redis, memcached, array
 CACHE_PREFIX=glueful:
 CACHE_TTL=3600
 
+# Extensions installer (in-admin composer require via the /extensions API).
+# Off in production unless EXTENSIONS_INSTALL_ENABLED is set.
+EXTENSIONS_INSTALL_ENABLED=
+EXTENSIONS_INSTALL_AUTO_ENABLE=true
+EXTENSIONS_INSTALL_TIMEOUT=600
+
 # Queue Configuration
 QUEUE_CONNECTION=database    # database, redis, sync, null
 QUEUE_PROCESS_ENABLED=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,54 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.66.0] - 2026-07-05 — Adhara
+
+### Added
+- **Extensions: install a Glueful extension from the admin UI, no SSH required.** A new
+  install pipeline lets an operator run `composer require` for a catalog extension from the
+  browser instead of the server terminal. `ExtensionInstaller::start()` validates the package
+  (catalog-membership allowlist + `glueful/` vendor prefix, no shell), then spawns a **detached**
+  `composer require` via `extensions:install-run` (`proc_open` with array argv + `setsid`, so it
+  survives an FPM recycle); on success it auto-enables the extension in a **fresh PHP subprocess**
+  (`extensions:enable-installed`) to sidestep the running worker's stale autoloader, then writes
+  the extension cache. Progress is polled through a `CacheStore`-backed `InstallJobStore`
+  (status enum `queued|running|succeeded|failed|installed_not_enabled`, 64 KB output cap). New
+  building blocks: `src/Extensions/Install/` (`ExtensionInstaller`, `InstallJobStore`,
+  `HostCapability`, and `InstallDisabled`/`PackageNotAllowed`/`HostNotWritable` exceptions),
+  `src/Support/Process/` (`DetachedRunner`, `ComposerBinaryResolver`, `ProcessRunner` +
+  `SymfonyProcessRunner`), `ExtensionCatalog` (two-stage Packagist fetch filtered to
+  `type=glueful-extension`), and a batteries-included `ExtensionsController` at
+  `/api/v1/extensions` (index / catalog / install / install-status / enable / disable),
+  registered in `CoreProvider`.
+- **Security guardrails on the install path.** Guarded by the `system.config` permission tier and
+  the `EXTENSIONS_INSTALL_ENABLED` kill-switch (off in production by default); a host-writability
+  preflight returns `409` on a read-only deploy; the package must be a member of the resolved
+  Packagist catalog (not a substring match). Every install is audited via the injected logger.
+
+### Fixed
+- **Uploads: SVG (and any type the app's allowlist permits) no longer 400s on the content check.**
+  `FileUploader::validateFileContent()` re-checked the detected mime against the hard-coded
+  `DEFAULT_ALLOWED_MIME_TYPES` constant, overruling the configured `uploads.allowed_types` that
+  `validateMimeType()` had already honored — so `image/svg+xml` passed the claimed-mime gate under
+  `image/*` and then failed content validation ("Invalid file type"). The content check now uses the
+  same configured allowlist (wildcards included; unconfigured installs still fall back to the
+  default constant), and the extension→mime map learned `svg` → `image/svg+xml`. Safety posture
+  unchanged: SVG stays out of `isSafeInlineMime` (served as attachment, never inline) and the
+  hazard scan still rejects `<script>`-bearing payloads — both regression-tested.
+
+### Upgrade Notes
+- **New env vars for the extension installer** (all optional; safe defaults):
+  - `EXTENSIONS_INSTALL_ENABLED` — master kill-switch. **Defaults to on outside production and off
+    in production** (`APP_ENV=production`). Leave unset unless you want to override that default.
+  - `EXTENSIONS_INSTALL_AUTO_ENABLE` (default `true`) — auto-enable an extension right after a
+    successful install.
+  - `EXTENSIONS_INSTALL_TIMEOUT` (default `600`) — seconds before a `composer require` run is
+    considered timed out.
+- No migrations, no config file is required to change — the new `install` block in
+  `config/extensions.php` ships with working defaults. To expose the installer in production you
+  must explicitly set `EXTENSIONS_INSTALL_ENABLED=true` and ensure the deploy's vendor/ tree is
+  writable by the web user.
+
 ## [1.65.3] - 2026-07-03 — Acrux
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,24 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.66.0 — Adhara (Minor, Released 2026-07-05)
+- **Install extensions from the admin UI, no SSH.** A new install pipeline runs `composer require`
+  for a catalog extension from the browser: `ExtensionInstaller` validates the package against the
+  Packagist catalog (allowlist + `glueful/` vendor prefix, no shell), spawns a **detached**
+  `composer require` (`proc_open` + array argv + `setsid`, survives FPM recycles), then auto-enables
+  in a **fresh PHP subprocess** to dodge the running worker's stale autoloader and rewrites the
+  extension cache. Progress polls a `CacheStore`-backed job store. Ships `src/Extensions/Install/`,
+  `src/Support/Process/`, `ExtensionCatalog`, and a batteries-included `ExtensionsController` at
+  `/api/v1/extensions`.
+- **Guardrails:** `system.config` permission tier, `EXTENSIONS_INSTALL_ENABLED` kill-switch (off in
+  production by default), host-writability preflight (`409` on read-only deploys), catalog-membership
+  allowlist, and per-install audit logging.
+- **SVG uploads no longer 400 on the content check.** `FileUploader::validateFileContent()` now honors
+  the configured `uploads.allowed_types` allowlist (wildcards included) instead of the hard-coded
+  default constant; safety posture unchanged (SVG served as attachment, `<script>` payloads rejected).
+- Notes: **Minor release** — adds three optional `EXTENSIONS_INSTALL_*` env vars with safe defaults;
+  no migrations, no breaking changes.
+
 ### 1.65.3 — Acrux (Patch, Released 2026-07-03)
 - **`RandomStringGenerator::generate()` no longer reads past its random-byte buffer.** The
   rejection-sampling inner loop consumed bytes without a refill guard; rejections clustering at

--- a/config/extensions.php
+++ b/config/extensions.php
@@ -19,4 +19,17 @@ return [
     'enabled' => [
         // 'Glueful\\Extensions\\Aegis\\Services\\AegisServiceProvider',
     ],
+
+    /**
+     * In-admin extension installer (composer require via the /extensions API).
+     * Off in production unless EXTENSIONS_INSTALL_ENABLED is explicitly set.
+     * Keep env() reads here — NOT inside `enabled` above (that must stay a
+     * literal list the enable/disable writer can edit).
+     */
+    'install' => [
+        'enabled'     => env('EXTENSIONS_INSTALL_ENABLED', env('APP_ENV') !== 'production'),
+        'auto_enable' => (bool) env('EXTENSIONS_INSTALL_AUTO_ENABLE', true),
+        'timeout'     => (int) env('EXTENSIONS_INSTALL_TIMEOUT', 600),
+        'vendor'      => 'glueful/',
+    ],
 ];

--- a/docs/superpowers/plans/2026-07-05-extensions-manager.md
+++ b/docs/superpowers/plans/2026-07-05-extensions-manager.md
@@ -1,0 +1,1630 @@
+# Extensions Manager Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an in-admin extension installer — a framework-core `/extensions/*` API to browse (Packagist), install (`composer require`, detached), and enable/disable Glueful extensions, plus the Thallo admin UI that consumes it.
+
+**Architecture:** Framework-core HTTP surface (`ExtensionsController` + `routes/extensions.php`) over reusable seams (`PackageManifest`, `EnabledProviders`, `ExtensionResolver`, `ExtensionStateWriter`, `ExtensionManager::writeCacheNow()`). Install runs `composer require` in a **detached** OS process (`proc_open`, argv array, `setsid` on POSIX) whose status lands in `CacheStore`; the autoload-sensitive enable+cache step runs in a **fresh PHP subprocess**. Thallo builds the page as an `authFetch` consumer.
+
+**Tech Stack:** PHP 8.3, Symfony Process/Console, `Glueful\Http\Client` (symfony/http-client), `Glueful\Cache\CacheStore`, Vue 3 + Nuxt UI + vitest (Thallo).
+
+**Spec:** `docs/superpowers/specs/2026-07-05-extensions-manager-design.md`
+
+## Global Constraints
+
+- **No shell.** Every external command uses an **argv array**. Outer detached spawn = `proc_open` with an array command. Inner blocking runs (composer, fresh enable) = Symfony `Process` with an array command. `shell_exec`/concatenated command strings are forbidden.
+- **String-command fallback is guarded.** `proc_open` uses array argv on all supported PHP (8.3+). If a platform ever needs a string command, it MUST be built by mapping `escapeshellarg()` over **every** argv segment (`DetachedRunner::toShellCommand()`), and that helper MUST stay covered by a unit test.
+- **Permission tier:** mutating endpoints require `system.config.edit`; read endpoints require `system.config.view` (via `AuthorizationTrait`).
+- **Kill-switch:** `config('extensions.install.enabled')` — default `APP_ENV !== 'production'`. When off, mutating endpoints return `403`.
+- **Host capability:** install checks writability of `vendor/`, `composer.json`, `composer.lock`, `config/extensions.php`, `bootstrap/cache/` (+ composer binary); enable/disable check `config/extensions.php` + `bootstrap/cache/`. Failure → `409 { reason }`.
+- **Allowlist:** a package is installable only if it is in the fetched, type-verified Packagist catalog (vendor `glueful/`, `type: glueful-extension`); plus a name-grammar check that rejects non-`glueful/`, flag-like (`-…`), or malformed names before composer sees them.
+- **Audit:** `LogManager->channel('audit')->info(...)` with `{ action, actor_id, resource_type:'extension', resource_id, result, duration_ms }`.
+- **Framework version constant:** `Glueful\Support\Version::VERSION`.
+- **Work on `dev` directly. No feature branch. Commit at phase boundaries (not per task). No attribution trailers in commit messages. Do not stage `CLAUDE.md`.**
+
+---
+
+## File Structure
+
+**Framework** (`/Users/michaeltawiahsowah/Sites/glueful/framework`):
+- `config/extensions.php` — add `install` block (Task 1)
+- `.env.example` — add `EXTENSIONS_INSTALL_*` keys (Task 1)
+- `src/Support/Process/ComposerBinaryResolver.php` — single composer-binary source, shared by preflight + runner (Task 2)
+- `src/Extensions/Install/HostCapability.php` — writability + composer probe (Task 2)
+- `src/Extensions/Install/InstallJobStore.php` — CacheStore-backed job status (Task 3)
+- `src/Support/Process/DetachedRunner.php` — detached spawn + escape guard (Task 4)
+- `src/Support/Process/ProcessRunner.php` + `SymfonyProcessRunner.php` — testable blocking runner (Task 5)
+- `src/Console/Commands/Extensions/EnableInstalledCommand.php` — fresh-process enabler (Task 5)
+- `src/Console/Commands/Extensions/InstallRunCommand.php` — the detached runner (Task 6)
+- `src/Extensions/ExtensionCatalog.php` — Packagist fetch/hydrate + state (Task 7)
+- `src/Extensions/Install/ExtensionInstaller.php` + install exceptions (Task 8)
+- `src/DTOs/ExtensionInstallData.php`, `src/DTOs/ExtensionToggleData.php` (Task 9)
+- `src/Controllers/ExtensionsController.php` — repurpose the unrouted controller (Task 10)
+- `src/Container/Providers/CoreProvider.php` — register services (Task 10)
+- `routes/extensions.php` + `src/Routing/RouteManifest.php` (Task 11)
+
+**Thallo** (`/Users/michaeltawiahsowah/Sites/glueful/lemma`) — separable follow-on phase:
+- `admin/src/queries/extensions.ts` (Task 12)
+- `admin/src/pages/developers/extensions/index.vue` (Task 13)
+- `admin/src/__tests__/extensionsPage.spec.ts` (Task 14)
+
+---
+
+## Phase 1 — Foundations
+
+### Task 1: `install` config block + env keys
+
+**Files:**
+- Modify: `config/extensions.php`
+- Modify: `.env.example`
+
+**Interfaces:**
+- Produces: config keys `extensions.install.{enabled,auto_enable,timeout,vendor}`.
+
+- [ ] **Step 1: Add the `install` block to `config/extensions.php`** (keep `enabled` a pure literal list — the file's doc comment forbids `env()` inside it; put reads in the sibling key):
+
+```php
+return [
+    'enabled' => [
+        // ... existing literal FQCN list, untouched ...
+    ],
+    'install' => [
+        'enabled'     => env('EXTENSIONS_INSTALL_ENABLED', env('APP_ENV') !== 'production'),
+        'auto_enable' => (bool) env('EXTENSIONS_INSTALL_AUTO_ENABLE', true),
+        'timeout'     => (int) env('EXTENSIONS_INSTALL_TIMEOUT', 600),
+        'vendor'      => 'glueful/',
+    ],
+];
+```
+
+- [ ] **Step 2: Append documented keys to `.env.example`** (near other feature flags):
+
+```dotenv
+# Extensions installer (in-admin composer require). Off in production unless set.
+EXTENSIONS_INSTALL_ENABLED=
+EXTENSIONS_INSTALL_AUTO_ENABLE=true
+EXTENSIONS_INSTALL_TIMEOUT=600
+```
+
+- [ ] **Step 3: Verify config loads** — Run: `php glueful config:show extensions.install` (or `php -r` bootstrap). Expected: array with `enabled`, `auto_enable`, `timeout`, `vendor` keys; no fatal.
+
+*(No commit yet — commit at end of Phase 1.)*
+
+---
+
+### Task 2: `HostCapability` service
+
+**Files:**
+- Create: `src/Extensions/Install/HostCapability.php`
+- Test: `tests/Unit/Extensions/Install/HostCapabilityTest.php`
+
+**Interfaces:**
+- Produces:
+  - `ComposerBinaryResolver::resolve(): ?string` — the **single** source of the composer binary (honors `COMPOSER_BINARY`), reused by preflight AND the runner.
+  - `HostCapability::__construct(ApplicationContext $context, ComposerBinaryResolver $composer)`
+  - `forInstall(): ?array` — `null` when OK, else `['reason' => string, 'detail' => string]`
+  - `forToggle(): ?array` — same shape
+  - `composerBinary(): ?string` — delegates to the resolver
+
+- [ ] **Step 1: Write the failing tests** — a read-only *existing* path, AND (P1 fix) a **missing** path under a read-only parent:
+
+```php
+namespace Glueful\Tests\Unit\Extensions\Install;
+
+use Glueful\Extensions\Install\HostCapability;
+use Glueful\Support\Process\ComposerBinaryResolver;
+use PHPUnit\Framework\TestCase;
+
+final class HostCapabilityTest extends TestCase
+{
+    public function test_flags_a_readonly_existing_path(): void
+    {
+        $dir = $this->tempDir(0555);            // read+execute, not writable
+        $cap = new HostCapability(FakeContext::withBasePath($dir), new ComposerBinaryResolver());
+        $result = $cap->forToggle();
+        $this->assertSame('read_only_filesystem', $result['reason']);
+    }
+
+    public function test_flags_missing_vendor_under_unwritable_base(): void
+    {
+        // base exists but is read-only; vendor/ and composer.lock do NOT exist yet.
+        $base = $this->tempDir(0555);
+        $cap = new HostCapability(FakeContext::withBasePath($base), new ComposerBinaryResolver());
+        $result = $cap->forInstall();           // would `composer require` into a read-only base
+        $this->assertIsArray($result, 'missing vendor/composer.lock under a read-only base must fail preflight');
+        $this->assertSame('read_only_filesystem', $result['reason']);
+    }
+}
+```
+*(`FakeContext` is a tiny in-test double whose `base_path()`/`config_path()` return under a temp dir — reuse the suite's context helper if one exists; else add a minimal fake. `tempDir($mode)` mkdirs a unique temp dir with the given mode and registers teardown cleanup that chmods 0755 first.)*
+
+- [ ] **Step 2: Run it to verify it fails** — Run: `vendor/bin/phpunit tests/Unit/Extensions/Install/HostCapabilityTest.php` → FAIL (class not found / missing-path case not handled).
+
+- [ ] **Step 3a: Create the shared `ComposerBinaryResolver`** (both preflight and the runner MUST use this — never a second `ExecutableFinder` call):
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace Glueful\Support\Process;
+
+use Symfony\Component\Process\ExecutableFinder;
+
+final class ComposerBinaryResolver
+{
+    /** Honors COMPOSER_BINARY, else finds `composer` on PATH. Null when absent. */
+    public function resolve(): ?string
+    {
+        $candidate = getenv('COMPOSER_BINARY') ?: 'composer';
+        // Absolute/relative explicit path → accept if executable; else search PATH.
+        if (str_contains($candidate, '/') && is_executable($candidate)) {
+            return $candidate;
+        }
+        return (new ExecutableFinder())->find($candidate) ?? null;
+    }
+}
+```
+
+- [ ] **Step 3b: Implement `HostCapability`** — delegate composer resolution, and (P1 fix) check the path if it exists, otherwise the **nearest existing ancestor** (the directory the file/dir would be created in):
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Install;
+
+use Glueful\Bootstrap\ApplicationContext;
+use Glueful\Support\Process\ComposerBinaryResolver;
+
+final class HostCapability
+{
+    public function __construct(
+        private ApplicationContext $context,
+        private ComposerBinaryResolver $composer,
+    ) {}
+
+    /** @return array{reason:string,detail:string}|null null = installable */
+    public function forInstall(): ?array
+    {
+        if ($this->composerBinary() === null) {
+            return ['reason' => 'composer_missing', 'detail' => 'composer binary not found on PATH'];
+        }
+        return $this->firstUnwritable($this->installPaths());
+    }
+
+    /** @return array{reason:string,detail:string}|null null = toggleable */
+    public function forToggle(): ?array
+    {
+        return $this->firstUnwritable($this->togglePaths());
+    }
+
+    public function composerBinary(): ?string
+    {
+        return $this->composer->resolve();
+    }
+
+    /** @return list<string> */
+    private function installPaths(): array
+    {
+        return [
+            base_path($this->context, 'vendor'),
+            base_path($this->context, 'composer.json'),
+            base_path($this->context, 'composer.lock'),
+            config_path($this->context, 'extensions.php'),
+            base_path($this->context, 'bootstrap/cache'),
+        ];
+    }
+
+    /** @return list<string> */
+    private function togglePaths(): array
+    {
+        return [
+            config_path($this->context, 'extensions.php'),
+            base_path($this->context, 'bootstrap/cache'),
+        ];
+    }
+
+    /**
+     * @param list<string> $paths
+     * @return array{reason:string,detail:string}|null
+     */
+    private function firstUnwritable(array $paths): ?array
+    {
+        foreach ($paths as $path) {
+            // Check the path itself if present; otherwise the nearest existing
+            // ancestor — the dir the tool will create the file/dir in. A missing
+            // vendor/composer.lock under a read-only base MUST fail here.
+            if (!is_writable($this->writabilityTarget($path))) {
+                return ['reason' => 'read_only_filesystem', 'detail' => $path];
+            }
+        }
+        return null;
+    }
+
+    private function writabilityTarget(string $path): string
+    {
+        $current = $path;
+        while (!file_exists($current)) {
+            $parent = dirname($current);
+            if ($parent === $current) {
+                return $current; // reached filesystem root
+            }
+            $current = $parent;
+        }
+        return $current;
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass** — Run: `vendor/bin/phpunit tests/Unit/Extensions/Install/HostCapabilityTest.php` → PASS (both the existing-readonly and missing-under-readonly cases).
+
+---
+
+### Task 3: `InstallJobStore`
+
+**Files:**
+- Create: `src/Extensions/Install/InstallJobStore.php`
+- Test: `tests/Unit/Extensions/Install/InstallJobStoreTest.php`
+
+**Interfaces:**
+- Consumes: `Glueful\Cache\CacheStore` (container id `cache.store`).
+- Produces:
+  - `create(string $package): string` (jobId)
+  - `get(string $jobId): ?array`
+  - `markRunning(string $jobId): void`
+  - `appendOutput(string $jobId, string $chunk): void`
+  - `finish(string $jobId, string $status, ?int $exitCode = null, ?string $error = null, ?string $enableError = null): void`
+  - Record: `{ id, package, status, output, exitCode, error, enableError, startedAt, finishedAt }`
+  - **Status values:** `queued | running | succeeded | failed | installed_not_enabled` — `succeeded` = composer installed AND enabled (or auto-enable off, no error); `installed_not_enabled` = composer installed but auto-enable failed (`enableError` set); `failed` = composer/spawn failed.
+
+- [ ] **Step 1: Write the failing test** (backed by an in-memory `CacheStore` fake / array driver):
+
+```php
+public function test_lifecycle_create_run_finish(): void
+{
+    $store = new InstallJobStore(new ArrayCacheStore());
+    $id = $store->create('glueful/aegis');
+    $this->assertSame('queued', $store->get($id)['status']);
+
+    $store->markRunning($id);
+    $store->appendOutput($id, "Resolving...\n");
+    $store->appendOutput($id, "Installing glueful/aegis\n");
+    $this->assertSame('running', $store->get($id)['status']);
+    $this->assertStringContainsString('Installing glueful/aegis', $store->get($id)['output']);
+
+    $store->finish($id, 'succeeded', 0, null, null);
+    $rec = $store->get($id);
+    $this->assertSame('succeeded', $rec['status']);
+    $this->assertSame(0, $rec['exitCode']);
+    $this->assertNotNull($rec['finishedAt']);
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails** — FAIL (class not found).
+
+- [ ] **Step 3: Implement `InstallJobStore`**
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Install;
+
+use Glueful\Cache\CacheStore;
+
+final class InstallJobStore
+{
+    private const PREFIX = 'ext_install:';
+    private const TTL = 3600;
+    private const OUTPUT_CAP = 65536; // ~64KB tail
+
+    /** @param CacheStore<mixed> $cache */
+    public function __construct(private CacheStore $cache) {}
+
+    public function create(string $package): string
+    {
+        $id = bin2hex(random_bytes(12));
+        $this->put($id, [
+            'id' => $id, 'package' => $package, 'status' => 'queued',
+            'output' => '', 'exitCode' => null, 'error' => null, 'enableError' => null,
+            'startedAt' => date(DATE_ATOM), 'finishedAt' => null,
+        ]);
+        return $id;
+    }
+
+    /** @return array<string,mixed>|null */
+    public function get(string $jobId): ?array
+    {
+        $rec = $this->cache->get(self::PREFIX . $jobId);
+        return is_array($rec) ? $rec : null;
+    }
+
+    public function markRunning(string $jobId): void
+    {
+        $this->patch($jobId, ['status' => 'running']);
+    }
+
+    public function appendOutput(string $jobId, string $chunk): void
+    {
+        $rec = $this->get($jobId);
+        if ($rec === null) {
+            return;
+        }
+        $out = (string) $rec['output'] . $chunk;
+        if (strlen($out) > self::OUTPUT_CAP) {
+            $out = substr($out, -self::OUTPUT_CAP);
+        }
+        $this->patch($jobId, ['output' => $out]);
+    }
+
+    public function finish(
+        string $jobId,
+        string $status,
+        ?int $exitCode = null,
+        ?string $error = null,
+        ?string $enableError = null,
+    ): void {
+        $this->patch($jobId, [
+            'status' => $status, 'exitCode' => $exitCode,
+            'error' => $error, 'enableError' => $enableError,
+            'finishedAt' => date(DATE_ATOM),
+        ]);
+    }
+
+    /** @param array<string,mixed> $changes */
+    private function patch(string $jobId, array $changes): void
+    {
+        $rec = $this->get($jobId);
+        if ($rec === null) {
+            return;
+        }
+        $this->put($jobId, array_merge($rec, $changes));
+    }
+
+    /** @param array<string,mixed> $rec */
+    private function put(string $jobId, array $rec): void
+    {
+        $this->cache->set(self::PREFIX . $jobId, $rec, self::TTL);
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass** — PASS.
+
+- [ ] **Step 5: Commit Phase 1**
+
+```bash
+git add config/extensions.php .env.example src/Support/Process/ComposerBinaryResolver.php \
+        src/Extensions/Install/HostCapability.php src/Extensions/Install/InstallJobStore.php \
+        tests/Unit/Extensions/Install/
+git commit -m "extensions installer: config, host-capability checks, install job store"
+```
+
+---
+
+## Phase 2 — Process runner (the risky path first)
+
+### Task 4: `DetachedRunner` — true non-blocking spawn
+
+**Files:**
+- Create: `src/Support/Process/DetachedRunner.php`
+- Test: `tests/Unit/Support/Process/DetachedRunnerTest.php`
+
+**Interfaces:**
+- Produces:
+  - `DetachedRunner::__construct(ApplicationContext $context, ?\Closure $spawn = null)` — `$spawn(array $argv, string $cwd, string $log): void` injectable for tests; default wraps `proc_open`.
+  - `spawnInstall(string $jobId, string $package): void`
+  - `buildArgv(string $jobId, string $package): list<string>` (public for assertion)
+  - `static toShellCommand(list<string> $argv): string` — the escaped string-fallback guard.
+
+- [ ] **Step 1: Write the failing tests** — argv build, setsid probe, escape guard, and the **non-blocking** contract:
+
+```php
+public function test_buildArgv_is_pure_array_and_targets_the_runner(): void
+{
+    $r = new DetachedRunner(FakeContext::withBasePath('/srv/app'));
+    $argv = $r->buildArgv('job123', 'glueful/aegis');
+    $this->assertContains('extensions:install-run', $argv);
+    $this->assertContains('glueful/aegis', $argv);
+    $this->assertSame(PHP_BINARY, $argv[array_search('extensions:install-run', $argv) - 2]);
+}
+
+public function test_toShellCommand_escapes_every_segment(): void
+{
+    $s = DetachedRunner::toShellCommand(['php', 'glueful', 'extensions:install-run', 'j', 'a b; rm -rf /']);
+    $this->assertStringContainsString(escapeshellarg('a b; rm -rf /'), $s);
+    $this->assertStringNotContainsString('; rm -rf /', str_replace(escapeshellarg('a b; rm -rf /'), '', $s));
+}
+
+public function test_spawn_returns_immediately_without_waiting(): void
+{
+    $started = null; $returned = null;
+    $spy = function (array $argv, string $cwd, string $log) use (&$started, &$returned): void {
+        $started = microtime(true);      // a real detached spawn would return now
+    };
+    $r = new DetachedRunner(FakeContext::withBasePath(sys_get_temp_dir()), $spy);
+    $t0 = microtime(true);
+    $r->spawnInstall('job1', 'glueful/aegis');
+    $returned = microtime(true);
+    $this->assertLessThan(0.5, $returned - $t0, 'spawnInstall must not block');
+    $this->assertNotNull($started);
+}
+
+public function test_real_detached_spawn_returns_before_child_completes(): void
+{
+    if (!function_exists('proc_open')) {
+        $this->markTestSkipped('proc_open unavailable');
+    }
+    $marker = sys_get_temp_dir() . '/mark_' . bin2hex(random_bytes(4));
+    $log = sys_get_temp_dir() . '/log_' . bin2hex(random_bytes(4));
+
+    // Real detached child: sleeps 400ms, then writes the marker. Pure argv, no shell.
+    $t0 = microtime(true);
+    DetachedRunner::detachedSpawn(
+        [PHP_BINARY, '-r', 'usleep(400000); file_put_contents($argv[1], "x");', $marker],
+        sys_get_temp_dir(),
+        $log,
+    );
+    $elapsed = microtime(true) - $t0;
+
+    // Non-blocking: returned well before the child's 400ms sleep elapsed...
+    $this->assertLessThan(0.3, $elapsed, 'detachedSpawn must return before the child finishes');
+    $this->assertFileDoesNotExist($marker, 'child should still be running when spawn returns');
+
+    // ...and the detached child completes independently afterward.
+    $deadline = microtime(true) + 3.0;
+    while (!file_exists($marker) && microtime(true) < $deadline) {
+        usleep(20000);
+    }
+    $this->assertFileExists($marker, 'detached child ran to completion after spawn returned');
+    @unlink($marker);
+    @unlink($log);
+}
+```
+
+- [ ] **Step 2: Run to verify failure** — FAIL (class not found).
+
+- [ ] **Step 3: Implement `DetachedRunner`**
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace Glueful\Support\Process;
+
+use Glueful\Bootstrap\ApplicationContext;
+use Symfony\Component\Process\ExecutableFinder;
+
+/**
+ * Fire-and-forget spawn for the extensions install runner.
+ *
+ * Non-blocking property comes from proc_open (we never wait/proc_close).
+ * Survival across FPM recycle comes from `setsid` (new session) on POSIX.
+ * Always pure argv — no shell. See toShellCommand() for the guarded string form.
+ */
+final class DetachedRunner
+{
+    private \Closure $spawn;
+
+    public function __construct(private ApplicationContext $context, ?\Closure $spawn = null)
+    {
+        $this->spawn = $spawn ?? self::defaultSpawn();
+    }
+
+    public function spawnInstall(string $jobId, string $package): void
+    {
+        $argv = $this->buildArgv($jobId, $package);
+        $log = storage_path($this->context, "logs/ext-install-{$jobId}.log");
+        ($this->spawn)($argv, base_path($this->context), $log);
+    }
+
+    /** @return list<string> */
+    public function buildArgv(string $jobId, string $package): array
+    {
+        $argv = [PHP_BINARY, base_path($this->context, 'glueful'), 'extensions:install-run', $jobId, $package];
+        if ($this->hasSetsid()) {
+            array_unshift($argv, 'setsid');
+        }
+        return $argv;
+    }
+
+    /**
+     * Guarded string fallback — only for a platform that cannot take array argv.
+     * Every segment is escapeshellarg'd. Kept covered by a unit test.
+     * @param list<string> $argv
+     */
+    public static function toShellCommand(array $argv): string
+    {
+        return implode(' ', array_map('escapeshellarg', $argv));
+    }
+
+    private function hasSetsid(): bool
+    {
+        return (new ExecutableFinder())->find('setsid') !== null;
+    }
+
+    private static function defaultSpawn(): \Closure
+    {
+        return static fn(array $argv, string $cwd, string $log) => self::detachedSpawn($argv, $cwd, $log);
+    }
+
+    /**
+     * The real detached spawn: proc_open with array argv (no shell), stdio to a
+     * file, and NO proc_close() — so it returns immediately and the child is not
+     * reaped by PHP at shutdown. Public + static so the real path is testable.
+     * @param list<string> $argv
+     */
+    public static function detachedSpawn(array $argv, string $cwd, string $log): void
+    {
+        $descriptors = [
+            0 => ['file', '/dev/null', 'r'],
+            1 => ['file', $log, 'w'],
+            2 => ['file', $log, 'a'],
+        ];
+        $pipes = [];
+        $proc = proc_open($argv, $descriptors, $pipes, $cwd); // array argv → no shell
+        if (is_resource($proc)) {
+            foreach ($pipes as $p) {
+                if (is_resource($p)) {
+                    fclose($p);
+                }
+            }
+            // Deliberately NO proc_close() — that would wait. Detach and return.
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify pass** — PASS.
+
+---
+
+### Task 5: `ProcessRunner` seam + `EnableInstalledCommand` (fresh-process enabler)
+
+**Files:**
+- Create: `src/Support/Process/ProcessRunner.php` (interface), `src/Support/Process/SymfonyProcessRunner.php`
+- Create: `src/Console/Commands/Extensions/EnableInstalledCommand.php`
+- Test: `tests/Unit/Console/Commands/Extensions/EnableInstalledCommandTest.php`
+
+**Interfaces:**
+- Produces:
+  - `interface ProcessRunner { public function run(array $cmd, string $cwd, float $timeout, ?callable $onOutput = null): array; }` → `array{exitCode:int,output:string}`
+  - `EnableInstalledCommand` = `extensions:enable-installed <package>`, prints a single JSON line `{"ok":bool,"provider"?:string,"error"?:string}`.
+
+- [ ] **Step 1: Write the failing tests** — both the not-a-candidate contract AND (P2 fix) the **happy path**, since this command is the autoloader-freshness fix and must be proven to write config + recompile. Harness: build a temp app dir with `vendor/composer/installed.json` containing one `type: glueful-extension` package whose `extra.glueful.provider` is a real dummy provider class defined in the test namespace (so `class_exists` succeeds), and a temp `config/extensions.php` with `['enabled' => []]`; point the command's `ApplicationContext` at that base/config dir; register a **spy** `ExtensionManager` so `writeCacheNow()` calls are observable.
+
+```php
+public function test_emits_ok_false_json_when_package_not_a_candidate(): void
+{
+    $tester = $this->runCommand(['package' => 'glueful/does-not-exist']); // no candidate
+    $decoded = json_decode(trim($tester->getDisplay()), true);
+    $this->assertFalse($decoded['ok']);
+    $this->assertNotEmpty($decoded['error']);
+}
+
+public function test_happy_path_writes_config_calls_writeCacheNow_and_emits_ok_true(): void
+{
+    $base = $this->makeTempAppWithCandidate(
+        package: 'glueful/aegis',
+        provider: \Glueful\Tests\Support\DummyAegisProvider::class, // real class the test defines
+    );
+    $spy = new SpyExtensionManager();
+    $tester = $this->runCommand(['package' => 'glueful/aegis'], base: $base, extensions: $spy);
+
+    // 1) JSON contract
+    $decoded = json_decode(trim($tester->getDisplay()), true);
+    $this->assertTrue($decoded['ok']);
+    $this->assertSame(\Glueful\Tests\Support\DummyAegisProvider::class, $decoded['provider']);
+
+    // 2) config/extensions.php now lists the provider FQCN
+    $enabled = (require $base . '/config/extensions.php')['enabled'];
+    $this->assertContains(\Glueful\Tests\Support\DummyAegisProvider::class, $enabled);
+
+    // 3) the manifest cache was recompiled
+    $this->assertSame(1, $spy->writeCacheNowCalls);
+}
+```
+
+- [ ] **Step 2: Run to verify failure** — FAIL.
+
+- [ ] **Step 3: Implement `ProcessRunner` + `SymfonyProcessRunner`**
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace Glueful\Support\Process;
+
+interface ProcessRunner
+{
+    /**
+     * @param list<string> $cmd
+     * @return array{exitCode:int,output:string}
+     */
+    public function run(array $cmd, string $cwd, float $timeout, ?callable $onOutput = null): array;
+}
+```
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace Glueful\Support\Process;
+
+use Symfony\Component\Process\Process;
+
+final class SymfonyProcessRunner implements ProcessRunner
+{
+    public function run(array $cmd, string $cwd, float $timeout, ?callable $onOutput = null): array
+    {
+        $process = new Process($cmd, $cwd);
+        $process->setTimeout($timeout);
+        $process->run(function (string $type, string $buffer) use ($onOutput): void {
+            if ($onOutput !== null) {
+                $onOutput($buffer);
+            }
+        });
+        return [
+            'exitCode' => $process->getExitCode() ?? 1,
+            'output' => $process->getOutput() . $process->getErrorOutput(),
+        ];
+    }
+}
+```
+
+- [ ] **Step 4: Implement `EnableInstalledCommand`** (no `APP_ENV=production` guard — gated upstream; mirrors `EnableCommand`'s resolve→preflight→write→recompile, printing JSON):
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace Glueful\Console\Commands\Extensions;
+
+use Glueful\Console\BaseCommand;
+use Glueful\Extensions\EnabledProviders;
+use Glueful\Extensions\ExtensionManager;
+use Glueful\Extensions\ExtensionResolver;
+use Glueful\Extensions\ExtensionStateWriter;
+use Glueful\Extensions\PackageManifest;
+use Glueful\Support\Version;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'extensions:enable-installed',
+    description: 'Enable a just-installed extension (internal; runs in a fresh PHP process)'
+)]
+final class EnableInstalledCommand extends BaseCommand
+{
+    protected function configure(): void
+    {
+        $this->addArgument('package', InputArgument::REQUIRED, 'Composer package, e.g. glueful/aegis');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $package = (string) $input->getArgument('package');
+        $context = $this->getContext();
+
+        $candidates = (new PackageManifest($context))->getCandidates();
+        $candidate = $candidates[$package] ?? null;
+        if ($candidate === null) {
+            return $this->emit($output, false, error: "Package not installed or not a Glueful extension: {$package}");
+        }
+        $provider = $candidate->provider;
+
+        $current = EnabledProviders::from($context);
+        if (in_array($provider, $current, true)) {
+            return $this->emit($output, true, provider: $provider);
+        }
+
+        $proposed = [...$current, $provider];
+        $result = (new ExtensionResolver())->resolve($candidates, $proposed, Version::VERSION);
+        if ($result->hasErrors()) {
+            $msg = implode('; ', array_map(static fn($e) => "[{$e->kind}] {$e->message}", $result->errors));
+            return $this->emit($output, false, error: $msg);
+        }
+
+        try {
+            (new ExtensionStateWriter())->enable(config_path($context, 'extensions.php'), $provider);
+            $this->getService(ExtensionManager::class)->writeCacheNow();
+        } catch (\Throwable $e) {
+            return $this->emit($output, false, error: $e->getMessage());
+        }
+
+        return $this->emit($output, true, provider: $provider);
+    }
+
+    private function emit(OutputInterface $output, bool $ok, ?string $provider = null, ?string $error = null): int
+    {
+        $output->writeln((string) json_encode(array_filter(
+            ['ok' => $ok, 'provider' => $provider, 'error' => $error],
+            static fn($v) => $v !== null,
+        )));
+        return $ok ? self::SUCCESS : self::FAILURE;
+    }
+}
+```
+
+- [ ] **Step 5: Run tests** — PASS.
+
+---
+
+### Task 6: `InstallRunCommand` — the detached runner
+
+**Files:**
+- Create: `src/Console/Commands/Extensions/InstallRunCommand.php`
+- Test: `tests/Unit/Console/Commands/Extensions/InstallRunCommandTest.php`
+
+**Interfaces:**
+- Consumes: `InstallJobStore`, `ProcessRunner` (injected; default `SymfonyProcessRunner`).
+- Command: `extensions:install-run <jobId> <package>`.
+
+- [ ] **Step 1: Write the failing tests** (inject a **fake `ProcessRunner`** scripting exit codes/output for the composer call and the enable call; assert job transitions and that composer-failure short-circuits before enable):
+
+```php
+public function test_success_path_runs_composer_then_fresh_enable_and_finishes_succeeded(): void
+{
+    $store = new InstallJobStore(new ArrayCacheStore());
+    $jobId = $store->create('glueful/aegis');
+    $calls = [];
+    $runner = new FakeProcessRunner(function (array $cmd) use (&$calls) {
+        $calls[] = $cmd;
+        if (in_array('require', $cmd, true)) return ['exitCode' => 0, 'output' => "Installing\n"];
+        return ['exitCode' => 0, 'output' => json_encode(['ok' => true, 'provider' => 'X']) . "\n"];
+    });
+    $this->runCommand($store, $runner, ['jobId' => $jobId, 'package' => 'glueful/aegis']);
+
+    $this->assertSame('succeeded', $store->get($jobId)['status']);
+    $this->assertTrue(in_array('require', $calls[0], true));                    // composer first
+    $this->assertContains('extensions:enable-installed', $calls[1]);            // fresh enable second
+    $this->assertNull($store->get($jobId)['enableError']);
+}
+
+public function test_composer_failure_short_circuits_before_enable(): void
+{
+    $store = new InstallJobStore(new ArrayCacheStore());
+    $jobId = $store->create('glueful/aegis');
+    $calls = [];
+    $runner = new FakeProcessRunner(function (array $cmd) use (&$calls) {
+        $calls[] = $cmd;
+        return ['exitCode' => 1, 'output' => "Could not resolve\n"];
+    });
+    $this->runCommand($store, $runner, ['jobId' => $jobId, 'package' => 'glueful/aegis']);
+
+    $this->assertSame('failed', $store->get($jobId)['status']);
+    $this->assertCount(1, $calls); // enable never ran
+}
+
+public function test_composer_ok_but_enable_fails_ends_installed_not_enabled(): void
+{
+    $store = new InstallJobStore(new ArrayCacheStore());
+    $jobId = $store->create('glueful/aegis');
+    $runner = new FakeProcessRunner(function (array $cmd) {
+        if (in_array('require', $cmd, true)) return ['exitCode' => 0, 'output' => "Installing\n"];
+        return ['exitCode' => 1, 'output' => json_encode(['ok' => false, 'error' => 'missing dependency']) . "\n"];
+    });
+    $this->runCommand($store, $runner, ['jobId' => $jobId, 'package' => 'glueful/aegis']);
+
+    $rec = $store->get($jobId);
+    $this->assertSame('installed_not_enabled', $rec['status']);       // NOT 'failed', NOT plain 'succeeded'
+    $this->assertSame('missing dependency', $rec['enableError']);
+}
+```
+
+- [ ] **Step 2: Run to verify failure** — FAIL.
+
+- [ ] **Step 3: Implement `InstallRunCommand`**
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace Glueful\Console\Commands\Extensions;
+
+use Glueful\Bootstrap\ApplicationContext;
+use Glueful\Console\BaseCommand;
+use Glueful\Extensions\Install\InstallJobStore;
+use Glueful\Support\Process\ComposerBinaryResolver;
+use Glueful\Support\Process\ProcessRunner;
+use Glueful\Support\Process\SymfonyProcessRunner;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'extensions:install-run',
+    description: 'Run a detached extension install (composer require + fresh-process enable)'
+)]
+final class InstallRunCommand extends BaseCommand
+{
+    private ComposerBinaryResolver $composer;
+
+    public function __construct(
+        ?ContainerInterface $container = null,
+        ?ApplicationContext $context = null,
+        private ?ProcessRunner $runner = null,
+        ?ComposerBinaryResolver $composer = null,
+    ) {
+        parent::__construct($container, $context);
+        $this->runner ??= new SymfonyProcessRunner();
+        $this->composer = $composer ?? new ComposerBinaryResolver();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('jobId', InputArgument::REQUIRED);
+        $this->addArgument('package', InputArgument::REQUIRED);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $jobId = (string) $input->getArgument('jobId');
+        $package = (string) $input->getArgument('package');
+        $context = $this->getContext();
+        $store = $this->getService(InstallJobStore::class);
+        $cwd = base_path($context);
+
+        $store->markRunning($jobId);
+
+        $composer = $this->composer->resolve(); // SAME resolver as preflight (honors COMPOSER_BINARY)
+        if ($composer === null) {
+            $store->finish($jobId, 'failed', null, 'composer binary not found');
+            return self::FAILURE;
+        }
+        $timeout = (float) config('extensions.install.timeout', 600);
+        $install = $this->runner->run(
+            [$composer, 'require', $package, '--no-interaction', '--no-progress'],
+            $cwd,
+            $timeout,
+            static fn(string $chunk) => $store->appendOutput($jobId, $chunk),
+        );
+
+        if ($install['exitCode'] !== 0) {
+            $store->finish($jobId, 'failed', $install['exitCode'], 'composer require failed');
+            return self::FAILURE;
+        }
+
+        $enableError = null;
+        if ((bool) config('extensions.install.auto_enable', true)) {
+            $enable = $this->runner->run(
+                [PHP_BINARY, base_path($context, 'glueful'), 'extensions:enable-installed', $package],
+                $cwd,
+                120.0,
+                static fn(string $chunk) => $store->appendOutput($jobId, $chunk),
+            );
+            $decoded = $this->lastJsonLine($enable['output']);
+            if (($decoded['ok'] ?? false) !== true) {
+                $enableError = $decoded['error'] ?? 'enable failed';
+            }
+        }
+
+        // Distinct terminal states: `succeeded` = installed AND enabled (or auto-enable
+        // off with no error); `installed_not_enabled` = composer installed but the
+        // auto-enable step failed (e.g. a missing dependency) — not a hard failure.
+        if ($enableError !== null) {
+            $store->finish($jobId, 'installed_not_enabled', 0, null, $enableError);
+            return self::SUCCESS;
+        }
+        $store->finish($jobId, 'succeeded', 0);
+        return self::SUCCESS;
+    }
+
+    /** @return array<string,mixed> */
+    private function lastJsonLine(string $output): array
+    {
+        foreach (array_reverse(array_filter(array_map('trim', explode("\n", $output)))) as $line) {
+            $decoded = json_decode($line, true);
+            if (is_array($decoded)) {
+                return $decoded;
+            }
+        }
+        return [];
+    }
+}
+```
+
+- [ ] **Step 4: Run tests** — PASS.
+
+- [ ] **Step 5: Commit Phase 2**
+
+```bash
+git add src/Support/Process/ src/Console/Commands/Extensions/EnableInstalledCommand.php \
+        src/Console/Commands/Extensions/InstallRunCommand.php tests/Unit/Support/Process/ \
+        tests/Unit/Console/Commands/Extensions/
+git commit -m "extensions installer: detached runner, fresh-process enabler, install-run command"
+```
+
+---
+
+## Phase 3 — Catalog + installer orchestration
+
+### Task 7: `ExtensionCatalog`
+
+**Files:**
+- Create: `src/Extensions/ExtensionCatalog.php`
+- Test: `tests/Unit/Extensions/ExtensionCatalogTest.php`
+
+**Interfaces:**
+- Consumes: `Glueful\Http\Client`, `Glueful\Cache\CacheStore`, `Glueful\Extensions\ExtensionManager`, `ApplicationContext`.
+- Produces:
+  - `catalog(bool $refresh = false): array` — `list<array{package,description,version,downloads,repository,state}>`
+  - `installed(): array` — `list<array{package,provider,version,label,state}>`
+  - `state ∈ {available, installed, enabled}` (catalog) / `{enabled, available, enabled_missing}` (installed)
+
+- [ ] **Step 1: Write the failing test** — stub `Client` to return a search payload then a p2 payload; assert only `glueful/` + `type: glueful-extension` rows survive, `version` is hydrated, and state reflects installed/enabled cross-reference (inject a fake candidates+enabled source). Representative assertion:
+
+```php
+public function test_catalog_filters_to_glueful_extension_type_and_hydrates_version(): void
+{
+    $http = new FakeClient([
+        'https://packagist.org/search.json?type=glueful-extension&per_page=100' => [
+            'results' => [
+                ['name' => 'glueful/aegis', 'description' => 'Auth', 'downloads' => 10, 'repository' => 'r'],
+                ['name' => 'other/thing',  'description' => 'No',   'downloads' => 1,  'repository' => 'r'],
+            ],
+        ],
+        'https://repo.packagist.org/p2/glueful/aegis.json' => [
+            'packages' => ['glueful/aegis' => [['version' => '1.2.0', 'type' => 'glueful-extension']]],
+        ],
+    ]);
+    $catalog = $this->makeCatalog($http, installed: [], enabled: []);
+    $rows = $catalog->catalog(refresh: true);
+    $this->assertCount(1, $rows);
+    $this->assertSame('glueful/aegis', $rows[0]['package']);
+    $this->assertSame('1.2.0', $rows[0]['version']);
+    $this->assertSame('available', $rows[0]['state']);
+}
+```
+
+- [ ] **Step 2: Run to verify failure** — FAIL.
+
+- [ ] **Step 3: Implement `ExtensionCatalog`** (two-stage fetch → hydrate → cache → cross-reference). Key methods:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace Glueful\Extensions;
+
+use Glueful\Bootstrap\ApplicationContext;
+use Glueful\Cache\CacheStore;
+use Glueful\Http\Client;
+
+final class ExtensionCatalog
+{
+    private const CACHE_KEY = 'ext_catalog:glueful';
+    private const CACHE_TTL = 3600;
+    private const VENDOR = 'glueful/';
+
+    public function __construct(
+        private ApplicationContext $context,
+        private Client $http,
+        private CacheStore $cache,
+        private ExtensionManager $extensions,
+    ) {}
+
+    /** @return list<array{package:string,description:string,version:?string,downloads:int,repository:string,state:string}> */
+    public function catalog(bool $refresh = false): array
+    {
+        $packages = $refresh ? null : $this->cache->get(self::CACHE_KEY);
+        if (!is_array($packages)) {
+            $packages = $this->fetchFromPackagist();
+            $this->cache->set(self::CACHE_KEY, $packages, self::CACHE_TTL);
+        }
+        $installed = $this->installedMap();       // package => provider
+        $enabled = EnabledProviders::from($this->context);
+
+        return array_map(function (array $p) use ($installed, $enabled): array {
+            $state = 'available';
+            if (isset($installed[$p['package']])) {
+                $state = in_array($installed[$p['package']], $enabled, true) ? 'enabled' : 'installed';
+            }
+            return [...$p, 'state' => $state];
+        }, $packages);
+    }
+
+    /** @return list<array{package:string,provider:string,version:?string,label:string,state:string}> */
+    public function installed(): array
+    {
+        $candidates = (new PackageManifest($this->context))->getCandidates();
+        $enabled = EnabledProviders::from($this->context);
+        $meta = $this->extensions->listMeta();
+
+        $rows = [];
+        foreach ($candidates as $package => $c) {
+            $rows[] = [
+                'package' => $package,
+                'provider' => $c->provider,
+                'version' => $c->version,
+                'label' => $meta[$c->provider]['name'] ?? $package,
+                'state' => in_array($c->provider, $enabled, true) ? 'enabled' : 'available',
+            ];
+        }
+        // enabled-but-missing: in allow-list but not an installed candidate.
+        $known = array_map(static fn($c) => $c->provider, $candidates);
+        foreach ($enabled as $provider) {
+            if (!in_array($provider, $known, true)) {
+                $rows[] = ['package' => $provider, 'provider' => $provider, 'version' => null,
+                           'label' => $provider, 'state' => 'enabled_missing'];
+            }
+        }
+        return $rows;
+    }
+
+    /** @return array<string,string> package => provider (installed candidates) */
+    private function installedMap(): array
+    {
+        $out = [];
+        foreach ((new PackageManifest($this->context))->getCandidates() as $package => $c) {
+            $out[$package] = $c->provider;
+        }
+        return $out;
+    }
+
+    /** @return list<array{package:string,description:string,version:?string,downloads:int,repository:string}> */
+    private function fetchFromPackagist(): array
+    {
+        $names = $this->searchNames();       // stage 1: names + summary
+        $rows = [];
+        foreach ($names as $name => $summary) {
+            $meta = $this->hydrate($name);   // stage 2: version + type re-verify
+            if ($meta === null) {
+                continue;                    // not type glueful-extension
+            }
+            $rows[] = [
+                'package' => $name,
+                'description' => (string) ($summary['description'] ?? ''),
+                'version' => $meta['version'],
+                'downloads' => (int) ($summary['downloads'] ?? 0),
+                'repository' => (string) ($summary['repository'] ?? ''),
+            ];
+        }
+        return $rows;
+    }
+
+    /** @return array<string,array<string,mixed>> name => summary, vendor-filtered */
+    private function searchNames(): array
+    {
+        $url = 'https://packagist.org/search.json?type=glueful-extension&per_page=100';
+        $out = [];
+        while ($url !== null) {
+            $json = $this->http->get($url)->json();
+            foreach (($json['results'] ?? []) as $r) {
+                $name = (string) ($r['name'] ?? '');
+                if (str_starts_with($name, self::VENDOR)) {
+                    $out[$name] = $r;
+                }
+            }
+            $url = isset($json['next']) ? (string) $json['next'] : null;
+        }
+        return $out;
+    }
+
+    /** @return array{version:?string}|null null when not a glueful-extension */
+    private function hydrate(string $name): ?array
+    {
+        $json = $this->http->get("https://repo.packagist.org/p2/{$name}.json")->json();
+        $versions = $json['packages'][$name] ?? [];
+        $latestStable = null;
+        foreach ($versions as $v) {
+            if (($v['type'] ?? null) !== 'glueful-extension') {
+                return null;
+            }
+            $ver = (string) ($v['version'] ?? '');
+            if ($ver !== '' && !str_contains($ver, 'dev') && $latestStable === null) {
+                $latestStable = $ver;    // p2 lists newest first
+            }
+        }
+        return $versions === [] ? null : ['version' => $latestStable];
+    }
+}
+```
+
+- [ ] **Step 4: Run tests** — PASS.
+
+---
+
+### Task 8: `ExtensionInstaller` + install exceptions
+
+**Files:**
+- Create: `src/Extensions/Install/ExtensionInstaller.php`
+- Create: `src/Extensions/Install/InstallDisabledException.php`, `HostNotWritableException.php`, `PackageNotAllowedException.php`
+- Test: `tests/Unit/Extensions/Install/ExtensionInstallerTest.php`
+
+**Interfaces:**
+- Consumes: `ApplicationContext`, `ExtensionCatalog`, `InstallJobStore`, `HostCapability`, `DetachedRunner`.
+- Produces:
+  - `start(string $package): array{jobId:string,status:string}`
+  - Throws `InstallDisabledException` (kill-switch), `HostNotWritableException` (has `->reason`/`->detail`), `PackageNotAllowedException`.
+
+- [ ] **Step 1: Write the failing tests** — validation order + happy path (fake `DetachedRunner` records the spawn; no real process):
+
+```php
+public function test_rejects_flag_like_and_non_glueful_and_non_catalog_packages(): void
+{
+    $inst = $this->makeInstaller(catalog: ['glueful/aegis']);
+    foreach (['--evil', 'evil/thallo', 'glueful/not-in-catalog', 'GLUEFUL/Aegis'] as $bad) {
+        try { $inst->start($bad); $this->fail("accepted $bad"); }
+        catch (PackageNotAllowedException) { $this->addToCount(1); }
+    }
+}
+
+public function test_happy_path_creates_job_and_spawns_detached(): void
+{
+    $spawned = [];
+    $runner = new FakeDetachedRunner(function (string $jobId, string $pkg) use (&$spawned) { $spawned[] = [$jobId, $pkg]; });
+    $inst = $this->makeInstaller(catalog: ['glueful/aegis'], runner: $runner, killSwitch: true, hostOk: true);
+    $res = $inst->start('glueful/aegis');
+    $this->assertSame('queued', $res['status']);
+    $this->assertSame('glueful/aegis', $spawned[0][1]);
+}
+
+public function test_kill_switch_off_throws(): void
+{
+    $inst = $this->makeInstaller(catalog: ['glueful/aegis'], killSwitch: false);
+    $this->expectException(InstallDisabledException::class);
+    $inst->start('glueful/aegis');
+}
+```
+
+- [ ] **Step 2: Run to verify failure** — FAIL.
+
+- [ ] **Step 3: Implement the exceptions + installer**
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Install;
+
+final class HostNotWritableException extends \RuntimeException
+{
+    public function __construct(public readonly string $reason, public readonly string $detail)
+    {
+        parent::__construct("Host not writable ({$reason}): {$detail}");
+    }
+}
+```
+*(`InstallDisabledException` and `PackageNotAllowedException` are trivial `\RuntimeException` subclasses.)*
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Install;
+
+use Glueful\Bootstrap\ApplicationContext;
+use Glueful\Extensions\ExtensionCatalog;
+use Glueful\Support\Process\DetachedRunner;
+
+final class ExtensionInstaller
+{
+    private const NAME_GRAMMAR = '/^[a-z0-9]([_.-]?[a-z0-9]+)*\/[a-z0-9]([_.-]?[a-z0-9]+)*$/';
+
+    public function __construct(
+        private ApplicationContext $context,
+        private ExtensionCatalog $catalog,
+        private InstallJobStore $jobs,
+        private HostCapability $host,
+        private DetachedRunner $runner,
+    ) {}
+
+    /** @return array{jobId:string,status:string} */
+    public function start(string $package): array
+    {
+        if (!(bool) config('extensions.install.enabled', false)) {
+            throw new InstallDisabledException('Extension installation is disabled.');
+        }
+        if (($cap = $this->host->forInstall()) !== null) {
+            throw new HostNotWritableException($cap['reason'], $cap['detail']);
+        }
+        $this->assertAllowed($package);
+
+        $jobId = $this->jobs->create($package);
+        $this->runner->spawnInstall($jobId, $package);
+        return ['jobId' => $jobId, 'status' => 'queued'];
+    }
+
+    private function assertAllowed(string $package): void
+    {
+        $vendor = (string) config('extensions.install.vendor', 'glueful/');
+        if (
+            !str_starts_with($package, $vendor)
+            || $package[0] === '-'
+            || preg_match(self::NAME_GRAMMAR, $package) !== 1
+        ) {
+            throw new PackageNotAllowedException("Invalid or non-{$vendor} package: {$package}");
+        }
+        $inCatalog = array_filter($this->catalog->catalog(), static fn($r) => $r['package'] === $package);
+        if ($inCatalog === []) {
+            throw new PackageNotAllowedException("Not an installable Glueful extension: {$package}");
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests** — PASS.
+
+- [ ] **Step 5: Commit Phase 3**
+
+```bash
+git add src/Extensions/ExtensionCatalog.php src/Extensions/Install/ExtensionInstaller.php \
+        src/Extensions/Install/*Exception.php tests/Unit/Extensions/
+git commit -m "extensions installer: packagist catalog + installer orchestration"
+```
+
+---
+
+## Phase 4 — HTTP surface
+
+### Task 9: Request DTOs
+
+**Files:**
+- Create: `src/DTOs/ExtensionInstallData.php`, `src/DTOs/ExtensionToggleData.php`
+- Test: `tests/Unit/DTOs/ExtensionDataTest.php`
+
+**Interfaces:**
+- Produces: `ExtensionInstallData { string $package }`, `ExtensionToggleData { string $package }` (both `RequestData` + `#[Rule]`).
+
+- [ ] **Step 1: Write the failing test** — a `422`-triggering empty payload validates false via the framework validator harness; a valid payload hydrates `$package`. (Follow the existing `RefreshTokenData` test pattern in the suite.)
+
+- [ ] **Step 2: Run to verify failure** — FAIL.
+
+- [ ] **Step 3: Implement**
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace Glueful\DTOs;
+
+use Glueful\Validation\Attributes\Rule;
+use Glueful\Validation\Contracts\RequestData;
+
+final class ExtensionInstallData implements RequestData
+{
+    public function __construct(
+        #[Rule('required|string|max:150')]
+        public readonly string $package,
+    ) {}
+}
+```
+*(`ExtensionToggleData` is identical with the same single `package` field.)*
+
+- [ ] **Step 4: Run tests** — PASS.
+
+---
+
+### Task 10: `ExtensionsController` + service registration
+
+**Files:**
+- Modify: `src/Controllers/ExtensionsController.php` (repurpose the unrouted controller)
+- Modify: `src/Container/Providers/CoreProvider.php` (register new services)
+- Test: `tests/Feature/Extensions/ExtensionsControllerTest.php`
+
+**Interfaces:**
+- Consumes: `ExtensionCatalog`, `ExtensionInstaller`, `InstallJobStore`, `HostCapability`, `EnabledProviders`/`ExtensionStateWriter`/`ExtensionManager` (for enable/disable), `LogManager`.
+- Produces: controller actions `index`, `catalog`, `install`, `installStatus`, `enable`, `disable`.
+
+- [ ] **Step 1: Write the failing integration tests** — with the installer/catalog faked (no real composer): `403` without `system.config`, `403` kill-switch off, `409` host unwritable, `201 {jobId}` happy path, `422` bad package, `installStatus` 200/404, `enable`/`disable` call `ExtensionStateWriter`+`writeCacheNow` (spy) and `409` when config/cache unwritable, `422` on resolver error. Representative:
+
+```php
+public function test_install_returns_201_with_jobId_on_happy_path(): void
+{
+    $this->actingAsSystemConfigAdmin();
+    $this->swap(ExtensionInstaller::class, new FakeInstaller(['jobId' => 'abc', 'status' => 'queued']));
+    $res = $this->postJson('/api/v1/extensions/install', ['package' => 'glueful/aegis']);
+    $res->assertStatus(201)->assertJsonPath('data.jobId', 'abc');
+}
+
+public function test_install_403_when_kill_switch_off(): void
+{
+    $this->actingAsSystemConfigAdmin();
+    $this->swap(ExtensionInstaller::class, new FakeInstaller(throws: new InstallDisabledException('off')));
+    $this->postJson('/api/v1/extensions/install', ['package' => 'glueful/aegis'])->assertStatus(403);
+}
+```
+
+- [ ] **Step 2: Run to verify failure** — FAIL.
+
+- [ ] **Step 3: Implement the controller** (repurpose the existing `ExtensionsController`, keeping `BaseController` conventions; map installer exceptions to HTTP):
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace Glueful\Controllers;
+
+use Glueful\Bootstrap\ApplicationContext;
+use Glueful\DTOs\ExtensionInstallData;
+use Glueful\DTOs\ExtensionToggleData;
+use Glueful\Extensions\EnabledProviders;
+use Glueful\Extensions\ExtensionCatalog;
+use Glueful\Extensions\ExtensionManager;
+use Glueful\Extensions\ExtensionResolver;
+use Glueful\Extensions\ExtensionStateWriter;
+use Glueful\Extensions\Install\ExtensionInstaller;
+use Glueful\Extensions\Install\HostCapability;
+use Glueful\Extensions\Install\HostNotWritableException;
+use Glueful\Extensions\Install\InstallDisabledException;
+use Glueful\Extensions\Install\InstallJobStore;
+use Glueful\Extensions\Install\PackageNotAllowedException;
+use Glueful\Extensions\PackageManifest;
+use Glueful\Http\Response;
+use Glueful\Logging\LogManager;
+use Glueful\Support\Version;
+
+final class ExtensionsController extends BaseController
+{
+    public function __construct(
+        ApplicationContext $context,
+        private ExtensionCatalog $catalog,
+        private ExtensionInstaller $installer,
+        private InstallJobStore $jobs,
+        private HostCapability $host,
+        private ExtensionManager $extensions,
+        private LogManager $log,
+    ) {
+        parent::__construct($context);
+    }
+
+    public function index(): Response
+    {
+        $this->requirePermission('system.config.view');
+        return $this->success(['installed' => $this->catalog->installed()]);
+    }
+
+    public function catalog(): Response
+    {
+        $this->requirePermission('system.config.view');
+        return $this->success(['catalog' => $this->catalog->catalog()]);
+    }
+
+    public function install(ExtensionInstallData $data): Response
+    {
+        $this->requirePermission('system.config.edit');
+        try {
+            $result = $this->installer->start($data->package);
+        } catch (InstallDisabledException $e) {
+            return $this->forbidden($e->getMessage());
+        } catch (HostNotWritableException $e) {
+            return Response::error($e->getMessage(), 409, ['reason' => $e->reason]);
+        } catch (PackageNotAllowedException $e) {
+            return $this->validationError(['package' => [$e->getMessage()]]);
+        }
+        $this->audit('extension.install', $data->package, 'queued');
+        return $this->created($result, 'Install started');
+    }
+
+    public function installStatus(string $jobId): Response
+    {
+        $this->requirePermission('system.config.view');
+        $rec = $this->jobs->get($jobId);
+        return $rec === null ? $this->notFound('Unknown install job') : $this->success($rec);
+    }
+
+    public function enable(ExtensionToggleData $data): Response
+    {
+        return $this->toggle($data->package, enable: true);
+    }
+
+    public function disable(ExtensionToggleData $data): Response
+    {
+        return $this->toggle($data->package, enable: false);
+    }
+
+    private function toggle(string $package, bool $enable): Response
+    {
+        $this->requirePermission('system.config.edit');
+        if (($cap = $this->host->forToggle()) !== null) {
+            return Response::error('Host not writable', 409, ['reason' => $cap['reason']]);
+        }
+        $candidates = (new PackageManifest($this->context))->getCandidates();
+        $candidate = $candidates[$package] ?? null;
+        if ($candidate === null) {
+            return $this->notFound("Not an installed extension: {$package}");
+        }
+        $provider = $candidate->provider;
+        $current = EnabledProviders::from($this->context);
+        $proposed = $enable
+            ? [...$current, $provider]
+            : array_values(array_filter($current, static fn($p) => $p !== $provider));
+
+        $result = (new ExtensionResolver())->resolve($candidates, $proposed, Version::VERSION);
+        if ($result->hasErrors()) {
+            return $this->validationError(['extension' => array_map(
+                static fn($e) => "[{$e->kind}] {$e->message}",
+                $result->errors,
+            )]);
+        }
+        $writer = new ExtensionStateWriter();
+        $configPath = config_path($this->context, 'extensions.php');
+        $enable ? $writer->enable($configPath, $provider) : $writer->disable($configPath, $provider);
+        $this->extensions->writeCacheNow();
+
+        $this->audit($enable ? 'extension.enable' : 'extension.disable', $package, 'succeeded');
+        return $this->success(['package' => $package, 'provider' => $provider,
+                               'state' => $enable ? 'enabled' : 'available']);
+    }
+
+    private function audit(string $action, string $package, string $result): void
+    {
+        $this->log->channel('audit')->info($action, [
+            'action' => $action,
+            'actor_id' => $this->getCurrentUserUuid(),   // BaseController/CachedUserContextTrait helper
+            'resource_type' => 'extension',
+            'resource_id' => $package,
+            'result' => $result,
+        ]);
+    }
+}
+```
+*(Confirm the exact `Response::error(...)` signature and the current-user accessor name from `BaseController`/`CachedUserContextTrait`; adjust if the helper is `getUserUuid()`.)*
+
+- [ ] **Step 4: Register services in `CoreProvider::defs()`** — most autowire cleanly (all ctor deps are container-registered: `ApplicationContext`, `Client`, `CacheStore`, `ExtensionManager`, `LogManager`):
+
+```php
+$defs[\Glueful\Support\Process\ComposerBinaryResolver::class] = $this->autowire(\Glueful\Support\Process\ComposerBinaryResolver::class);
+$defs[\Glueful\Extensions\Install\HostCapability::class]   = $this->autowire(\Glueful\Extensions\Install\HostCapability::class);
+$defs[\Glueful\Extensions\Install\InstallJobStore::class]  = $this->autowire(\Glueful\Extensions\Install\InstallJobStore::class);
+$defs[\Glueful\Support\Process\DetachedRunner::class]      = $this->autowire(\Glueful\Support\Process\DetachedRunner::class);
+$defs[\Glueful\Extensions\ExtensionCatalog::class]         = $this->autowire(\Glueful\Extensions\ExtensionCatalog::class);
+$defs[\Glueful\Extensions\Install\ExtensionInstaller::class] = $this->autowire(\Glueful\Extensions\Install\ExtensionInstaller::class);
+```
+*(`InstallJobStore` needs the `cache.store` binding for its `CacheStore` param — if autowire can't resolve the interface, add a `FactoryDefinition` that passes `$c->get('cache.store')`.)*
+
+- [ ] **Step 5: Run tests** — PASS.
+
+---
+
+### Task 11: Routes + manifest + command cache
+
+**Files:**
+- Create: `routes/extensions.php`
+- Modify: `src/Routing/RouteManifest.php`
+- Test: `tests/Feature/Extensions/ExtensionsRouteTest.php`
+
+- [ ] **Step 1: Write the failing test** — assert `GET /api/v1/extensions` resolves (200 for an authorized `system.config` user; 401/403 otherwise), proving the route is mounted.
+
+- [ ] **Step 2: Run to verify failure** — FAIL (404, route not registered).
+
+- [ ] **Step 3: Create `routes/extensions.php`**
+
+```php
+<?php
+use Glueful\Controllers\ExtensionsController;
+use Glueful\Routing\Router;
+
+/** @var Router $router */
+$router->group(['prefix' => '/extensions'], function (Router $router): void {
+    $router->get('/', [ExtensionsController::class, 'index'])->middleware(['auth', 'rate_limit:60,60']);
+    $router->get('/catalog', [ExtensionsController::class, 'catalog'])->middleware(['auth', 'rate_limit:30,60']);
+    $router->post('/install', [ExtensionsController::class, 'install'])->middleware(['auth', 'rate_limit:10,60']);
+    $router->get('/install/{jobId}', [ExtensionsController::class, 'installStatus'])->middleware(['auth', 'rate_limit:120,60']);
+    $router->post('/enable', [ExtensionsController::class, 'enable'])->middleware(['auth', 'rate_limit:20,60']);
+    $router->post('/disable', [ExtensionsController::class, 'disable'])->middleware(['auth', 'rate_limit:20,60']);
+});
+```
+
+- [ ] **Step 4: Register it in `RouteManifest::generate()`** — add to the `api_routes` array:
+
+```php
+'api_routes' => [
+    '/routes/auth.php',
+    '/routes/blobs.php',
+    '/routes/resource.php',
+    '/routes/extensions.php',
+],
+```
+
+- [ ] **Step 5: Refresh the command manifest** so the two new console commands are discoverable — Run: `php glueful commands:cache`. Expected: manifest rebuilt including `extensions:install-run` and `extensions:enable-installed` (`php glueful list | grep extensions`).
+
+- [ ] **Step 6: Run tests + quality gates**
+
+```bash
+vendor/bin/phpunit tests/Feature/Extensions tests/Unit/Extensions tests/Unit/Support/Process
+composer run phpcs
+composer run analyse:changed
+```
+Expected: green.
+
+- [ ] **Step 7: Commit Phase 4**
+
+```bash
+git add src/DTOs/ExtensionInstallData.php src/DTOs/ExtensionToggleData.php \
+        src/Controllers/ExtensionsController.php src/Container/Providers/CoreProvider.php \
+        routes/extensions.php src/Routing/RouteManifest.php tests/Feature/Extensions/ tests/Unit/DTOs/
+git commit -m "extensions installer: HTTP controller, DTOs, routes"
+```
+
+---
+
+## Phase 5 — Thallo admin UI (repo: `glueful/lemma`) — separable follow-on
+
+> This phase lives in a **different repo** (`/Users/michaeltawiahsowah/Sites/glueful/lemma`) and depends on the framework API from Phases 1–4 being released/linked. It can be executed as its own plan. Follows the `settings/email` page patterns.
+
+### Task 12: `queries/extensions.ts`
+
+**Files:**
+- Create: `admin/src/queries/extensions.ts`
+- Test: covered via Task 14.
+
+**Interfaces:**
+- Produces: `fetchInstalled()`, `fetchCatalog()`, `installExtension(package)`, `fetchInstallJob(jobId)`, `enableExtension(package)`, `disableExtension(package)`; types `ExtensionRow`, `CatalogRow`, `InstallJob`.
+
+- [ ] **Step 1: Implement** (mirror `queries/email.ts`; confirm the mount — API-prefixed per `RouteManifest`, so use `${runtimeConfig.apiBase}/extensions/...`, NOT root-mounted):
+
+```ts
+import { authFetch } from '@/api/authFetch'
+
+export interface ExtensionRow { package: string; provider: string; version: string | null; label: string; state: 'enabled' | 'available' | 'enabled_missing' }
+export interface CatalogRow { package: string; description: string; version: string | null; downloads: number; repository: string; state: 'available' | 'installed' | 'enabled' }
+export interface InstallJob { id: string; package: string; status: 'queued' | 'running' | 'succeeded' | 'failed' | 'installed_not_enabled'; output: string; exitCode: number | null; error: string | null; enableError: string | null }
+
+const base = '/api/v1/extensions'  // confirm apiBase prefix at implementation time
+
+export async function fetchInstalled(): Promise<ExtensionRow[]> {
+  const json = await authFetch(`${base}`)
+  return (json.data?.installed ?? []) as ExtensionRow[]
+}
+export async function fetchCatalog(): Promise<CatalogRow[]> {
+  const json = await authFetch(`${base}/catalog`)
+  return (json.data?.catalog ?? []) as CatalogRow[]
+}
+export async function installExtension(pkg: string): Promise<{ jobId: string }> {
+  const json = await authFetch(`${base}/install`, { method: 'POST', body: JSON.stringify({ package: pkg }) })
+  return (json.data ?? json) as { jobId: string }
+}
+export async function fetchInstallJob(jobId: string): Promise<InstallJob> {
+  const json = await authFetch(`${base}/install/${encodeURIComponent(jobId)}`)
+  return (json.data ?? json) as InstallJob
+}
+export async function enableExtension(pkg: string): Promise<void> {
+  await authFetch(`${base}/enable`, { method: 'POST', body: JSON.stringify({ package: pkg }) })
+}
+export async function disableExtension(pkg: string): Promise<void> {
+  await authFetch(`${base}/disable`, { method: 'POST', body: JSON.stringify({ package: pkg }) })
+}
+```
+
+### Task 13: `pages/developers/extensions/index.vue`
+
+**Files:**
+- Create: `admin/src/pages/developers/extensions/index.vue`
+
+- [ ] **Step 1: Implement** two sections — **Installed** (rows with enable/disable toggles + `state` badges; `enabled_missing` shown as a warning) and **Browse** (catalog cards with Install buttons). Install → `installExtension` → poll `fetchInstallJob` every ~1500ms until a **terminal** `status ∈ {succeeded, failed, installed_not_enabled}`, show streaming `output` in a `UCollapsible`, then refresh the installed list. Terminal display:
+  - `succeeded` → success toast, row flips to `enabled`.
+  - `installed_not_enabled` → **warning** toast/badge "Installed but not enabled" showing `enableError` (e.g. "needs a dependency"); the row appears in Installed as `available` with an Enable button (so the operator can resolve the dependency and enable manually). This is NOT rendered as a failure.
+  - `failed` → error toast showing `error` + the output tail.
+
+  A `403` on install/toggle hides the affordance with a note; a `409` (`reason: read_only_filesystem`) shows "install on deploy". Use `definePage({ meta: { requiresAuth: true } })`. No CodeMirror. (Follow the `settings/email/index.vue` structure: `UDashboardPanel`/`UDashboardNavbar`, `UCard`, `data-test` hooks on every actionable element.)
+
+### Task 14: `extensionsPage.spec.ts`
+
+**Files:**
+- Create: `admin/src/__tests__/extensionsPage.spec.ts`
+
+- [ ] **Step 1: Write tests** (mock `@/queries/extensions`, per `emailSettingsPage.spec.ts`): renders installed rows + state badges; renders catalog cards; **install → poll → enabled transition** (advance the poll with fake timers, second `fetchInstallJob` returns `succeeded`, assert installed list refetched and row shows `enabled`); **install → poll → `installed_not_enabled`** (second poll returns `installed_not_enabled` + `enableError`; assert a *warning* — not error — is shown, the `enableError` text renders, and the row appears as `available` with an Enable button); enable/disable call the query; `403` hides install with a note; `409 read_only_filesystem` shows "install on deploy". Assert via `data-test` hooks (Nuxt UI portals/unstubbable components — never assert dropdown DOM).
+
+- [ ] **Step 2: Run** — Run: `pnpm --filter admin test` (or the repo's vitest script). Expected: green. Also run `pnpm --filter admin type-check`.
+
+- [ ] **Step 3: Commit (lemma repo)**
+
+```bash
+git add admin/src/queries/extensions.ts admin/src/pages/developers/extensions/index.vue admin/src/__tests__/extensionsPage.spec.ts
+git commit -m "admin: extensions manager page (browse, install, enable/disable)"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** every spec §5 component maps to a task (HostCapability→T2, InstallJobStore→T3, DetachedRunner→T4, ProcessRunner/EnableInstalled→T5, InstallRun→T6, Catalog→T7, Installer→T8, DTOs→T9, Controller/registration→T10, routes→T11, UI→T12–14). Security controls (§4): kill-switch T1/T8, host-capability T2/T8/T10, allowlist T8, no-shell T4, audit T10, permission T10.
+- **Type consistency:** job record shape identical across T3/T6/T10/T12, including the five-value status enum `queued|running|succeeded|failed|installed_not_enabled` (T3 doc ↔ T6 `finish()` ↔ T12 TS union ↔ T13/T14 UI); `catalog()`/`installed()` row shapes match T7↔T10↔T12; `start(): {jobId,status}` consistent T8↔T10.
+- **Single-source invariants (review fixes):** composer binary resolves through one `ComposerBinaryResolver` in both preflight (T2/HostCapability) and the runner (T6) — no divergent `ExecutableFinder` call; host-capability checks the nearest existing ancestor for missing paths (T2), so a missing `vendor/`/`composer.lock` under a read-only base fails preflight; the real `proc_open`/no-`proc_close` path is covered by a live child-process test (T4), not only the injected closure.
+- **Confirm-at-implementation (non-blocking):** exact `Response::error()` signature and the current-user accessor name in `BaseController`; whether `InstallJobStore`'s `CacheStore` param autowires or needs a `FactoryDefinition` binding `cache.store`; the Thallo `apiBase` prefix for `queries/extensions.ts`.

--- a/docs/superpowers/specs/2026-07-05-extensions-manager-design.md
+++ b/docs/superpowers/specs/2026-07-05-extensions-manager-design.md
@@ -1,0 +1,448 @@
+# Extensions Manager — Design Spec
+
+**Date:** 2026-07-05
+**Status:** Draft for review
+**Repo:** `glueful/framework` (API + logic) · `glueful/lemma` / Thallo admin (UI)
+
+## 1. Goal
+
+Let an operator browse, install, and enable/disable Glueful extensions **from the
+admin UI** — no server terminal. Installing an extension currently means SSHing
+to the box and running `composer require glueful/<pkg>` by hand, then
+`php glueful extensions:enable <pkg>`. This feature brings that workflow into the
+browser, the way WordPress/Ghost install add-ons.
+
+## 2. Scope
+
+**In:**
+- Framework-core HTTP API under `/extensions/*` (reusable by any Glueful app).
+- Browse installable extensions from **Packagist** (vendor `glueful/`,
+  type `glueful-extension`).
+- Install one via `composer require` run as a **detached background process**,
+  with pollable status.
+- List installed extensions; **enable/disable** them.
+- Thallo admin page (`/developers/extensions`) as the first consumer.
+
+**Out (v1):**
+- Remote/curated catalog hosted on thallo.dev (Packagist is the source; loader is
+  written so a remote catalog can slot in later).
+- Uninstall / `composer remove` from the UI. (Disable is enough operationally;
+  removal stays a CLI/terminal action.)
+- Version pinning UI, update-in-place, dependency-conflict resolution UI
+  (the resolver *preflight* runs, but we surface errors, not a resolver wizard).
+- Rollback of a failed `composer require` (we report the failure; the tree is
+  left as composer left it).
+- A full web terminal / console page (explicitly dropped — the installer subsumes
+  the only workflow that motivated it).
+
+## 3. Architecture
+
+```
+Thallo admin (Vue)                Framework core (PHP)
+──────────────────                ─────────────────────
+pages/developers/                 routes/extensions.php ─► ExtensionsController
+  extensions/index.vue                                       │
+  │ authFetch                       ┌────────────────────────┼───────────────────┐
+  ▼                                 ▼                        ▼                   ▼
+queries/extensions.ts        ExtensionCatalog        ExtensionInstaller    (enable/disable)
+  GET  /extensions           (Packagist + state)     │  spawns detached      ExtensionStateWriter
+  GET  /extensions/catalog          │                │  runner, returns id   + writeCacheNow()
+  POST /extensions/install     Glueful\Http\Client    ▼
+  GET  /extensions/install/{id}  → packagist.org   InstallJobStore (CacheStore)
+  POST /extensions/enable                               ▲
+  POST /extensions/disable        detached runner ──────┘ writes status
+                                  `php glueful extensions:install-run <id> <pkg>`
+                                     └► composer require (Symfony Process, array args)
+```
+
+**Why detached, not synchronous:** `composer require` takes 30s–minutes and
+streams output. The POST returns a `jobId` immediately; the runner is a separate
+OS process that outlives the request and writes progress to a shared store the
+page polls. We chose a detached process over a queue job so it works on
+self-hosted setups with **no queue worker running**.
+
+**Why framework-core, not Thallo-only:** the API + composer logic live in the
+framework so every Glueful app inherits the installer; Thallo only builds the UI.
+This matches the existing `/email` and `/rbac` split (backend owns the API,
+Thallo builds the page).
+
+## 4. Security model (the crux)
+
+Running `composer require` from a web request is remote code execution by design
+(`composer require` executes downloaded package scripts as the web user). The
+feature *is* the boundary around it. Controls, all required:
+
+1. **Permission tier — `system.config`.** Mutating endpoints call
+   `$this->requirePermission('system.config.edit')`; read endpoints call
+   `$this->requirePermission('system.config.view')` (via
+   `AuthorizationTrait`, the `ConfigController` precedent). Superuser bypass is
+   handled by the Gate's `SuperRoleVoter` (`config/permissions.php` →
+   `super_roles`). This is the one genuinely new capability the button grants —
+   it turns "admin login" into "server code execution", so it sits at the
+   highest existing tier, not `content.manage`.
+
+2. **Kill-switch — `EXTENSIONS_INSTALL_ENABLED`.** `config('extensions.install.enabled')`.
+   Default: enabled when `APP_ENV !== 'production'`; in production it is **off
+   unless explicitly set true**. When off, install/enable/disable return `403`
+   with a clear message; browse endpoints still work.
+
+3. **Host capability detection — every file the flow mutates.** A single
+   `HostCapability` check, reused by all mutating endpoints. **Install** requires
+   writability of *all* of: `vendor/`, `composer.json`, `composer.lock`,
+   `config/extensions.php`, and the extension cache
+   (`bootstrap/cache/extensions.php` + its directory) — plus a resolvable
+   composer binary. **Enable/disable** don't run composer but *do* rewrite
+   `config/extensions.php` and recompile the cache, so they run their own subset
+   preflight (`config/extensions.php` + `bootstrap/cache/`). Without the enable
+   subset check, an immutable deploy could pass the install preflight and then
+   fail halfway through the enable/cache step. For a target that does not yet
+   exist (e.g. no `composer.lock`/`vendor/` on a fresh box), the check walks up to
+   the nearest existing ancestor — the directory the file would be created in — so
+   a missing target under a read-only parent is caught, not skipped. On a
+   read-only/immutable container this fails cleanly: `409` with a specific `reason`
+   (`read_only_filesystem` | `composer_missing`), and the UI shows "add this on
+   deploy" instead of a broken spinner.
+
+4. **Package allowlist — catalog membership, not substring.** A package is
+   installable only if it is a member of the fetched Packagist catalog
+   (vendor `glueful/` **and** `type: glueful-extension`). We do **not** use
+   `str_contains('glueful')`. Belt-and-braces name validation before it ever
+   reaches composer:
+   - must match composer's package-name grammar
+     `^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9]([_.-]?[a-z0-9]+)*$`;
+   - must start with `glueful/`;
+   - must **not** start with `-` (blocks a name being read as a composer flag);
+   - must be present in the catalog.
+
+5. **No shell.** Every external command is invoked with **array arguments** —
+   never `shell_exec`, never a concatenated command string, so there is no
+   metacharacter/injection surface. The *outer* detached spawn (web → runner)
+   uses `proc_open` with an **argv array** (`setsid` prepended on POSIX is also
+   argv, not a shell string; see §5.6). The *inner* blocking runs (composer, and
+   the fresh-process enable) use Symfony `Process` with an argv array
+   (`['composer','require',$package,'--no-interaction','--no-progress']`).
+
+6. **Production guard is deliberately not inherited from the CLI.** The
+   `extensions:enable|disable` **console** commands refuse when
+   `APP_ENV === 'production'`. The HTTP path does **not** call those commands; it
+   calls `ExtensionStateWriter` + `ExtensionManager::writeCacheNow()` directly,
+   gated instead by controls 1–3. This is a conscious decision: the CLI guard
+   assumes "prod config is edited by hand"; the whole point here is to lift that
+   for authorized superusers behind the kill-switch.
+
+7. **Audit — concrete mechanism.** The framework has no dedicated audit service;
+   it uses channel-based structured logging (`LogManager->channel('name')->info(msg, context)`).
+   Every install/enable/disable writes a structured record to a dedicated
+   `audit` channel via `LogManager` (resolve `\Glueful\Logging\LogManager` from
+   the container), with context
+   `{ action: 'extension.install'|'extension.enable'|'extension.disable',
+   actor_id, resource_type: 'extension', resource_id: <package>,
+   result: 'succeeded'|'failed', duration_ms }`.
+
+## 5. Components
+
+### 5.1 `ExtensionsController` (framework)
+`src/Controllers/ExtensionsController.php` — an `ExtensionsController` already
+exists but is **unrouted** (dead `index()`/`summary()`). Repurpose/replace it as
+the manager controller. Extends `BaseController`; constructor injects
+`ApplicationContext`, `ExtensionCatalog`, `ExtensionInstaller`, `InstallJobStore`,
+and the enable/disable collaborators. Uses `success()/created()/forbidden()/notFound()`
+response helpers and `requirePermission()`.
+
+### 5.2 Routes
+`routes/extensions.php` (new framework route file), registered in
+`src/Routing/RouteManifest.php::generate()` under `api_routes` (so it mounts under
+the API prefix, e.g. `/api/v1/extensions`). Route file uses the fluent
+`$router->group(['prefix' => '/extensions'], …)` pattern (per `routes/health.php`),
+each route `->middleware(['auth', 'rate_limit:…'])`.
+
+> **UI path note:** extension/core routes are root-mounted for Thallo consumers in
+> the existing code via `loadRoutesFrom` (no prefix — the `/rbac`, `/email`
+> precedent). `RouteManifest` mounts core `api_routes` **under** the API prefix.
+> The plan must confirm which mount the Thallo `authFetch` client targets and keep
+> `queries/extensions.ts` consistent (literal `/extensions/*` vs
+> `${apiBase}/extensions/*`). Default assumption: API-prefixed, like other
+> `RouteManifest` core routes.
+
+### 5.3 `ExtensionCatalog` (framework service)
+`src/Extensions/ExtensionCatalog.php`. Responsibilities:
+- **Fetch** installable packages from Packagist via `Glueful\Http\Client::get()`,
+  in **two stages** (the search response alone is insufficient — verified:
+  `search.json` returns `name, description, url, repository, downloads, favers`
+  but **no `version` and no `type`**):
+  1. **List** — `https://packagist.org/search.json?type=glueful-extension&per_page=100`
+     (server-side type filter; follow `next` pagination), keep only `name`
+     starting `glueful/`. Gives name/description/downloads/repository.
+  2. **Hydrate** — for each candidate, fetch `https://repo.packagist.org/p2/<name>.json`
+     to obtain the latest stable `version` **and** re-verify
+     `type === 'glueful-extension'` (belt-and-braces, not relying on the
+     undocumented server-side filter). Only type-verified rows enter the catalog
+     — this is what makes the install allowlist (§4.4 "catalog membership")
+     genuinely type-checked.
+  Fallback if the search type filter returns nothing:
+  `https://packagist.org/packages/list.json?vendor=glueful` → the same p2 hydrate
+  + type filter. Cache the normalized, hydrated result in `CacheStore` (~1h TTL)
+  so the p2 fan-out runs at most hourly, not per request.
+- **Cross-reference state** against the local install:
+  - installed = keys of `PackageManifest::getCandidates()` (reads
+    `vendor/composer/installed.json`).
+  - enabled = `EnabledProviders::from($context)` (provider FQCNs).
+  - Each catalog row → `state ∈ {available, installed, enabled}` plus
+    `description`, `downloads`, `version`, `repository`.
+- **List installed** (for `GET /extensions`): the `ListCommand` cross-reference —
+  `getCandidates()` × `EnabledProviders::from()` × `ExtensionManager::listMeta()`
+  → rows with `state ∈ {enabled, available, enabled_missing}`
+  (`enabled_missing` = in allow-list but not a candidate).
+
+### 5.4 `ExtensionInstaller` + `InstallJobStore` (framework)
+- `src/Extensions/Install/InstallJobStore.php` — thin wrapper over `CacheStore`
+  (service id `cache.store` / `\Glueful\Cache\CacheStore::class`). Key
+  `ext_install:<jobId>`, TTL ~1h. Record shape:
+  ```
+  { id, package,
+    status: queued|running|succeeded|failed|installed_not_enabled,
+    output: string (tail, capped ~64KB), exitCode: ?int,
+    error: ?string,        // composer/spawn failure
+    enableError: ?string,  // set with status=installed_not_enabled
+    startedAt, finishedAt }
+  ```
+  `succeeded` = composer installed AND enabled (or auto-enable off, no error);
+  `installed_not_enabled` = composer installed but auto-enable failed (not a hard
+  failure — the operator can resolve the dependency and enable manually);
+  `failed` = composer/spawn failed.
+  Methods: `create(package): string jobId`, `get(jobId): ?array`,
+  `markRunning(jobId)`, `appendOutput(jobId, chunk)`,
+  `finish(jobId, status, exitCode, error=null)`.
+  > `CacheStore` must be a **shared** driver (file/redis, not the array driver) so
+  > the detached process and the web process see the same record. This is
+  > inherent — the runner is a separate process regardless.
+- `src/Extensions/Install/ExtensionInstaller.php` — `start(package): string jobId`:
+  runs the §4 validation, `InstallJobStore::create()`, spawns the detached runner
+  (§6.3), returns the jobId. Does **not** block.
+
+### 5.5 `extensions:install-run` console command (the runner)
+`src/Console/Commands/Extensions/InstallRunCommand.php` (`#[AsCommand('extensions:install-run')]`,
+extends `BaseCommand`). Args: `jobId`, `package`. This is the process the outer
+spawn (§5.6) launches detached. Flow:
+1. `InstallJobStore::markRunning(jobId)`.
+2. `new Process(['composer','require',$package,'--no-interaction','--no-progress'], base_path($ctx))`
+   with `setTimeout((float) config('extensions.install.timeout', 600))`; run
+   (blocking — correct here, we're already detached) with a callback that
+   `appendOutput`s each buffer chunk. On non-zero →
+   `finish(jobId, failed, exitCode, stderrTail)` and stop.
+3. On exit 0 and `config('extensions.install.auto_enable', true)`: **hand the
+   enable+cache step to a fresh PHP subprocess** (§5.5b) via
+   `new Process([PHP_BINARY, base_path($ctx,'glueful'), 'extensions:enable-installed', $package], base_path($ctx))` →
+   `->run()` (blocking; we want its result). Merge its outcome into the job
+   record.
+
+   > **Why a fresh process (P1 fix).** The runner started *before* composer wrote
+   > the new package, so its in-memory autoloader can't see the new provider
+   > class. `ExtensionManager::writeCacheNow()` instantiates providers
+   > (`class_exists`/construct), so calling it in the runner would silently drop
+   > or fail on the just-installed provider. A fresh `php` process loads the
+   > freshly-generated `vendor/autoload.php` and resolves the provider correctly.
+4. `InstallJobStore::finish(jobId, succeeded|failed, exitCode, error?)`. If
+   composer succeeded but enable-installed reported a resolver error, the terminal
+   state is `succeeded` with an `enable_error` note (installed-but-not-enabled is
+   valid).
+
+Injecting both `Process` calls via a small factory keeps the command testable
+without hitting real composer/network.
+
+### 5.5b `extensions:enable-installed` console command (fresh-process enabler)
+`src/Console/Commands/Extensions/EnableInstalledCommand.php`
+(`#[AsCommand('extensions:enable-installed')]`). Arg: `package`. Runs in its own
+PHP process (fresh autoloader). Flow: resolve provider FQCN via
+`PackageManifest::getCandidates()`; preflight the proposed enabled set with
+`(new ExtensionResolver())->resolve($candidates, $proposed, Version::VERSION)`;
+on no errors, `(new ExtensionStateWriter())->enable(config_path($ctx,'extensions.php'), $provider)`
+then `$this->getService(ExtensionManager::class)->writeCacheNow()`. Prints a
+structured result (JSON line) the runner parses. **No `APP_ENV=production`
+guard** — unlike the interactive `extensions:enable`, this internal command is
+only reachable via the runner, which is gated upstream by the HTTP kill-switch +
+`system.config.edit` + host-capability checks. Reusable as the shared
+enable-after-install seam.
+
+### 5.6 `DetachedRunner` helper (framework) — the true non-blocking spawn
+`src/Support/Process/DetachedRunner.php`. Spawns the runner so the install POST
+**returns immediately** and the child **outlives the request**.
+
+> **P1 correction — do NOT use Symfony `Process` here.** `setsid <program>` does
+> not daemonize on its own (it `exec`s the program in a new session, keeping the
+> same child PID), and `Process::run()` *waits* for that child — so
+> `Process(['setsid', …])->run()` would block for the entire composer run,
+> breaking §3's contract. `Process::start()` doesn't fix it either: Symfony
+> `Process::__destruct()` calls `stop()`, which SIGKILLs the child when the
+> object is GC'd at request end.
+
+**Mechanism — `proc_open` with an argv array, no wait, stdio redirected to the
+job log:**
+```php
+$cmd = ['setsid', PHP_BINARY, base_path($ctx,'glueful'),
+        'extensions:install-run', $jobId, $package];   // setsid dropped in fallback
+$log = storage_path($ctx, "logs/ext-install-$jobId.log");
+$descriptors = [
+    0 => ['file', '/dev/null', 'r'],
+    1 => ['file', $log, 'w'],
+    2 => ['file', $log, 'a'],
+];
+$proc = proc_open($cmd, $descriptors, $pipes, base_path($ctx));
+// return NOW — no proc_close()/wait. proc_open children are NOT reaped by PHP on
+// shutdown (unlike Symfony Process), so the child survives the request.
+```
+- **`proc_open` gives the non-blocking property** (it returns as soon as the child
+  is spawned; we never wait on it).
+- **`setsid` gives the survival property** on POSIX — the child runs in a new
+  session, so a signal to the FPM worker's process group on recycle won't reach
+  it. Still pure argv (no shell), so no injection surface.
+- **Fallback (macOS dev — `setsid` verified absent on the dev box):** same
+  `proc_open` without the `setsid` prefix. Still non-blocking and not reaped by
+  PHP; the child shares the session, acceptable outside production. Strategy chosen
+  by probing for a `setsid` binary on `PATH`, defaulting to the no-setsid path.
+- The runner streams composer output to `InstallJobStore` (the poll source); the
+  `$log` file is a redundant on-disk transcript for debugging.
+
+**Testability / acceptance:** `DetachedRunner` takes an injectable spawn callable
+(default wraps `proc_open`) so tests assert (a) the exact argv is built,
+(b) `setsid` is present/absent per the probe, and (c) **the call returns without
+waiting** — e.g. spawn a marker runner that sleeps and assert `DetachedRunner`
+returns before the marker completes. This directly guards the "returns
+immediately" contract.
+
+### 5.7 Request DTOs (framework)
+`src/DTOs/ExtensionInstallData.php`, `ExtensionToggleData.php` implementing
+`Glueful\Validation\Contracts\RequestData`:
+```php
+final class ExtensionInstallData implements RequestData {
+    public function __construct(
+        #[Rule('required|string|max:150')] public readonly string $package,
+    ) {}
+}
+```
+(The strict allowlist/grammar check in §4 runs in `ExtensionInstaller`, not the
+DTO — it needs the live catalog.) `enable`/`disable` take
+`ExtensionToggleData { package }`.
+
+### 5.8 Config + env
+`config/extensions.php` gains a sibling key to `enabled` (keep `enabled` a pure
+literal list — the doc comment forbids `env()` calls *inside* it):
+```php
+'install' => [
+    'enabled'     => env('EXTENSIONS_INSTALL_ENABLED', env('APP_ENV') !== 'production'),
+    'auto_enable' => env('EXTENSIONS_INSTALL_AUTO_ENABLE', true),
+    'timeout'     => (int) env('EXTENSIONS_INSTALL_TIMEOUT', 600),
+    'vendor'      => 'glueful/',   // allowlist prefix
+],
+```
+Add `EXTENSIONS_INSTALL_ENABLED`, `EXTENSIONS_INSTALL_AUTO_ENABLE`,
+`EXTENSIONS_INSTALL_TIMEOUT` to `.env.example` with comments. Mirror the `install`
+block into the api-skeleton's shadow `config/extensions.php` on release
+(skeleton config parity).
+
+### 5.9 Thallo UI
+- `admin/src/queries/extensions.ts` — `authFetch` wrappers + TS types
+  (`ExtensionRow`, `CatalogRow`, `InstallJob`) for the six endpoints, following
+  `queries/email.ts` conventions.
+- `admin/src/pages/developers/extensions/index.vue` — two sections:
+  **Installed** (list with enable/disable toggles, `state` badges) and
+  **Browse / catalog** (cards with Install buttons). Install → POST → poll
+  `GET /extensions/install/{jobId}` every ~1.5s, show streaming output in a
+  disclosure, flip to "enabled" on success. `403` (kill-switch/permission) hides
+  the install affordance with an explanatory note; `409 read_only_filesystem`
+  shows "install on deploy". No CodeMirror here.
+- No new Thallo controller (API is framework); page is frontend-only.
+
+## 6. API contract
+
+| Method | Path | Permission | Body | Returns |
+|---|---|---|---|---|
+| GET  | `/extensions` | `system.config.view` | — | `{ installed: ExtensionRow[] }` |
+| GET  | `/extensions/catalog` | `system.config.view` | — | `{ catalog: CatalogRow[] }` (cached) |
+| POST | `/extensions/install` | `system.config.edit` | `{ package }` | `201 { jobId, status:'queued' }` / `403` (switch/perm) / `409 { reason }` (host) / `422` (bad package) |
+| GET  | `/extensions/install/{jobId}` | `system.config.view` | — | `{ id, package, status, output, exitCode, error, startedAt, finishedAt }` / `404` |
+| POST | `/extensions/enable` | `system.config.edit` | `{ package }` | `{ package, provider, state:'enabled' }` / `409 { reason }` (config/cache not writable) / `422` (resolver error) |
+| POST | `/extensions/disable` | `system.config.edit` | `{ package }` | `{ package, provider, state:'available' }` / `409 { reason }` (config/cache not writable) / `422` (dependency block) |
+
+`ExtensionRow = { package, provider, version, label, state: 'enabled'|'available'|'enabled_missing' }`
+`CatalogRow  = { package, description, version, downloads, repository, state: 'available'|'installed'|'enabled' }`
+
+## 7. Data flow — install
+
+1. UI `POST /extensions/install { package: 'glueful/aegis' }`.
+2. Controller `requirePermission('system.config.edit')` → `ExtensionInstaller::start()`.
+3. Installer validates: kill-switch on, host writable, name grammar + `glueful/`
+   prefix + catalog membership. Fail → `403`/`409`/`422` (no job created).
+4. `InstallJobStore::create()` → jobId; `DetachedRunner` spawns
+   `php glueful extensions:install-run <jobId> glueful/aegis`; controller returns
+   `201 { jobId }`.
+5. Runner (detached via `proc_open`+`setsid`, §5.6): `markRunning` →
+   `composer require …` (Symfony `Process`, streaming `appendOutput`) → on 0 +
+   auto_enable: spawn a **fresh** `php glueful extensions:enable-installed glueful/aegis`
+   process (§5.5b — fresh autoloader sees the new provider) which does resolver
+   preflight → `ExtensionStateWriter::enable` → `writeCacheNow`; merge its result
+   → `finish(succeeded)` (or `finish(installed_not_enabled)` + `enableError` if the
+   preflight blocked enabling). On composer non-zero: `finish(failed, exitCode, stderrTail)`.
+6. UI polls `GET /extensions/install/{jobId}` until `status ∈ {succeeded, failed}`,
+   renders output, refreshes the installed list.
+
+## 8. Error handling
+
+- **Bad/foreign/flag-like package** → `422` before any job; never reaches composer.
+- **Kill-switch off / missing permission** → `403`.
+- **Read-only host** → `409 { reason }` with the specific failing capability:
+  install checks all five mutated paths; enable/disable check the config + cache
+  subset (so an immutable deploy is rejected up front, not mid-enable).
+  `reason ∈ { read_only_filesystem, composer_missing }`.
+- **composer non-zero** → job `failed` with captured stderr tail + exitCode; tree
+  left as-is (no auto-rollback in v1); UI shows the failure and output.
+- **Resolver preflight error post-install** (e.g. missing dependency) → package
+  stays installed but **not enabled**; job ends with the distinct terminal status
+  `installed_not_enabled` and `enableError` set; UI shows "installed, needs a
+  dependency" (a warning, not a failure) rather than silently enabling.
+- **Timeout** → Process killed at `install.timeout`; job `failed` with a timeout
+  note.
+- **Poll after TTL expiry** → `404`; UI treats a lost job as "unknown — refresh".
+
+## 9. Testing
+
+**Framework (PHPUnit):**
+- Unit: package-name validator (rejects non-`glueful/`, `--flag`, invalid grammar,
+  non-catalog); `ExtensionCatalog` state cross-reference with a stubbed
+  `Http\Client` + fake `installed.json`/enabled list; `InstallJobStore`
+  round-trip on a file/array-backed `CacheStore`; `DetachedRunner` builds the
+  correct argv for setsid vs fallback (probe stubbed).
+- Integration: controller endpoints with a fake `ExtensionInstaller` (no real
+  composer): `403` without `system.config`, `403` when kill-switch off,
+  `409` when host not writable, `201 { jobId }` on happy path, `422` on bad
+  package; `enable`/`disable` call `ExtensionStateWriter` + `writeCacheNow`
+  (spy), return `409` when `config/extensions.php`/cache aren't writable
+  (the enable-subset preflight), and surface resolver errors as `422`.
+- `HostCapability`: reports the exact unwritable path/`reason` for each of the
+  five install paths and the two enable/disable paths (temp-dir fixtures with
+  chmod-toggled writability).
+- `DetachedRunner`: injected spawn callable → asserts the exact argv,
+  `setsid` present/absent per the probe, and **that it returns without waiting**
+  (spawn a sleeping marker runner; assert the call returns before the marker
+  finishes) — the guard for the §3 non-blocking contract.
+- Runner: `InstallRunCommand` with an injected fake `Process` factory (scripted
+  exit code + output for both the composer call and the fresh
+  `extensions:enable-installed` call) → asserts job transitions, that composer
+  failure short-circuits before enable, and that the auto-enable path invokes the
+  **fresh-process** command (not an in-process `writeCacheNow`); **never** shells
+  out in tests.
+- `EnableInstalledCommand`: with a fake candidate set → resolver-clean path calls
+  `ExtensionStateWriter::enable` + `writeCacheNow` (spies) and emits the structured
+  result line; resolver-error path emits the error without writing.
+
+**Thallo (vitest):** mock `queries/extensions.ts`; assert installed list +
+catalog render, install → poll → enabled transition, `403` hides install with a
+note, `409` shows "install on deploy". Stub any editor; none needed here.
+
+## 10. Open items for the plan
+- Confirm the Thallo mount (API-prefixed `RouteManifest` vs root-mounted) and pin
+  `queries/extensions.ts` base accordingly.
+- Confirm the `Version` import path used for the resolver preflight (the CLI
+  commands reference `Version::VERSION`).
+- Decide the catalog cache TTL + a manual "refresh catalog" affordance.
+- Confirm `storage_path()`/log location helper for the runner's on-disk transcript.

--- a/routes/extensions.php
+++ b/routes/extensions.php
@@ -1,0 +1,31 @@
+<?php
+
+use Glueful\Routing\Router;
+use Glueful\Controllers\ExtensionsController;
+
+/**
+ * @var \Glueful\Routing\Router $router Router instance injected by RouteManifest::load()
+ *
+ * In-admin extensions manager. Mounted under the API prefix (e.g. /api/v1/extensions).
+ * Authorization is enforced in the controller (system.config.view / .edit); `auth`
+ * middleware guarantees an authenticated principal first.
+ */
+$router->group(['prefix' => '/extensions'], function (Router $router) {
+    $router->get('/', [ExtensionsController::class, 'index'])
+        ->middleware(['auth', 'rate_limit:60,60']);
+
+    $router->get('/catalog', [ExtensionsController::class, 'catalog'])
+        ->middleware(['auth', 'rate_limit:30,60']);
+
+    $router->post('/install', [ExtensionsController::class, 'install'])
+        ->middleware(['auth', 'rate_limit:10,60']);
+
+    $router->get('/install/{jobId}', [ExtensionsController::class, 'installStatus'])
+        ->middleware(['auth', 'rate_limit:120,60']);
+
+    $router->post('/enable', [ExtensionsController::class, 'enable'])
+        ->middleware(['auth', 'rate_limit:20,60']);
+
+    $router->post('/disable', [ExtensionsController::class, 'disable'])
+        ->middleware(['auth', 'rate_limit:20,60']);
+});

--- a/src/Console/Commands/Extensions/EnableInstalledCommand.php
+++ b/src/Console/Commands/Extensions/EnableInstalledCommand.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Console\Commands\Extensions;
+
+use Glueful\Console\BaseCommand;
+use Glueful\Extensions\EnabledProviders;
+use Glueful\Extensions\ExtensionManager;
+use Glueful\Extensions\ExtensionResolver;
+use Glueful\Extensions\ExtensionStateWriter;
+use Glueful\Extensions\PackageManifest;
+use Glueful\Support\Version;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Enable a just-installed extension — internal, runs in a FRESH PHP process.
+ *
+ * The install runner spawns this in a new process precisely because its own
+ * in-memory autoloader predates `composer require` and cannot see the new provider
+ * class; a fresh process loads the freshly-generated vendor/autoload.php. Unlike
+ * the interactive `extensions:enable`, this has NO APP_ENV=production guard — it is
+ * only reachable via the runner, which is gated upstream by the HTTP kill-switch,
+ * `system.config.edit`, and host-capability checks. Emits a single JSON line the
+ * runner parses.
+ */
+#[AsCommand(
+    name: 'extensions:enable-installed',
+    description: 'Enable a just-installed extension (internal; runs in a fresh PHP process)'
+)]
+final class EnableInstalledCommand extends BaseCommand
+{
+    protected function configure(): void
+    {
+        $this->addArgument('package', InputArgument::REQUIRED, 'Composer package, e.g. glueful/aegis');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $package = (string) $input->getArgument('package');
+        $context = $this->getContext();
+
+        $candidates = (new PackageManifest($context))->getCandidates();
+        $candidate = $candidates[$package] ?? null;
+        if ($candidate === null) {
+            return $this->emit($output, false, error: "Package not installed or not a Glueful extension: {$package}");
+        }
+        $provider = $candidate->provider;
+
+        $current = EnabledProviders::from($context);
+        if (in_array($provider, $current, true)) {
+            return $this->emit($output, true, provider: $provider);
+        }
+
+        $proposed = [...$current, $provider];
+        $result = (new ExtensionResolver())->resolve($candidates, $proposed, Version::VERSION);
+        if ($result->hasErrors()) {
+            $message = implode('; ', array_map(
+                static fn($e) => "[{$e->kind}] {$e->message}",
+                $result->errors,
+            ));
+            return $this->emit($output, false, error: $message);
+        }
+
+        try {
+            (new ExtensionStateWriter())->enable(config_path($context, 'extensions.php'), $provider);
+            $this->getService(ExtensionManager::class)->writeCacheNow();
+        } catch (\Throwable $e) {
+            return $this->emit($output, false, error: $e->getMessage());
+        }
+
+        return $this->emit($output, true, provider: $provider);
+    }
+
+    private function emit(OutputInterface $output, bool $ok, ?string $provider = null, ?string $error = null): int
+    {
+        $payload = ['ok' => $ok];
+        if ($provider !== null) {
+            $payload['provider'] = $provider;
+        }
+        if ($error !== null) {
+            $payload['error'] = $error;
+        }
+        $output->writeln((string) json_encode($payload));
+        return $ok ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/src/Console/Commands/Extensions/InstallRunCommand.php
+++ b/src/Console/Commands/Extensions/InstallRunCommand.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Console\Commands\Extensions;
+
+use Glueful\Bootstrap\ApplicationContext;
+use Glueful\Console\BaseCommand;
+use Glueful\Extensions\Install\InstallJobStore;
+use Glueful\Support\Process\ComposerBinaryResolver;
+use Glueful\Support\Process\ProcessRunner;
+use Glueful\Support\Process\SymfonyProcessRunner;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * The detached install runner: `composer require <package>` then a FRESH-process
+ * enable. Launched by DetachedRunner so the install POST returns immediately; this
+ * process streams status into InstallJobStore, which the admin page polls.
+ *
+ * Terminal states:
+ *  - failed                — composer/spawn failed (enable never attempted)
+ *  - installed_not_enabled — composer installed but auto-enable failed (enableError)
+ *  - succeeded             — installed AND enabled (or auto-enable disabled)
+ */
+#[AsCommand(
+    name: 'extensions:install-run',
+    description: 'Run a detached extension install (composer require + fresh-process enable)'
+)]
+final class InstallRunCommand extends BaseCommand
+{
+    private ComposerBinaryResolver $composer;
+
+    public function __construct(
+        ?ContainerInterface $container = null,
+        ?ApplicationContext $context = null,
+        private ?ProcessRunner $runner = null,
+        ?ComposerBinaryResolver $composer = null,
+    ) {
+        parent::__construct($container, $context);
+        $this->runner ??= new SymfonyProcessRunner();
+        $this->composer = $composer ?? new ComposerBinaryResolver();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('jobId', InputArgument::REQUIRED);
+        $this->addArgument('package', InputArgument::REQUIRED);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $jobId = (string) $input->getArgument('jobId');
+        $package = (string) $input->getArgument('package');
+        $context = $this->getContext();
+        /** @var InstallJobStore $store */
+        $store = $this->getService(InstallJobStore::class);
+        $cwd = base_path($context);
+
+        $store->markRunning($jobId);
+
+        // SAME resolver as the preflight (honors COMPOSER_BINARY) — never a second search.
+        $composer = $this->composer->resolve();
+        if ($composer === null) {
+            $store->finish($jobId, 'failed', null, 'composer binary not found');
+            return self::FAILURE;
+        }
+
+        $timeout = (float) config($context, 'extensions.install.timeout', 600);
+        $install = $this->runner->run(
+            [$composer, 'require', $package, '--no-interaction', '--no-progress'],
+            $cwd,
+            $timeout,
+            static fn(string $chunk) => $store->appendOutput($jobId, $chunk),
+        );
+
+        if ($install['exitCode'] !== 0) {
+            $store->finish($jobId, 'failed', $install['exitCode'], 'composer require failed');
+            return self::FAILURE;
+        }
+
+        $enableError = null;
+        if ((bool) config($context, 'extensions.install.auto_enable', true)) {
+            $enable = $this->runner->run(
+                [PHP_BINARY, base_path($context, 'glueful'), 'extensions:enable-installed', $package],
+                $cwd,
+                120.0,
+                static fn(string $chunk) => $store->appendOutput($jobId, $chunk),
+            );
+            $decoded = $this->lastJsonLine($enable['output']);
+            if (($decoded['ok'] ?? false) !== true) {
+                $enableError = is_string($decoded['error'] ?? null) ? $decoded['error'] : 'enable failed';
+            }
+        }
+
+        // Distinct terminal states: `succeeded` = installed AND enabled; an
+        // auto-enable failure is `installed_not_enabled` (recoverable), NOT `failed`.
+        if ($enableError !== null) {
+            $store->finish($jobId, 'installed_not_enabled', 0, null, $enableError);
+            return self::SUCCESS;
+        }
+        $store->finish($jobId, 'succeeded', 0);
+        return self::SUCCESS;
+    }
+
+    /** @return array<string,mixed> */
+    private function lastJsonLine(string $output): array
+    {
+        $lines = array_reverse(array_filter(array_map('trim', explode("\n", $output))));
+        foreach ($lines as $line) {
+            $decoded = json_decode($line, true);
+            if (is_array($decoded)) {
+                return $decoded;
+            }
+        }
+        return [];
+    }
+}

--- a/src/Container/Providers/CoreProvider.php
+++ b/src/Container/Providers/CoreProvider.php
@@ -814,6 +814,20 @@ final class CoreProvider extends BaseServiceProvider
             fn() => new \Glueful\Encryption\EncryptionService($this->context)
         );
 
+        // Extensions manager / installer services (in-admin extension installer)
+        $defs[\Glueful\Support\Process\ComposerBinaryResolver::class] =
+            $this->autowire(\Glueful\Support\Process\ComposerBinaryResolver::class);
+        $defs[\Glueful\Extensions\Install\HostCapability::class] =
+            $this->autowire(\Glueful\Extensions\Install\HostCapability::class);
+        $defs[\Glueful\Extensions\Install\InstallJobStore::class] =
+            $this->autowire(\Glueful\Extensions\Install\InstallJobStore::class);
+        $defs[\Glueful\Support\Process\DetachedRunner::class] =
+            $this->autowire(\Glueful\Support\Process\DetachedRunner::class);
+        $defs[\Glueful\Extensions\ExtensionCatalog::class] =
+            $this->autowire(\Glueful\Extensions\ExtensionCatalog::class);
+        $defs[\Glueful\Extensions\Install\ExtensionInstaller::class] =
+            $this->autowire(\Glueful\Extensions\Install\ExtensionInstaller::class);
+
         return $defs;
     }
 }

--- a/src/Controllers/ExtensionsController.php
+++ b/src/Controllers/ExtensionsController.php
@@ -4,62 +4,144 @@ declare(strict_types=1);
 
 namespace Glueful\Controllers;
 
-use Glueful\Http\Response;
+use Glueful\Bootstrap\ApplicationContext;
+use Glueful\DTOs\ExtensionInstallData;
+use Glueful\DTOs\ExtensionToggleData;
+use Glueful\Extensions\EnabledProviders;
+use Glueful\Extensions\ExtensionCatalog;
 use Glueful\Extensions\ExtensionManager;
+use Glueful\Extensions\ExtensionResolver;
+use Glueful\Extensions\ExtensionStateWriter;
+use Glueful\Extensions\Install\ExtensionInstaller;
+use Glueful\Extensions\Install\HostCapability;
+use Glueful\Extensions\Install\HostNotWritableException;
+use Glueful\Extensions\Install\InstallDisabledException;
+use Glueful\Extensions\Install\InstallJobStore;
+use Glueful\Extensions\Install\PackageNotAllowedException;
+use Glueful\Extensions\PackageManifest;
+use Glueful\Http\Response;
+use Glueful\Support\Version;
+use Psr\Log\LoggerInterface;
 
 /**
- * Simplified read-only Extensions API
+ * In-admin extensions manager API (browse / install / enable / disable).
  *
- * Provides basic extension information for monitoring and CLI support.
- * Extension management is now done via CLI commands and config files.
+ * Mutating actions require the `system.config.edit` tier; reads require
+ * `system.config.view`. Install is gated further by the kill-switch + host
+ * capability inside {@see ExtensionInstaller}. All actions are audited.
  */
 class ExtensionsController extends BaseController
 {
     public function __construct(
-        \Glueful\Bootstrap\ApplicationContext $context,
-        private ExtensionManager $extensionManager
+        ApplicationContext $context,
+        private ExtensionCatalog $catalog,
+        private ExtensionInstaller $installer,
+        private InstallJobStore $jobs,
+        private HostCapability $host,
+        private ExtensionManager $extensions,
+        private LoggerInterface $auditLog,
     ) {
         parent::__construct($context);
     }
 
-    /**
-     * List all discovered extensions (read-only)
-     *
-     * @return mixed HTTP response
-     */
-    public function index(): mixed
+    /** Installed extensions with enable/disable state. */
+    public function index(): Response
     {
-        $providers = $this->extensionManager->getProviders();
-        $meta = $this->extensionManager->listMeta();
-
-        $extensions = [];
-        foreach ($providers as $class => $provider) {
-            $m = $meta[$class] ?? [];
-            $extensions[] = [
-                'slug' => $m['slug'] ?? basename(str_replace('\\', '/', $class)),
-                'name' => $m['name'] ?? $class,
-                'version' => $m['version'] ?? 'n/a',
-                'description' => $m['description'] ?? '',
-                'provider' => $class,
-            ];
-        }
-
-        return Response::success([
-            'extensions' => $extensions,
-            'total' => count($extensions)
-        ], 'Extensions retrieved successfully');
+        $this->requirePermission('system.config.view');
+        return $this->success(['installed' => $this->catalog->installed()]);
     }
 
-    /**
-     * Get extension system summary
-     *
-     * @return mixed HTTP response
-     */
-    public function summary(): mixed
+    /** Installable extensions from Packagist (cached), annotated with local state. */
+    public function catalog(): Response
     {
-        return Response::success(
-            $this->extensionManager->getSummary(),
-            'Extension system summary retrieved successfully'
-        );
+        $this->requirePermission('system.config.view');
+        return $this->success(['catalog' => $this->catalog->catalog()]);
+    }
+
+    /** Start a detached install; returns a job id the client polls. */
+    public function install(ExtensionInstallData $data): Response
+    {
+        $this->requirePermission('system.config.edit');
+        try {
+            $result = $this->installer->start($data->package);
+        } catch (InstallDisabledException $e) {
+            return $this->forbidden($e->getMessage());
+        } catch (HostNotWritableException $e) {
+            return Response::error($e->getMessage(), 409, ['reason' => $e->reason]);
+        } catch (PackageNotAllowedException $e) {
+            return $this->validationError(['package' => [$e->getMessage()]]);
+        }
+        $this->audit('extension.install', $data->package, 'queued');
+        return $this->created($result, 'Install started');
+    }
+
+    /** Poll a running/finished install job. */
+    public function installStatus(string $jobId): Response
+    {
+        $this->requirePermission('system.config.view');
+        $record = $this->jobs->get($jobId);
+        return $record === null ? $this->notFound('Unknown install job') : $this->success($record);
+    }
+
+    public function enable(ExtensionToggleData $data): Response
+    {
+        return $this->toggle($data->package, enable: true);
+    }
+
+    public function disable(ExtensionToggleData $data): Response
+    {
+        return $this->toggle($data->package, enable: false);
+    }
+
+    private function toggle(string $package, bool $enable): Response
+    {
+        $this->requirePermission('system.config.edit');
+
+        if (($cap = $this->host->forToggle()) !== null) {
+            return Response::error('Host not writable', 409, ['reason' => $cap['reason']]);
+        }
+
+        $candidates = (new PackageManifest($this->context))->getCandidates();
+        $candidate = $candidates[$package] ?? null;
+        if ($candidate === null) {
+            return $this->notFound("Not an installed extension: {$package}");
+        }
+        $provider = $candidate->provider;
+        $current = EnabledProviders::from($this->context);
+        $proposed = $enable
+            ? [...$current, $provider]
+            : array_values(array_filter($current, static fn($p) => $p !== $provider));
+
+        $result = (new ExtensionResolver())->resolve($candidates, $proposed, Version::VERSION);
+        if ($result->hasErrors()) {
+            return $this->validationError(['extension' => array_map(
+                static fn($e) => "[{$e->kind}] {$e->message}",
+                $result->errors,
+            )]);
+        }
+
+        $writer = new ExtensionStateWriter();
+        $configPath = config_path($this->context, 'extensions.php');
+        $enable ? $writer->enable($configPath, $provider) : $writer->disable($configPath, $provider);
+        $this->extensions->writeCacheNow();
+
+        $this->audit($enable ? 'extension.enable' : 'extension.disable', $package, 'succeeded');
+        return $this->success([
+            'package' => $package,
+            'provider' => $provider,
+            'state' => $enable ? 'enabled' : 'available',
+        ]);
+    }
+
+    private function audit(string $action, string $package, string $result): void
+    {
+        $this->auditLog->info($action, [
+            'log_channel' => 'audit',
+            'action' => $action,
+            'actor_id' => $this->getCurrentUserUuid(),
+            'resource_type' => 'extension',
+            'resource_id' => $package,
+            'result' => $result,
+        ]);
     }
 }

--- a/src/DTOs/ExtensionInstallData.php
+++ b/src/DTOs/ExtensionInstallData.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\DTOs;
+
+use Glueful\Validation\Attributes\Rule;
+use Glueful\Validation\Contracts\RequestData;
+
+/**
+ * Request body for the extensions install endpoint.
+ *
+ * The router hydrates + validates this before the controller runs; a missing/blank
+ * `package` is a 422 here. The strict allowlist (vendor prefix, name grammar,
+ * catalog membership) runs later in {@see \Glueful\Extensions\Install\ExtensionInstaller}
+ * because it needs the live catalog.
+ */
+final class ExtensionInstallData implements RequestData
+{
+    public function __construct(
+        #[Rule('required|string|max:150')]
+        public string $package,
+    ) {
+    }
+}

--- a/src/DTOs/ExtensionToggleData.php
+++ b/src/DTOs/ExtensionToggleData.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\DTOs;
+
+use Glueful\Validation\Attributes\Rule;
+use Glueful\Validation\Contracts\RequestData;
+
+/** Request body for the extensions enable/disable endpoints. */
+final class ExtensionToggleData implements RequestData
+{
+    public function __construct(
+        #[Rule('required|string|max:150')]
+        public string $package,
+    ) {
+    }
+}

--- a/src/Extensions/ExtensionCatalog.php
+++ b/src/Extensions/ExtensionCatalog.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions;
+
+use Glueful\Bootstrap\ApplicationContext;
+use Glueful\Cache\CacheStore;
+use Glueful\Http\Client;
+
+/**
+ * The installable / installed extension catalog.
+ *
+ * Browse = Packagist packages of type `glueful-extension` under the `glueful/`
+ * vendor, hydrated for version + type re-verification, then cross-referenced with
+ * the local install so each row carries a state. Installed = the local candidates
+ * cross-referenced with the enabled allow-list.
+ */
+class ExtensionCatalog
+{
+    private const CACHE_KEY = 'ext_catalog:glueful';
+    private const CACHE_TTL = 3600;
+    private const VENDOR = 'glueful/';
+    private const SEARCH_URL = 'https://packagist.org/search.json?type=glueful-extension&per_page=100';
+
+    /** @param CacheStore<mixed> $cache */
+    public function __construct(
+        private ApplicationContext $context,
+        private Client $http,
+        private CacheStore $cache,
+        private ExtensionManager $extensions,
+    ) {
+    }
+
+    /**
+     * @return list<array{package:string,description:string,version:?string,downloads:int,repository:string,state:string}>
+     */
+    public function catalog(bool $refresh = false): array
+    {
+        $packages = $refresh ? null : $this->cache->get(self::CACHE_KEY);
+        if (!is_array($packages)) {
+            $packages = $this->fetchFromPackagist();
+            $this->cache->set(self::CACHE_KEY, $packages, self::CACHE_TTL);
+        }
+
+        $installed = $this->installedMap();
+        $enabled = EnabledProviders::from($this->context);
+
+        return array_map(function (array $p) use ($installed, $enabled): array {
+            $state = 'available';
+            if (isset($installed[$p['package']])) {
+                $state = in_array($installed[$p['package']], $enabled, true) ? 'enabled' : 'installed';
+            }
+            return [...$p, 'state' => $state];
+        }, $packages);
+    }
+
+    /**
+     * @return list<array{package:string,provider:string,version:?string,label:string,state:string}>
+     */
+    public function installed(): array
+    {
+        $candidates = (new PackageManifest($this->context))->getCandidates();
+        $enabled = EnabledProviders::from($this->context);
+        $meta = $this->extensions->listMeta();
+
+        $rows = [];
+        $known = [];
+        foreach ($candidates as $package => $candidate) {
+            $known[] = $candidate->provider;
+            $rows[] = [
+                'package' => $package,
+                'provider' => $candidate->provider,
+                'version' => $candidate->version,
+                'label' => is_string($meta[$candidate->provider]['name'] ?? null)
+                    ? $meta[$candidate->provider]['name']
+                    : $package,
+                'state' => in_array($candidate->provider, $enabled, true) ? 'enabled' : 'available',
+            ];
+        }
+        // enabled-but-missing: allow-listed provider with no installed candidate.
+        foreach ($enabled as $provider) {
+            if (!in_array($provider, $known, true)) {
+                $rows[] = [
+                    'package' => $provider,
+                    'provider' => $provider,
+                    'version' => null,
+                    'label' => $provider,
+                    'state' => 'enabled_missing',
+                ];
+            }
+        }
+        return $rows;
+    }
+
+    /** @return array<string,string> package => provider (installed candidates) */
+    private function installedMap(): array
+    {
+        $out = [];
+        foreach ((new PackageManifest($this->context))->getCandidates() as $package => $candidate) {
+            $out[$package] = $candidate->provider;
+        }
+        return $out;
+    }
+
+    /**
+     * @return list<array{package:string,description:string,version:?string,downloads:int,repository:string}>
+     */
+    private function fetchFromPackagist(): array
+    {
+        $rows = [];
+        foreach ($this->searchNames() as $name => $summary) {
+            $version = $this->hydrateVersion($name); // null when not a glueful-extension
+            if ($version === false) {
+                continue;
+            }
+            $rows[] = [
+                'package' => $name,
+                'description' => is_string($summary['description'] ?? null) ? $summary['description'] : '',
+                'version' => $version,
+                'downloads' => (int) ($summary['downloads'] ?? 0),
+                'repository' => is_string($summary['repository'] ?? null) ? $summary['repository'] : '',
+            ];
+        }
+        return $rows;
+    }
+
+    /** @return array<string,array<string,mixed>> name => summary, vendor-filtered */
+    private function searchNames(): array
+    {
+        $url = self::SEARCH_URL;
+        $out = [];
+        while ($url !== null) {
+            $json = $this->fetchJson($url);
+            foreach ($this->asList($json['results'] ?? null) as $result) {
+                $name = is_string($result['name'] ?? null) ? $result['name'] : '';
+                if (str_starts_with($name, self::VENDOR)) {
+                    $out[$name] = $result;
+                }
+            }
+            $url = is_string($json['next'] ?? null) ? $json['next'] : null;
+        }
+        return $out;
+    }
+
+    /**
+     * Latest stable version string, null when unknown, or false when the package
+     * is NOT type `glueful-extension` (excluded from the catalog).
+     *
+     * @return string|null|false
+     */
+    private function hydrateVersion(string $name)
+    {
+        $json = $this->fetchJson("https://repo.packagist.org/p2/{$name}.json");
+        $versions = $this->asList($json['packages'][$name] ?? null);
+        if ($versions === []) {
+            return false;
+        }
+        $latestStable = null;
+        foreach ($versions as $version) {
+            if (($version['type'] ?? null) !== 'glueful-extension') {
+                return false; // type re-verification failed
+            }
+            $ver = is_string($version['version'] ?? null) ? $version['version'] : '';
+            if ($latestStable === null && $ver !== '' && !str_contains($ver, 'dev')) {
+                $latestStable = $ver; // p2 lists newest first
+            }
+        }
+        return $latestStable;
+    }
+
+    /**
+     * Seam over the HTTP client so catalog logic is unit-testable without HTTP.
+     *
+     * @return array<string,mixed>
+     */
+    protected function fetchJson(string $url): array
+    {
+        $decoded = $this->http->get($url)->json();
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @param mixed $value
+     * @return list<array<string,mixed>>
+     */
+    private function asList($value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+        return array_values(array_filter($value, 'is_array'));
+    }
+}

--- a/src/Extensions/Install/ExtensionInstaller.php
+++ b/src/Extensions/Install/ExtensionInstaller.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Install;
+
+use Glueful\Bootstrap\ApplicationContext;
+use Glueful\Extensions\ExtensionCatalog;
+use Glueful\Support\Process\DetachedRunner;
+
+/**
+ * Validates an install request and launches the detached runner.
+ *
+ * Guard order (fail fast, cheapest/most-decisive first): kill-switch → host
+ * capability → package allowlist (name grammar + vendor prefix + catalog
+ * membership). Only after all pass is a job created and the runner spawned.
+ */
+final class ExtensionInstaller
+{
+    /** Composer package-name grammar (vendor/name, lowercase). */
+    private const NAME_GRAMMAR = '/^[a-z0-9]([_.-]?[a-z0-9]+)*\/[a-z0-9]([_.-]?[a-z0-9]+)*$/';
+
+    public function __construct(
+        private ApplicationContext $context,
+        private ExtensionCatalog $catalog,
+        private InstallJobStore $jobs,
+        private HostCapability $host,
+        private DetachedRunner $runner,
+    ) {
+    }
+
+    /**
+     * @return array{jobId:string,status:string}
+     * @throws InstallDisabledException|HostNotWritableException|PackageNotAllowedException
+     */
+    public function start(string $package): array
+    {
+        if (!(bool) config($this->context, 'extensions.install.enabled', false)) {
+            throw new InstallDisabledException('Extension installation is disabled.');
+        }
+        if (($cap = $this->host->forInstall()) !== null) {
+            throw new HostNotWritableException($cap['reason'], $cap['detail']);
+        }
+        $this->assertAllowed($package);
+
+        $jobId = $this->jobs->create($package);
+        $this->runner->spawnInstall($jobId, $package);
+
+        return ['jobId' => $jobId, 'status' => 'queued'];
+    }
+
+    private function assertAllowed(string $package): void
+    {
+        $vendor = (string) config($this->context, 'extensions.install.vendor', 'glueful/');
+
+        if (
+            $package === ''
+            || $package[0] === '-'                              // never let a name be read as a flag
+            || !str_starts_with($package, $vendor)
+            || preg_match(self::NAME_GRAMMAR, $package) !== 1
+        ) {
+            throw new PackageNotAllowedException("Invalid or non-{$vendor} package: {$package}");
+        }
+
+        foreach ($this->catalog->catalog() as $row) {
+            if (($row['package'] ?? null) === $package) {
+                return;
+            }
+        }
+        throw new PackageNotAllowedException("Not an installable Glueful extension: {$package}");
+    }
+}

--- a/src/Extensions/Install/HostCapability.php
+++ b/src/Extensions/Install/HostCapability.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Install;
+
+use Glueful\Bootstrap\ApplicationContext;
+use Glueful\Support\Process\ComposerBinaryResolver;
+
+/**
+ * Preflight: can this host actually perform the write-heavy install / toggle?
+ *
+ * Install runs `composer require` and recompiles the extension cache, so it needs
+ * every file it mutates to be writable. Enable/disable don't run composer but do
+ * rewrite config/extensions.php and recompile the cache, so they check that subset.
+ * On a read-only/immutable deploy this reports a reason the controller maps to 409
+ * BEFORE anything is spawned — instead of failing halfway through.
+ */
+final class HostCapability
+{
+    public function __construct(
+        private ApplicationContext $context,
+        private ComposerBinaryResolver $composer,
+    ) {
+    }
+
+    /** @return array{reason:string,detail:string}|null null = installable */
+    public function forInstall(): ?array
+    {
+        if ($this->composerBinary() === null) {
+            return ['reason' => 'composer_missing', 'detail' => 'composer binary not found on PATH'];
+        }
+        return $this->firstUnwritable($this->installPaths());
+    }
+
+    /** @return array{reason:string,detail:string}|null null = toggleable */
+    public function forToggle(): ?array
+    {
+        return $this->firstUnwritable($this->togglePaths());
+    }
+
+    public function composerBinary(): ?string
+    {
+        return $this->composer->resolve();
+    }
+
+    /** @return list<string> */
+    private function installPaths(): array
+    {
+        return [
+            base_path($this->context, 'vendor'),
+            base_path($this->context, 'composer.json'),
+            base_path($this->context, 'composer.lock'),
+            config_path($this->context, 'extensions.php'),
+            base_path($this->context, 'bootstrap/cache'),
+        ];
+    }
+
+    /** @return list<string> */
+    private function togglePaths(): array
+    {
+        return [
+            config_path($this->context, 'extensions.php'),
+            base_path($this->context, 'bootstrap/cache'),
+        ];
+    }
+
+    /**
+     * @param list<string> $paths
+     * @return array{reason:string,detail:string}|null
+     */
+    private function firstUnwritable(array $paths): ?array
+    {
+        foreach ($paths as $path) {
+            // Check the path itself when it exists; otherwise the nearest existing
+            // ancestor — the directory the tool will create the file/dir in. A
+            // missing vendor/composer.lock under a read-only base MUST fail here.
+            if (!is_writable($this->writabilityTarget($path))) {
+                return ['reason' => 'read_only_filesystem', 'detail' => $path];
+            }
+        }
+        return null;
+    }
+
+    private function writabilityTarget(string $path): string
+    {
+        $current = $path;
+        while (!file_exists($current)) {
+            $parent = dirname($current);
+            if ($parent === $current) {
+                return $current; // reached filesystem root
+            }
+            $current = $parent;
+        }
+        return $current;
+    }
+}

--- a/src/Extensions/Install/HostNotWritableException.php
+++ b/src/Extensions/Install/HostNotWritableException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Install;
+
+/** The host cannot perform the write-heavy install (read-only FS / no composer). Maps to HTTP 409. */
+final class HostNotWritableException extends \RuntimeException
+{
+    public function __construct(public readonly string $reason, public readonly string $detail)
+    {
+        parent::__construct("Host not writable ({$reason}): {$detail}");
+    }
+}

--- a/src/Extensions/Install/InstallDisabledException.php
+++ b/src/Extensions/Install/InstallDisabledException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Install;
+
+/** The install kill-switch (extensions.install.enabled) is off. Maps to HTTP 403. */
+final class InstallDisabledException extends \RuntimeException
+{
+}

--- a/src/Extensions/Install/InstallJobStore.php
+++ b/src/Extensions/Install/InstallJobStore.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Install;
+
+use Glueful\Cache\CacheStore;
+
+/**
+ * Transient status for a detached extension install, keyed by job id in the cache.
+ *
+ * The detached runner (a separate OS process) and the web request share this store,
+ * so it must be backed by a shared driver (file/redis, not array) at runtime. The
+ * admin page polls get() until a terminal status.
+ *
+ * Status values:
+ *  - queued                — created, not yet started
+ *  - running               — composer require in progress
+ *  - succeeded             — installed AND enabled (or auto-enable off, no error)
+ *  - installed_not_enabled — installed but auto-enable failed (enableError set)
+ *  - failed                — composer/spawn failed
+ */
+final class InstallJobStore
+{
+    private const PREFIX = 'ext_install:';
+    private const TTL = 3600;
+    private const OUTPUT_CAP = 65536; // ~64KB tail
+
+    /** @param CacheStore<mixed> $cache */
+    public function __construct(private CacheStore $cache)
+    {
+    }
+
+    public function create(string $package): string
+    {
+        $id = bin2hex(random_bytes(12));
+        $this->put($id, [
+            'id' => $id,
+            'package' => $package,
+            'status' => 'queued',
+            'output' => '',
+            'exitCode' => null,
+            'error' => null,
+            'enableError' => null,
+            'startedAt' => date(DATE_ATOM),
+            'finishedAt' => null,
+        ]);
+        return $id;
+    }
+
+    /** @return array<string,mixed>|null */
+    public function get(string $jobId): ?array
+    {
+        $rec = $this->cache->get(self::PREFIX . $jobId);
+        return is_array($rec) ? $rec : null;
+    }
+
+    public function markRunning(string $jobId): void
+    {
+        $this->patch($jobId, ['status' => 'running']);
+    }
+
+    public function appendOutput(string $jobId, string $chunk): void
+    {
+        $rec = $this->get($jobId);
+        if ($rec === null) {
+            return;
+        }
+        $out = (string) $rec['output'] . $chunk;
+        if (strlen($out) > self::OUTPUT_CAP) {
+            $out = substr($out, -self::OUTPUT_CAP);
+        }
+        $this->patch($jobId, ['output' => $out]);
+    }
+
+    public function finish(
+        string $jobId,
+        string $status,
+        ?int $exitCode = null,
+        ?string $error = null,
+        ?string $enableError = null,
+    ): void {
+        $this->patch($jobId, [
+            'status' => $status,
+            'exitCode' => $exitCode,
+            'error' => $error,
+            'enableError' => $enableError,
+            'finishedAt' => date(DATE_ATOM),
+        ]);
+    }
+
+    /** @param array<string,mixed> $changes */
+    private function patch(string $jobId, array $changes): void
+    {
+        $rec = $this->get($jobId);
+        if ($rec === null) {
+            return;
+        }
+        $this->put($jobId, array_merge($rec, $changes));
+    }
+
+    /** @param array<string,mixed> $rec */
+    private function put(string $jobId, array $rec): void
+    {
+        $this->cache->set(self::PREFIX . $jobId, $rec, self::TTL);
+    }
+}

--- a/src/Extensions/Install/PackageNotAllowedException.php
+++ b/src/Extensions/Install/PackageNotAllowedException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Install;
+
+/** Package failed the name-grammar / vendor-prefix / catalog-membership allowlist. Maps to HTTP 422. */
+final class PackageNotAllowedException extends \RuntimeException
+{
+}

--- a/src/Routing/RouteManifest.php
+++ b/src/Routing/RouteManifest.php
@@ -44,6 +44,7 @@ class RouteManifest
                 // 2fa routes moved to glueful/users (loaded by UsersServiceProvider).
                 '/routes/blobs.php',
                 '/routes/resource.php',
+                '/routes/extensions.php',
             ],
             // Framework routes that don't get the API prefix (public endpoints)
             'public_routes' => [

--- a/src/Support/Process/ComposerBinaryResolver.php
+++ b/src/Support/Process/ComposerBinaryResolver.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Support\Process;
+
+use Symfony\Component\Process\ExecutableFinder;
+
+/**
+ * The single source of the composer binary path.
+ *
+ * Reused by BOTH the install preflight (HostCapability) and the install runner
+ * (InstallRunCommand) so they can never diverge — preflight passing must mean the
+ * runner uses the same binary. Honors the COMPOSER_BINARY env override, else finds
+ * `composer` on PATH.
+ */
+final class ComposerBinaryResolver
+{
+    /** Absolute path to the composer binary, or null when none is resolvable. */
+    public function resolve(): ?string
+    {
+        $candidate = getenv('COMPOSER_BINARY') ?: 'composer';
+
+        // An explicit path override is honored when it points at an executable.
+        if (str_contains($candidate, '/')) {
+            return is_executable($candidate) ? $candidate : null;
+        }
+
+        return (new ExecutableFinder())->find($candidate) ?? null;
+    }
+}

--- a/src/Support/Process/DetachedRunner.php
+++ b/src/Support/Process/DetachedRunner.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Support\Process;
+
+use Glueful\Bootstrap\ApplicationContext;
+use Symfony\Component\Process\ExecutableFinder;
+
+/**
+ * Fire-and-forget spawn for the extensions install runner.
+ *
+ * The install POST must return immediately while the composer run (30s–minutes)
+ * continues in the background. Two properties, from two mechanisms:
+ *  - NON-BLOCKING comes from proc_open — we never wait/proc_close, and proc_open
+ *    children are not reaped by PHP at shutdown (unlike Symfony Process, whose
+ *    __destruct SIGKILLs the child).
+ *  - SURVIVAL across an FPM worker recycle comes from `setsid` (POSIX) — the child
+ *    runs in a new session, so a signal to the worker's process group misses it.
+ *
+ * Always pure argv (no shell), so there is no injection surface. The escaped
+ * string form (toShellCommand) exists only as a guarded fallback and is tested.
+ */
+final class DetachedRunner
+{
+    private \Closure $spawn;
+
+    public function __construct(private ApplicationContext $context, ?\Closure $spawn = null)
+    {
+        $this->spawn = $spawn ?? self::defaultSpawn();
+    }
+
+    public function spawnInstall(string $jobId, string $package): void
+    {
+        $argv = $this->buildArgv($jobId, $package);
+        $log = storage_path($this->context, "logs/ext-install-{$jobId}.log");
+        ($this->spawn)($argv, base_path($this->context), $log);
+    }
+
+    /** @return list<string> */
+    public function buildArgv(string $jobId, string $package): array
+    {
+        $argv = [
+            PHP_BINARY,
+            base_path($this->context, 'glueful'),
+            'extensions:install-run',
+            $jobId,
+            $package,
+        ];
+        if ($this->hasSetsid()) {
+            array_unshift($argv, 'setsid');
+        }
+        return $argv;
+    }
+
+    /**
+     * Guarded string fallback — only for a platform that cannot take array argv.
+     * Every segment is escapeshellarg'd, so a hostile package/job value cannot break
+     * out. Kept covered by a unit test even though array argv is the live path.
+     *
+     * @param list<string> $argv
+     */
+    public static function toShellCommand(array $argv): string
+    {
+        return implode(' ', array_map('escapeshellarg', $argv));
+    }
+
+    private function hasSetsid(): bool
+    {
+        return (new ExecutableFinder())->find('setsid') !== null;
+    }
+
+    private static function defaultSpawn(): \Closure
+    {
+        return static fn(array $argv, string $cwd, string $log) => self::detachedSpawn($argv, $cwd, $log);
+    }
+
+    /**
+     * The real detached spawn: proc_open with array argv (no shell), stdio to a
+     * file, and NO proc_close() — so it returns immediately and the child is not
+     * reaped by PHP at shutdown. Public + static so the real path is testable.
+     *
+     * @param list<string> $argv
+     */
+    public static function detachedSpawn(array $argv, string $cwd, string $log): void
+    {
+        $descriptors = [
+            0 => ['file', '/dev/null', 'r'],
+            1 => ['file', $log, 'w'],
+            2 => ['file', $log, 'a'],
+        ];
+        $pipes = [];
+        $proc = proc_open($argv, $descriptors, $pipes, $cwd); // array argv → no shell
+        if (is_resource($proc)) {
+            foreach ($pipes as $pipe) {
+                if (is_resource($pipe)) {
+                    fclose($pipe);
+                }
+            }
+            // Deliberately NO proc_close() — that would wait. Detach and return.
+        }
+    }
+}

--- a/src/Support/Process/ProcessRunner.php
+++ b/src/Support/Process/ProcessRunner.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Support\Process;
+
+/**
+ * A blocking external-command runner, injected so command classes can be tested
+ * without spawning real processes (composer, a child PHP invocation).
+ */
+interface ProcessRunner
+{
+    /**
+     * @param list<string> $cmd argv (no shell)
+     * @param callable(string):void|null $onOutput receives each output chunk
+     * @return array{exitCode:int,output:string}
+     */
+    public function run(array $cmd, string $cwd, float $timeout, ?callable $onOutput = null): array;
+}

--- a/src/Support/Process/SymfonyProcessRunner.php
+++ b/src/Support/Process/SymfonyProcessRunner.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Support\Process;
+
+use Symfony\Component\Process\Process;
+
+final class SymfonyProcessRunner implements ProcessRunner
+{
+    public function run(array $cmd, string $cwd, float $timeout, ?callable $onOutput = null): array
+    {
+        $process = new Process($cmd, $cwd);
+        $process->setTimeout($timeout);
+        $process->run(function (string $type, string $buffer) use ($onOutput): void {
+            if ($onOutput !== null) {
+                $onOutput($buffer);
+            }
+        });
+
+        return [
+            'exitCode' => $process->getExitCode() ?? 1,
+            'output' => $process->getOutput() . $process->getErrorOutput(),
+        ];
+    }
+}

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,15 +13,15 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.65.3';
+    public const VERSION = '1.66.0';
 
 
     /** Release code name */
-    public const NAME = 'Acrux';
+    public const NAME = 'Adhara';
 
 
     /** Release date */
-    public const RELEASE_DATE = '2026-07-03';
+    public const RELEASE_DATE = '2026-07-05';
 
     /** Minimum required PHP version */
     public const MIN_PHP_VERSION = '8.3.0';

--- a/src/Uploader/FileUploader.php
+++ b/src/Uploader/FileUploader.php
@@ -492,6 +492,12 @@ final class FileUploader
     }
 
     /**
+     * The detected-mime allowlist check honors the SAME configured list as
+     * validateMimeType() (uploads.allowed_types with wildcard support, falling
+     * back to DEFAULT_ALLOWED_MIME_TYPES) — otherwise a type the app config
+     * explicitly allows (e.g. image/svg+xml under 'image/*') would pass the
+     * claimed-mime gate and then 400 here on the hard-coded constant.
+     *
      * @param array<string, mixed> $file
      */
     private function validateFileContent(array $file, ?string $detectedMime = null): void
@@ -512,10 +518,10 @@ final class FileUploader
                 if (!in_array($mime, $mimeMap[$originalExt], true)) {
                     throw ValidationException::forField('file', 'MIME type does not match file extension');
                 }
-            } elseif (!in_array($mime, self::DEFAULT_ALLOWED_MIME_TYPES, true)) {
+            } elseif (!$this->mimeAllowed($mime, $this->getAllowedMimeTypes())) {
                 throw ValidationException::forField('file', 'Invalid file type');
             }
-        } elseif (!in_array($mime, self::DEFAULT_ALLOWED_MIME_TYPES, true)) {
+        } elseif (!$this->mimeAllowed($mime, $this->getAllowedMimeTypes())) {
             throw ValidationException::forField('file', 'Invalid file type');
         }
 
@@ -713,6 +719,10 @@ final class FileUploader
             'png' => ['image/png'],
             'gif' => ['image/gif'],
             'webp' => ['image/webp'],
+            // Uploadable only when the app's allowed_types permits it (e.g.
+            // 'image/*'); UploadController serves it as attachment (not in
+            // isSafeInlineMime) and the hazard scan rejects <script> payloads.
+            'svg' => ['image/svg+xml'],
             // Videos
             'mp4' => ['video/mp4'],
             'mov' => ['video/quicktime'],

--- a/tests/Unit/Console/Commands/Extensions/EnableInstalledCommandTest.php
+++ b/tests/Unit/Console/Commands/Extensions/EnableInstalledCommandTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Console\Commands\Extensions;
+
+use Glueful\Bootstrap\ApplicationContext;
+use Glueful\Console\Commands\Extensions\EnableInstalledCommand;
+use Glueful\Extensions\ExtensionManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class EnableInstalledCommandTest extends TestCase
+{
+    /** @var list<string> */
+    private array $tempDirs = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempDirs as $dir) {
+            $this->rmrf($dir);
+        }
+    }
+
+    public function test_emits_ok_false_json_when_package_not_a_candidate(): void
+    {
+        $base = $this->makeApp(withCandidate: false);
+        $tester = $this->runCommand($base, 'glueful/does-not-exist');
+
+        $decoded = json_decode(trim($tester->getDisplay()), true);
+        $this->assertFalse($decoded['ok']);
+        $this->assertNotEmpty($decoded['error']);
+    }
+
+    public function test_happy_path_writes_config_recompiles_cache_and_emits_ok_true(): void
+    {
+        $provider = 'Glueful\\Tests\\Support\\DummyAegisProvider';
+        $base = $this->makeApp(withCandidate: true, provider: $provider);
+
+        $tester = $this->runCommand($base, 'glueful/aegis');
+
+        // 1) JSON contract
+        $decoded = json_decode(trim($tester->getDisplay()), true);
+        $this->assertTrue($decoded['ok']);
+        $this->assertSame($provider, $decoded['provider']);
+
+        // 2) config/extensions.php now lists the provider FQCN
+        $enabled = (require $base . '/config/extensions.php')['enabled'];
+        $this->assertContains($provider, $enabled);
+
+        // 3) writeCacheNow() ran — its side effect is the compiled cache file
+        $this->assertFileExists($base . '/bootstrap/cache/extensions.php');
+    }
+
+    private function runCommand(string $base, string $package): CommandTester
+    {
+        $context = ApplicationContext::forTesting($base);
+        $container = $this->container($context);
+        $command = new EnableInstalledCommand($container, $context);
+        $tester = new CommandTester($command);
+        $tester->execute(['package' => $package]);
+        return $tester;
+    }
+
+    private function makeApp(bool $withCandidate, string $provider = 'Glueful\\X\\Provider'): string
+    {
+        $base = sys_get_temp_dir() . '/eic_' . bin2hex(random_bytes(6));
+        mkdir($base . '/config', 0755, true);
+        mkdir($base . '/bootstrap/cache', 0755, true);
+        $this->tempDirs[] = $base;
+
+        file_put_contents($base . '/config/extensions.php', "<?php\n\nreturn ['enabled' => []];\n");
+
+        if ($withCandidate) {
+            mkdir($base . '/vendor/composer', 0755, true);
+            file_put_contents($base . '/vendor/composer/installed.json', (string) json_encode([
+                'packages' => [[
+                    'name' => 'glueful/aegis',
+                    'type' => 'glueful-extension',
+                    'version' => '1.2.0',
+                    'extra' => ['glueful' => ['provider' => $provider]],
+                ]],
+            ]));
+        }
+
+        return $base;
+    }
+
+    private function container(ApplicationContext $context): ContainerInterface
+    {
+        return new class ($context) implements ContainerInterface {
+            private ExtensionManager $extensions;
+
+            public function __construct(private ApplicationContext $context)
+            {
+                $this->extensions = new ExtensionManager($this);
+            }
+
+            public function get(string $id): mixed
+            {
+                return match ($id) {
+                    ApplicationContext::class => $this->context,
+                    ExtensionManager::class => $this->extensions,
+                    default => throw new class ("No service {$id}") extends \RuntimeException implements
+                        \Psr\Container\NotFoundExceptionInterface {},
+                };
+            }
+
+            public function has(string $id): bool
+            {
+                return in_array($id, [ApplicationContext::class, ExtensionManager::class], true);
+            }
+        };
+    }
+
+    private function rmrf(string $dir): void
+    {
+        if (!file_exists($dir)) {
+            return;
+        }
+        foreach (scandir($dir) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $entry;
+            is_dir($path) ? $this->rmrf($path) : @unlink($path);
+        }
+        @rmdir($dir);
+    }
+}

--- a/tests/Unit/Console/Commands/Extensions/InstallRunCommandTest.php
+++ b/tests/Unit/Console/Commands/Extensions/InstallRunCommandTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Console\Commands\Extensions;
+
+use Glueful\Bootstrap\ApplicationContext;
+use Glueful\Cache\Drivers\ArrayCacheDriver;
+use Glueful\Console\Commands\Extensions\InstallRunCommand;
+use Glueful\Extensions\Install\InstallJobStore;
+use Glueful\Support\Process\ProcessRunner;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class InstallRunCommandTest extends TestCase
+{
+    private ?string $prevComposerEnv = null;
+
+    protected function setUp(): void
+    {
+        // Composer resolution must succeed so execute() reaches the runner.
+        $this->prevComposerEnv = getenv('COMPOSER_BINARY') ?: null;
+        putenv('COMPOSER_BINARY=' . PHP_BINARY);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->prevComposerEnv === null
+            ? putenv('COMPOSER_BINARY')
+            : putenv('COMPOSER_BINARY=' . $this->prevComposerEnv);
+    }
+
+    public function test_success_path_runs_composer_then_fresh_enable_and_finishes_succeeded(): void
+    {
+        $store = new InstallJobStore(new ArrayCacheDriver());
+        $jobId = $store->create('glueful/aegis');
+        $calls = [];
+        $runner = new FakeProcessRunner(function (array $cmd) use (&$calls): array {
+            $calls[] = $cmd;
+            if (in_array('require', $cmd, true)) {
+                return ['exitCode' => 0, 'output' => "Installing\n"];
+            }
+            return ['exitCode' => 0, 'output' => json_encode(['ok' => true, 'provider' => 'X']) . "\n"];
+        });
+
+        $this->runCommand($store, $runner, $jobId, 'glueful/aegis');
+
+        $this->assertSame('succeeded', $store->get($jobId)['status']);
+        $this->assertContains('require', $calls[0]);                      // composer first
+        $this->assertContains('extensions:enable-installed', $calls[1]);  // fresh enable second
+        $this->assertNull($store->get($jobId)['enableError']);
+    }
+
+    public function test_composer_failure_short_circuits_before_enable(): void
+    {
+        $store = new InstallJobStore(new ArrayCacheDriver());
+        $jobId = $store->create('glueful/aegis');
+        $calls = [];
+        $runner = new FakeProcessRunner(function (array $cmd) use (&$calls): array {
+            $calls[] = $cmd;
+            return ['exitCode' => 1, 'output' => "Could not resolve\n"];
+        });
+
+        $this->runCommand($store, $runner, $jobId, 'glueful/aegis');
+
+        $this->assertSame('failed', $store->get($jobId)['status']);
+        $this->assertCount(1, $calls); // enable never ran
+    }
+
+    public function test_composer_ok_but_enable_fails_ends_installed_not_enabled(): void
+    {
+        $store = new InstallJobStore(new ArrayCacheDriver());
+        $jobId = $store->create('glueful/aegis');
+        $runner = new FakeProcessRunner(function (array $cmd): array {
+            if (in_array('require', $cmd, true)) {
+                return ['exitCode' => 0, 'output' => "Installing\n"];
+            }
+            return ['exitCode' => 1, 'output' => json_encode(['ok' => false, 'error' => 'missing dependency']) . "\n"];
+        });
+
+        $this->runCommand($store, $runner, $jobId, 'glueful/aegis');
+
+        $rec = $store->get($jobId);
+        $this->assertSame('installed_not_enabled', $rec['status']); // NOT failed, NOT plain succeeded
+        $this->assertSame('missing dependency', $rec['enableError']);
+    }
+
+    private function runCommand(InstallJobStore $store, ProcessRunner $runner, string $jobId, string $package): void
+    {
+        $context = ApplicationContext::forTesting(sys_get_temp_dir());
+        $container = new class ($context, $store) implements ContainerInterface {
+            public function __construct(private ApplicationContext $context, private InstallJobStore $store)
+            {
+            }
+
+            public function get(string $id): mixed
+            {
+                return match ($id) {
+                    ApplicationContext::class => $this->context,
+                    InstallJobStore::class => $this->store,
+                    default => throw new class ("No {$id}") extends \RuntimeException implements
+                        \Psr\Container\NotFoundExceptionInterface {},
+                };
+            }
+
+            public function has(string $id): bool
+            {
+                return in_array($id, [ApplicationContext::class, InstallJobStore::class], true);
+            }
+        };
+
+        $command = new InstallRunCommand($container, $context, $runner);
+        (new CommandTester($command))->execute(['jobId' => $jobId, 'package' => $package]);
+    }
+}
+
+/**
+ * Scripts ProcessRunner responses by a callback; records nothing itself (callers
+ * capture cmds via the callback closure).
+ */
+final class FakeProcessRunner implements ProcessRunner
+{
+    /** @param \Closure(list<string>):array{exitCode:int,output:string} $handler */
+    public function __construct(private \Closure $handler)
+    {
+    }
+
+    public function run(array $cmd, string $cwd, float $timeout, ?callable $onOutput = null): array
+    {
+        $result = ($this->handler)($cmd);
+        if ($onOutput !== null && $result['output'] !== '') {
+            $onOutput($result['output']);
+        }
+        return $result;
+    }
+}

--- a/tests/Unit/Controllers/ExtensionsControllerTest.php
+++ b/tests/Unit/Controllers/ExtensionsControllerTest.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Controllers;
+
+use Glueful\Bootstrap\ApplicationContext;
+use Glueful\Cache\Drivers\ArrayCacheDriver;
+use Glueful\Controllers\BaseController;
+use Glueful\Controllers\ExtensionsController;
+use Glueful\DTOs\ExtensionInstallData;
+use Glueful\DTOs\ExtensionToggleData;
+use Glueful\Extensions\ExtensionCatalog;
+use Glueful\Extensions\ExtensionManager;
+use Glueful\Extensions\Install\ExtensionInstaller;
+use Glueful\Extensions\Install\HostCapability;
+use Glueful\Extensions\Install\InstallJobStore;
+use Glueful\Support\Process\ComposerBinaryResolver;
+use Glueful\Support\Process\DetachedRunner;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * The controller is reflection-injected (BaseController's constructor needs a full
+ * container boot, out of scope for a unit test). `requirePermission` is stubbed to
+ * record the permission asked for; all other collaborators are real and driven by
+ * inputs, so exception→HTTP mapping and toggle branches get genuine coverage.
+ */
+final class ExtensionsControllerTest extends TestCase
+{
+    /** @var list<string> */
+    private array $tempDirs = [];
+    private ?string $prevComposerEnv = null;
+
+    protected function setUp(): void
+    {
+        $this->prevComposerEnv = getenv('COMPOSER_BINARY') ?: null;
+        putenv('COMPOSER_BINARY=' . PHP_BINARY);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->prevComposerEnv === null
+            ? putenv('COMPOSER_BINARY')
+            : putenv('COMPOSER_BINARY=' . $this->prevComposerEnv);
+        foreach ($this->tempDirs as $dir) {
+            $this->rmrf($dir);
+        }
+    }
+
+    public function test_install_happy_returns_201_with_jobId_and_checks_edit_permission(): void
+    {
+        $c = $this->build(killSwitch: true, catalog: ['glueful/aegis']);
+        $res = $c->controller->install(new ExtensionInstallData('glueful/aegis'));
+
+        $this->assertSame(201, $res->getStatusCode());
+        $this->assertContains('system.config.edit', $c->controller->perms);
+    }
+
+    public function test_install_403_when_kill_switch_off(): void
+    {
+        $c = $this->build(killSwitch: false, catalog: ['glueful/aegis']);
+        $this->assertSame(403, $c->controller->install(new ExtensionInstallData('glueful/aegis'))->getStatusCode());
+    }
+
+    public function test_install_422_when_package_not_in_catalog(): void
+    {
+        $c = $this->build(killSwitch: true, catalog: ['glueful/aegis']);
+        $this->assertSame(422, $c->controller->install(new ExtensionInstallData('glueful/other'))->getStatusCode());
+    }
+
+    public function test_install_409_when_host_read_only(): void
+    {
+        $c = $this->build(killSwitch: true, catalog: ['glueful/aegis'], readOnly: true);
+        $this->assertSame(409, $c->controller->install(new ExtensionInstallData('glueful/aegis'))->getStatusCode());
+    }
+
+    public function test_install_status_404_then_200(): void
+    {
+        $c = $this->build(killSwitch: true, catalog: ['glueful/aegis']);
+        $this->assertSame(404, $c->controller->installStatus('nope')->getStatusCode());
+
+        $jobId = $c->jobs->create('glueful/aegis');
+        $this->assertSame(200, $c->controller->installStatus($jobId)->getStatusCode());
+    }
+
+    public function test_index_checks_view_permission(): void
+    {
+        $c = $this->build(killSwitch: true, catalog: ['glueful/aegis']);
+        $this->assertSame(200, $c->controller->index()->getStatusCode());
+        $this->assertContains('system.config.view', $c->controller->perms);
+    }
+
+    public function test_enable_happy_writes_config_and_returns_enabled(): void
+    {
+        $provider = 'Glueful\\Tests\\Support\\DummyAegisProvider';
+        $c = $this->build(killSwitch: true, catalog: [], installedProvider: $provider);
+
+        $res = $c->controller->enable(new ExtensionToggleData('glueful/aegis'));
+
+        $this->assertSame(200, $res->getStatusCode());
+        $enabled = (require $c->base . '/config/extensions.php')['enabled'];
+        $this->assertContains($provider, $enabled);
+        $this->assertFileExists($c->base . '/bootstrap/cache/extensions.php');
+    }
+
+    public function test_enable_409_when_host_read_only(): void
+    {
+        $c = $this->build(killSwitch: true, catalog: [], installedProvider: 'X\\P', readOnly: true);
+        $this->assertSame(409, $c->controller->enable(new ExtensionToggleData('glueful/aegis'))->getStatusCode());
+    }
+
+    public function test_enable_404_when_not_installed(): void
+    {
+        $c = $this->build(killSwitch: true, catalog: []);
+        $this->assertSame(404, $c->controller->enable(new ExtensionToggleData('glueful/ghost'))->getStatusCode());
+    }
+
+    /**
+     * @param list<string> $catalog
+     */
+    private function build(bool $killSwitch, array $catalog, ?string $installedProvider = null, bool $readOnly = false): object
+    {
+        $base = sys_get_temp_dir() . '/ectrl_' . bin2hex(random_bytes(6));
+        mkdir($base . '/config', 0755, true);
+        mkdir($base . '/bootstrap/cache', 0755, true);
+        $this->tempDirs[] = $base;
+        file_put_contents($base . '/config/extensions.php', "<?php\n\nreturn ['enabled' => []];\n");
+
+        if ($installedProvider !== null) {
+            mkdir($base . '/vendor/composer', 0755, true);
+            file_put_contents($base . '/vendor/composer/installed.json', (string) json_encode([
+                'packages' => [[
+                    'name' => 'glueful/aegis',
+                    'type' => 'glueful-extension',
+                    'version' => '1.2.0',
+                    'extra' => ['glueful' => ['provider' => $installedProvider]],
+                ]],
+            ]));
+        }
+
+        $context = ApplicationContext::forTesting($base);
+        $context->mergeConfigDefaults('extensions', [
+            'install' => ['enabled' => $killSwitch, 'vendor' => 'glueful/'],
+        ]);
+
+        $container = new class ($context) implements ContainerInterface {
+            public function __construct(private ApplicationContext $context)
+            {
+            }
+
+            public function get(string $id): mixed
+            {
+                return $id === ApplicationContext::class ? $this->context
+                    : throw new class ("No {$id}") extends \RuntimeException implements
+                        \Psr\Container\NotFoundExceptionInterface {};
+            }
+
+            public function has(string $id): bool
+            {
+                return $id === ApplicationContext::class;
+            }
+        };
+
+        $rows = array_map(
+            static fn(string $pkg) => ['package' => $pkg, 'description' => '', 'version' => '1.0.0',
+                                       'downloads' => 0, 'repository' => '', 'state' => 'available'],
+            $catalog,
+        );
+        $fakeCatalog = new class ($rows) extends ExtensionCatalog {
+            /** @param list<array<string,mixed>> $rows */
+            public function __construct(private array $rows)
+            {
+            }
+
+            public function catalog(bool $refresh = false): array
+            {
+                return $this->rows;
+            }
+
+            public function installed(): array
+            {
+                return [];
+            }
+        };
+
+        $jobs = new InstallJobStore(new ArrayCacheDriver());
+        $host = new HostCapability($context, new ComposerBinaryResolver());
+        $extensions = new ExtensionManager($container);
+        $installer = new ExtensionInstaller($context, $fakeCatalog, $jobs, $host, new DetachedRunner($context, static fn() => null));
+
+        if ($readOnly) {
+            chmod($base . '/bootstrap/cache', 0555);
+            chmod($base . '/config', 0555);
+            chmod($base, 0555);
+        }
+
+        $controller = new class extends ExtensionsController {
+            /** @var list<string> */
+            public array $perms = [];
+
+            // phpcs:ignore
+            public function __construct()
+            {
+                // Skip BaseController's container-dependent constructor.
+            }
+
+            protected function requirePermission(string $permission, string $resource = 'system', array $context = []): void
+            {
+                $this->perms[] = $permission;
+            }
+
+            protected function getCurrentUserUuid(): ?string
+            {
+                return 'tester';
+            }
+        };
+
+        $this->inject($controller, BaseController::class, 'context', $context);
+        $this->inject($controller, ExtensionsController::class, 'catalog', $fakeCatalog);
+        $this->inject($controller, ExtensionsController::class, 'installer', $installer);
+        $this->inject($controller, ExtensionsController::class, 'jobs', $jobs);
+        $this->inject($controller, ExtensionsController::class, 'host', $host);
+        $this->inject($controller, ExtensionsController::class, 'extensions', $extensions);
+        $this->inject($controller, ExtensionsController::class, 'auditLog', new NullLogger());
+
+        return (object) ['controller' => $controller, 'jobs' => $jobs, 'base' => $base];
+    }
+
+    private function inject(object $obj, string $class, string $prop, mixed $value): void
+    {
+        $rp = new \ReflectionProperty($class, $prop);
+        $rp->setAccessible(true);
+        $rp->setValue($obj, $value);
+    }
+
+    private function rmrf(string $dir): void
+    {
+        if (!file_exists($dir)) {
+            return;
+        }
+        @chmod($dir, 0755);
+        foreach (scandir($dir) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $entry;
+            is_dir($path) ? $this->rmrf($path) : @unlink($path);
+        }
+        @rmdir($dir);
+    }
+}

--- a/tests/Unit/DTOs/ExtensionDataTest.php
+++ b/tests/Unit/DTOs/ExtensionDataTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\DTOs;
+
+use Glueful\DTOs\ExtensionInstallData;
+use Glueful\DTOs\ExtensionToggleData;
+use Glueful\Validation\RequestDataHydrator;
+use Glueful\Validation\ValidationException;
+use PHPUnit\Framework\TestCase;
+
+final class ExtensionDataTest extends TestCase
+{
+    private RequestDataHydrator $hydrator;
+
+    protected function setUp(): void
+    {
+        $this->hydrator = new RequestDataHydrator();
+    }
+
+    public function test_install_data_hydrates_package(): void
+    {
+        $dto = $this->hydrator->hydrate(ExtensionInstallData::class, ['package' => 'glueful/aegis']);
+        $this->assertInstanceOf(ExtensionInstallData::class, $dto);
+        $this->assertSame('glueful/aegis', $dto->package);
+    }
+
+    public function test_install_data_rejects_missing_package(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->hydrator->hydrate(ExtensionInstallData::class, []);
+    }
+
+    public function test_toggle_data_hydrates_package(): void
+    {
+        $dto = $this->hydrator->hydrate(ExtensionToggleData::class, ['package' => 'glueful/aegis']);
+        $this->assertSame('glueful/aegis', $dto->package);
+    }
+
+    public function test_toggle_data_rejects_blank_package(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->hydrator->hydrate(ExtensionToggleData::class, ['package' => '']);
+    }
+}

--- a/tests/Unit/Extensions/ExtensionCatalogTest.php
+++ b/tests/Unit/Extensions/ExtensionCatalogTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Extensions;
+
+use Glueful\Bootstrap\ApplicationContext;
+use Glueful\Cache\Drivers\ArrayCacheDriver;
+use Glueful\Extensions\ExtensionCatalog;
+use Glueful\Extensions\ExtensionManager;
+use Glueful\Http\Client;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+final class ExtensionCatalogTest extends TestCase
+{
+    /** @var list<string> */
+    private array $tempDirs = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempDirs as $dir) {
+            $this->rmrf($dir);
+        }
+    }
+
+    public function test_catalog_filters_by_vendor_and_type_and_hydrates_version(): void
+    {
+        $catalog = $this->catalog($this->packagistFixture(), installedJson: null);
+        $rows = $catalog->catalog(refresh: true);
+
+        // other/thing (wrong vendor) and glueful/faker (p2 type=library) are dropped.
+        $this->assertCount(1, $rows);
+        $this->assertSame('glueful/aegis', $rows[0]['package']);
+        $this->assertSame('1.2.0', $rows[0]['version']);   // hydrated from p2
+        $this->assertSame('Auth', $rows[0]['description']);
+        $this->assertSame('available', $rows[0]['state']); // nothing installed locally
+    }
+
+    public function test_state_is_installed_when_package_present_locally(): void
+    {
+        $installed = json_encode([
+            'packages' => [[
+                'name' => 'glueful/aegis',
+                'type' => 'glueful-extension',
+                'version' => '1.2.0',
+                'extra' => ['glueful' => ['provider' => 'Glueful\\Aegis\\Provider']],
+            ]],
+        ]);
+
+        $catalog = $this->catalog($this->packagistFixture(), installedJson: (string) $installed);
+        $rows = $catalog->catalog(refresh: true);
+
+        $this->assertSame('installed', $rows[0]['state']); // present but not enabled
+    }
+
+    /** @return array<string,array<string,mixed>> */
+    private function packagistFixture(): array
+    {
+        return [
+            'https://packagist.org/search.json?type=glueful-extension&per_page=100' => [
+                'results' => [
+                    ['name' => 'glueful/aegis', 'description' => 'Auth', 'downloads' => 10, 'repository' => 'r'],
+                    ['name' => 'glueful/faker', 'description' => 'Lib', 'downloads' => 5, 'repository' => 'r'],
+                    ['name' => 'other/thing', 'description' => 'No', 'downloads' => 1, 'repository' => 'r'],
+                ],
+            ],
+            'https://repo.packagist.org/p2/glueful/aegis.json' => [
+                'packages' => ['glueful/aegis' => [['version' => '1.2.0', 'type' => 'glueful-extension']]],
+            ],
+            'https://repo.packagist.org/p2/glueful/faker.json' => [
+                'packages' => ['glueful/faker' => [['version' => '2.0.0', 'type' => 'library']]],
+            ],
+        ];
+    }
+
+    /** @param array<string,array<string,mixed>> $map */
+    private function catalog(array $map, ?string $installedJson): ExtensionCatalog
+    {
+        $base = sys_get_temp_dir() . '/cat_' . bin2hex(random_bytes(6));
+        mkdir($base . '/config', 0755, true);
+        $this->tempDirs[] = $base;
+        if ($installedJson !== null) {
+            mkdir($base . '/vendor/composer', 0755, true);
+            file_put_contents($base . '/vendor/composer/installed.json', $installedJson);
+        }
+
+        $context = ApplicationContext::forTesting($base);
+        $container = new class ($context) implements ContainerInterface {
+            public function __construct(private ApplicationContext $context)
+            {
+            }
+
+            public function get(string $id): mixed
+            {
+                return $id === ApplicationContext::class ? $this->context
+                    : throw new class ("No {$id}") extends \RuntimeException implements
+                        \Psr\Container\NotFoundExceptionInterface {};
+            }
+
+            public function has(string $id): bool
+            {
+                return $id === ApplicationContext::class;
+            }
+        };
+
+        return new class (
+            $context,
+            $this->createMock(Client::class),
+            new ArrayCacheDriver(),
+            new ExtensionManager($container),
+            $map,
+        ) extends ExtensionCatalog {
+            /** @param array<string,array<string,mixed>> $map */
+            public function __construct($ctx, $http, $cache, $extensions, private array $map)
+            {
+                parent::__construct($ctx, $http, $cache, $extensions);
+            }
+
+            protected function fetchJson(string $url): array
+            {
+                return $this->map[$url] ?? [];
+            }
+        };
+    }
+
+    private function rmrf(string $dir): void
+    {
+        if (!file_exists($dir)) {
+            return;
+        }
+        foreach (scandir($dir) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $entry;
+            is_dir($path) ? $this->rmrf($path) : @unlink($path);
+        }
+        @rmdir($dir);
+    }
+}

--- a/tests/Unit/Extensions/Install/ExtensionInstallerTest.php
+++ b/tests/Unit/Extensions/Install/ExtensionInstallerTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Extensions\Install;
+
+use Glueful\Bootstrap\ApplicationContext;
+use Glueful\Cache\Drivers\ArrayCacheDriver;
+use Glueful\Extensions\ExtensionCatalog;
+use Glueful\Extensions\Install\ExtensionInstaller;
+use Glueful\Extensions\Install\HostCapability;
+use Glueful\Extensions\Install\InstallDisabledException;
+use Glueful\Extensions\Install\InstallJobStore;
+use Glueful\Extensions\Install\PackageNotAllowedException;
+use Glueful\Support\Process\ComposerBinaryResolver;
+use Glueful\Support\Process\DetachedRunner;
+use PHPUnit\Framework\TestCase;
+
+final class ExtensionInstallerTest extends TestCase
+{
+    /** @var list<string> */
+    private array $tempDirs = [];
+    private ?string $prevComposerEnv = null;
+
+    protected function setUp(): void
+    {
+        $this->prevComposerEnv = getenv('COMPOSER_BINARY') ?: null;
+        putenv('COMPOSER_BINARY=' . PHP_BINARY); // host preflight passes deterministically
+    }
+
+    protected function tearDown(): void
+    {
+        $this->prevComposerEnv === null
+            ? putenv('COMPOSER_BINARY')
+            : putenv('COMPOSER_BINARY=' . $this->prevComposerEnv);
+        foreach ($this->tempDirs as $dir) {
+            $this->rmrf($dir);
+        }
+    }
+
+    public function test_rejects_flag_like_non_glueful_and_non_catalog_packages(): void
+    {
+        [$installer] = $this->make(killSwitch: true, catalog: ['glueful/aegis']);
+
+        foreach (['--evil', 'evil/thallo', 'glueful/not-in-catalog', 'GLUEFUL/Aegis', ''] as $bad) {
+            try {
+                $installer->start($bad);
+                $this->fail("accepted disallowed package: '{$bad}'");
+            } catch (PackageNotAllowedException) {
+                $this->addToAssertionCount(1);
+            }
+        }
+    }
+
+    public function test_happy_path_creates_job_and_spawns_detached(): void
+    {
+        $spawned = [];
+        [$installer] = $this->make(
+            killSwitch: true,
+            catalog: ['glueful/aegis'],
+            spy: function (array $argv) use (&$spawned): void {
+                $spawned[] = $argv;
+            },
+        );
+
+        $result = $installer->start('glueful/aegis');
+
+        $this->assertSame('queued', $result['status']);
+        $this->assertNotEmpty($result['jobId']);
+        $this->assertCount(1, $spawned);
+        $this->assertContains('glueful/aegis', $spawned[0]);
+    }
+
+    public function test_kill_switch_off_throws(): void
+    {
+        [$installer] = $this->make(killSwitch: false, catalog: ['glueful/aegis']);
+        $this->expectException(InstallDisabledException::class);
+        $installer->start('glueful/aegis');
+    }
+
+    /**
+     * @param list<string> $catalog
+     * @return array{0:ExtensionInstaller}
+     */
+    private function make(bool $killSwitch, array $catalog, ?\Closure $spy = null): array
+    {
+        $base = sys_get_temp_dir() . '/inst_' . bin2hex(random_bytes(6));
+        mkdir($base . '/config', 0755, true);
+        $this->tempDirs[] = $base;
+
+        $context = ApplicationContext::forTesting($base);
+        $context->mergeConfigDefaults('extensions', [
+            'install' => ['enabled' => $killSwitch, 'vendor' => 'glueful/'],
+        ]);
+
+        $rows = array_map(
+            static fn(string $pkg) => ['package' => $pkg, 'description' => '', 'version' => '1.0.0',
+                                       'downloads' => 0, 'repository' => '', 'state' => 'available'],
+            $catalog,
+        );
+        $fakeCatalog = new class ($rows) extends ExtensionCatalog {
+            /** @param list<array<string,mixed>> $rows */
+            public function __construct(private array $rows)
+            {
+                // Intentionally skip parent constructor — catalog() is overridden.
+            }
+
+            public function catalog(bool $refresh = false): array
+            {
+                return $this->rows;
+            }
+        };
+
+        $installer = new ExtensionInstaller(
+            $context,
+            $fakeCatalog,
+            new InstallJobStore(new ArrayCacheDriver()),
+            new HostCapability($context, new ComposerBinaryResolver()),
+            new DetachedRunner($context, $spy ?? static fn() => null),
+        );
+
+        return [$installer];
+    }
+
+    private function rmrf(string $dir): void
+    {
+        if (!file_exists($dir)) {
+            return;
+        }
+        foreach (scandir($dir) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $entry;
+            is_dir($path) ? $this->rmrf($path) : @unlink($path);
+        }
+        @rmdir($dir);
+    }
+}

--- a/tests/Unit/Extensions/Install/HostCapabilityTest.php
+++ b/tests/Unit/Extensions/Install/HostCapabilityTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Extensions\Install;
+
+use Glueful\Bootstrap\ApplicationContext;
+use Glueful\Extensions\Install\HostCapability;
+use Glueful\Support\Process\ComposerBinaryResolver;
+use PHPUnit\Framework\TestCase;
+
+final class HostCapabilityTest extends TestCase
+{
+    /** @var list<string> */
+    private array $tempDirs = [];
+    private ?string $prevComposerEnv = null;
+
+    protected function setUp(): void
+    {
+        // Make composer resolution deterministic regardless of the CI PATH:
+        // point COMPOSER_BINARY at a known executable so forInstall() reaches the
+        // writability checks instead of short-circuiting on composer_missing.
+        $this->prevComposerEnv = getenv('COMPOSER_BINARY') ?: null;
+        putenv('COMPOSER_BINARY=' . PHP_BINARY);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->prevComposerEnv === null) {
+            putenv('COMPOSER_BINARY');
+        } else {
+            putenv('COMPOSER_BINARY=' . $this->prevComposerEnv);
+        }
+        foreach ($this->tempDirs as $dir) {
+            $this->rmrf($dir);
+        }
+    }
+
+    public function test_fully_writable_base_passes(): void
+    {
+        $base = $this->makeBase();
+        mkdir($base . '/config', 0755, true);
+        mkdir($base . '/bootstrap/cache', 0755, true);
+
+        $cap = new HostCapability(ApplicationContext::forTesting($base), new ComposerBinaryResolver());
+        $this->assertNull($cap->forInstall());
+        $this->assertNull($cap->forToggle());
+    }
+
+    public function test_flags_a_readonly_existing_path(): void
+    {
+        $base = $this->makeBase();
+        mkdir($base . '/config', 0755, true);
+        mkdir($base . '/bootstrap/cache', 0755, true);
+        chmod($base . '/bootstrap/cache', 0555); // exists, not writable
+
+        $cap = new HostCapability(ApplicationContext::forTesting($base), new ComposerBinaryResolver());
+        $result = $cap->forToggle();
+
+        $this->assertIsArray($result);
+        $this->assertSame('read_only_filesystem', $result['reason']);
+        $this->assertStringContainsString('bootstrap/cache', $result['detail']);
+    }
+
+    public function test_flags_missing_vendor_under_unwritable_base(): void
+    {
+        // Base exists but is read-only; vendor/ and composer.lock do NOT exist yet.
+        // A naive file_exists() check would skip them and pass — it must not.
+        $base = $this->makeBase(0555);
+
+        $cap = new HostCapability(ApplicationContext::forTesting($base), new ComposerBinaryResolver());
+        $result = $cap->forInstall();
+
+        $this->assertIsArray($result, 'missing vendor/composer.lock under a read-only base must fail preflight');
+        $this->assertSame('read_only_filesystem', $result['reason']);
+    }
+
+    private function makeBase(int $mode = 0755): string
+    {
+        $dir = sys_get_temp_dir() . '/hc_' . bin2hex(random_bytes(6));
+        mkdir($dir, 0755, true);
+        $this->tempDirs[] = $dir;
+        if ($mode !== 0755) {
+            chmod($dir, $mode);
+        }
+        return $dir;
+    }
+
+    private function rmrf(string $dir): void
+    {
+        if (!file_exists($dir)) {
+            return;
+        }
+        @chmod($dir, 0755);
+        foreach (scandir($dir) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $entry;
+            is_dir($path) ? $this->rmrf($path) : @unlink($path);
+        }
+        @rmdir($dir);
+    }
+}

--- a/tests/Unit/Extensions/Install/InstallJobStoreTest.php
+++ b/tests/Unit/Extensions/Install/InstallJobStoreTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Extensions\Install;
+
+use Glueful\Cache\Drivers\ArrayCacheDriver;
+use Glueful\Extensions\Install\InstallJobStore;
+use PHPUnit\Framework\TestCase;
+
+final class InstallJobStoreTest extends TestCase
+{
+    public function test_lifecycle_create_run_finish(): void
+    {
+        $store = new InstallJobStore(new ArrayCacheDriver());
+
+        $id = $store->create('glueful/aegis');
+        $this->assertSame('queued', $store->get($id)['status']);
+        $this->assertSame('glueful/aegis', $store->get($id)['package']);
+
+        $store->markRunning($id);
+        $store->appendOutput($id, "Resolving...\n");
+        $store->appendOutput($id, "Installing glueful/aegis\n");
+        $this->assertSame('running', $store->get($id)['status']);
+        $this->assertStringContainsString('Installing glueful/aegis', $store->get($id)['output']);
+
+        $store->finish($id, 'succeeded', 0, null, null);
+        $rec = $store->get($id);
+        $this->assertSame('succeeded', $rec['status']);
+        $this->assertSame(0, $rec['exitCode']);
+        $this->assertNotNull($rec['finishedAt']);
+    }
+
+    public function test_installed_not_enabled_terminal_state_carries_enable_error(): void
+    {
+        $store = new InstallJobStore(new ArrayCacheDriver());
+        $id = $store->create('glueful/aegis');
+
+        $store->finish($id, 'installed_not_enabled', 0, null, 'missing dependency');
+        $rec = $store->get($id);
+        $this->assertSame('installed_not_enabled', $rec['status']);
+        $this->assertSame('missing dependency', $rec['enableError']);
+        $this->assertNull($rec['error']);
+    }
+
+    public function test_output_is_capped_to_tail(): void
+    {
+        $store = new InstallJobStore(new ArrayCacheDriver());
+        $id = $store->create('glueful/aegis');
+
+        $store->appendOutput($id, str_repeat('a', 70000));
+        $store->appendOutput($id, 'TAIL_MARKER');
+        $out = $store->get($id)['output'];
+        $this->assertLessThanOrEqual(65536, strlen($out));
+        $this->assertStringContainsString('TAIL_MARKER', $out); // newest kept
+    }
+
+    public function test_unknown_job_returns_null_and_mutations_are_noops(): void
+    {
+        $store = new InstallJobStore(new ArrayCacheDriver());
+        $this->assertNull($store->get('nope'));
+        $store->markRunning('nope');       // must not throw
+        $store->appendOutput('nope', 'x');  // must not throw
+        $this->assertNull($store->get('nope'));
+    }
+}

--- a/tests/Unit/Support/Process/DetachedRunnerTest.php
+++ b/tests/Unit/Support/Process/DetachedRunnerTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Support\Process;
+
+use Glueful\Bootstrap\ApplicationContext;
+use Glueful\Support\Process\DetachedRunner;
+use PHPUnit\Framework\TestCase;
+
+final class DetachedRunnerTest extends TestCase
+{
+    /** @var list<string> */
+    private array $tempDirs = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempDirs as $dir) {
+            $this->rmrf($dir);
+        }
+    }
+
+    public function test_buildArgv_is_pure_array_and_targets_the_runner(): void
+    {
+        $runner = new DetachedRunner($this->context());
+        $argv = $runner->buildArgv('job123', 'glueful/aegis');
+
+        $this->assertContains('extensions:install-run', $argv);
+        $this->assertContains('glueful/aegis', $argv);
+        $this->assertContains('job123', $argv);
+        // PHP binary sits two before the command name (works with or without setsid).
+        $idx = (int) array_search('extensions:install-run', $argv, true);
+        $this->assertSame(PHP_BINARY, $argv[$idx - 2]);
+    }
+
+    public function test_toShellCommand_escapes_every_segment(): void
+    {
+        $hostile = 'a b; rm -rf /';
+        $cmd = DetachedRunner::toShellCommand(['php', 'glueful', 'extensions:install-run', 'j', $hostile]);
+
+        $this->assertStringContainsString(escapeshellarg($hostile), $cmd);
+        // Nothing outside the escaped token leaks the metacharacters.
+        $remainder = str_replace(escapeshellarg($hostile), '', $cmd);
+        $this->assertStringNotContainsString('; rm -rf /', $remainder);
+    }
+
+    public function test_spawnInstall_returns_when_injected_spawn_returns(): void
+    {
+        $seen = null;
+        $spy = function (array $argv, string $cwd, string $log) use (&$seen): void {
+            $seen = ['argv' => $argv, 'cwd' => $cwd, 'log' => $log];
+        };
+        $runner = new DetachedRunner($this->context(), $spy);
+        $runner->spawnInstall('job1', 'glueful/aegis');
+
+        $this->assertNotNull($seen);
+        $this->assertContains('glueful/aegis', $seen['argv']);
+        $this->assertStringContainsString('ext-install-job1.log', $seen['log']);
+    }
+
+    public function test_real_detached_spawn_returns_before_child_completes(): void
+    {
+        if (!function_exists('proc_open')) {
+            $this->markTestSkipped('proc_open unavailable');
+        }
+        $marker = sys_get_temp_dir() . '/mark_' . bin2hex(random_bytes(4));
+        $log = sys_get_temp_dir() . '/log_' . bin2hex(random_bytes(4));
+
+        // Real detached child: sleeps 400ms, then writes the marker. Pure argv, no shell.
+        $t0 = microtime(true);
+        DetachedRunner::detachedSpawn(
+            [PHP_BINARY, '-r', 'usleep(400000); file_put_contents($argv[1], "x");', $marker],
+            sys_get_temp_dir(),
+            $log,
+        );
+        $elapsed = microtime(true) - $t0;
+
+        // Non-blocking: returned well before the child's 400ms sleep elapsed...
+        $this->assertLessThan(0.3, $elapsed, 'detachedSpawn must return before the child finishes');
+        $this->assertFileDoesNotExist($marker, 'child should still be running when spawn returns');
+
+        // ...and the detached child completes independently afterward.
+        $deadline = microtime(true) + 3.0;
+        while (!file_exists($marker) && microtime(true) < $deadline) {
+            usleep(20000);
+        }
+        $this->assertFileExists($marker, 'detached child ran to completion after spawn returned');
+        @unlink($marker);
+        @unlink($log);
+    }
+
+    private function context(): ApplicationContext
+    {
+        $base = sys_get_temp_dir() . '/dr_' . bin2hex(random_bytes(6));
+        mkdir($base, 0755, true);
+        $this->tempDirs[] = $base;
+        return ApplicationContext::forTesting($base);
+    }
+
+    private function rmrf(string $dir): void
+    {
+        if (!file_exists($dir)) {
+            return;
+        }
+        foreach (scandir($dir) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $entry;
+            is_dir($path) ? $this->rmrf($path) : @unlink($path);
+        }
+        @rmdir($dir);
+    }
+}

--- a/tests/Unit/Uploader/FileUploaderNoMediaTest.php
+++ b/tests/Unit/Uploader/FileUploaderNoMediaTest.php
@@ -166,6 +166,69 @@ final class FileUploaderNoMediaTest extends TestCase
         $this->assertSame('image/png', $row['mime_type']);
     }
 
+    public function testSvgUploadsPassWhenTheConfiguredAllowlistPermitsImages(): void
+    {
+        // Regression: the detected-mime content check must honor the SAME
+        // configured allowlist as the claimed-mime gate ('image/*' covers
+        // image/svg+xml) — not the hard-coded default constant, which would
+        // 400 a type the app config explicitly allows.
+        /** @var FileUploader $uploader */
+        $uploader = $this->context->getContainer()->get(FileUploader::class);
+
+        $tmp = $this->createSvgFixture();
+
+        $result = $uploader->uploadMedia(
+            [
+                'name' => 'logo.svg',
+                'type' => 'image/svg+xml',
+                'tmp_name' => $tmp,
+                'error' => UPLOAD_ERR_OK,
+                'size' => filesize($tmp),
+            ],
+            'posts/uuid123',
+            ['save_to_blobs' => true]
+        );
+
+        $this->assertArrayHasKey('path', $result);
+        $this->assertFileExists($this->uploadsRoot . '/' . $result['path']);
+
+        $connection = new Connection();
+        $row = $connection->table('blobs')
+            ->where('uuid', $result['blob_uuid'])
+            ->first();
+        $this->assertIsArray($row);
+        $this->assertSame('image/svg+xml', $row['mime_type']);
+    }
+
+    public function testScriptBearingSvgIsStillRejectedByTheHazardScan(): void
+    {
+        // The XSS-shaped SVG stays blocked: allowing the TYPE does not bypass
+        // the content scan.
+        /** @var FileUploader $uploader */
+        $uploader = $this->context->getContainer()->get(FileUploader::class);
+
+        $tmp = $this->appPath . '/evil.svg';
+        file_put_contents(
+            $tmp,
+            '<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg">'
+            . '<script>alert(1)</script></svg>'
+        );
+
+        $this->expectException(\Glueful\Validation\ValidationException::class);
+
+        $uploader->uploadMedia(
+            [
+                'name' => 'evil.svg',
+                'type' => 'image/svg+xml',
+                'tmp_name' => $tmp,
+                'error' => UPLOAD_ERR_OK,
+                'size' => filesize($tmp),
+            ],
+            'posts/uuid123',
+            ['save_to_blobs' => false]
+        );
+    }
+
     public function testUploadMediaRunsContentHazardScanOnLivePath(): void
     {
         /** @var FileUploader $uploader */
@@ -266,6 +329,20 @@ final class FileUploaderNoMediaTest extends TestCase
 
             $table->unique('uuid');
         });
+    }
+
+    private function createSvgFixture(): string
+    {
+        $path = $this->appPath . '/fixture.svg';
+        // XML prolog keeps finfo's detection deterministic (image/svg+xml).
+        file_put_contents(
+            $path,
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            . '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">'
+            . '<rect width="16" height="16" fill="#3b82f6"/></svg>'
+        );
+
+        return $path;
     }
 
     private function createPngFixture(): string


### PR DESCRIPTION
- Extensions install pipeline: composer require from the admin UI via the
  /extensions API. Detached proc_open + setsid install (survives FPM recycle),
  fresh-subprocess auto-enable (dodges stale autoloader), CacheStore-backed job
  polling. Guarded by system.config, EXTENSIONS_INSTALL_ENABLED kill-switch
  (off in prod), host-writability preflight, catalog-membership allowlist.
- Fix: SVG uploads no longer 400 on the content check — validateFileContent()
  now honors the configured uploads.allowed_types allowlist instead of the
  hard-coded default constant. Safety posture unchanged.
- New optional env: EXTENSIONS_INSTALL_ENABLED / _AUTO_ENABLE / _TIMEOUT.