### PR TITLE
Fix route caching by replacing closures with controller handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Fixed
+- **Serving an SPA via `serveFrontend()` silently disabled route caching for the whole
+  application.** `ServiceProvider::serveFrontend()` registered its mount root and `/{rest}`
+  catch-all as **closures**, and `RouteCache` refuses to cache a route table containing any
+  closure — so every app that mounts an admin/SPA bundle ran with route caching off and logged
+  `[RouteCache] Skipping cache: N route(s) use closure handlers … Convert to [Controller::class,
+  "method"] syntax.` on each boot. The seam now registers controller handlers
+  (`[SpaMountController::class, 'root'|'asset']`) backed by a new `FrontendMountRegistry` that
+  resolves the owning mount from the request path by longest-prefix match (so multiple mounts —
+  `/admin`, `/portal`, … — are supported by one mount-agnostic controller). Asset/index serving is
+  byte-for-byte identical: mime typing, static-asset security headers, the immutable-vs-revalidate
+  cache split, ETag/`304`, path-traversal + dotfile + `.php` denial, and the SPA deep-link fallback.
+  New public classes `Glueful\Routing\FrontendMountRegistry` and `Glueful\Routing\SpaMountController`
+  (registered as shared services in `CoreProvider`); the `serveFrontend()` signature and behavior are
+  unchanged. Apps mounting an SPA regain route caching automatically — no code or config change and
+  no new env vars.
+
 ## [1.66.1] - 2026-07-06 — Adhara
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.66.2] - 2026-07-06 — Adhara
+
+### Fixed
+- **Serving an SPA via `serveFrontend()` silently disabled route caching for the whole
+  application.** `ServiceProvider::serveFrontend()` registered its mount root and `/{rest}`
+  catch-all as **closures**, and `RouteCache` refuses to cache a route table containing any
+  closure — so every app that mounts an admin/SPA bundle ran with route caching off and logged
+  `[RouteCache] Skipping cache: N route(s) use closure handlers … Convert to [Controller::class,
+  "method"] syntax.` on each boot. The seam now registers controller handlers
+  (`[SpaMountController::class, 'root'|'asset']`) backed by a new `FrontendMountRegistry` that
+  resolves the owning mount from the request path by longest-prefix match (so multiple mounts —
+  `/admin`, `/portal`, … — are supported by one mount-agnostic controller). Asset/index serving is
+  byte-for-byte identical: mime typing, static-asset security headers, the immutable-vs-revalidate
+  cache split, ETag/`304`, path-traversal + dotfile + `.php` denial, and the SPA deep-link fallback.
+  New public classes `Glueful\Routing\FrontendMountRegistry` and `Glueful\Routing\SpaMountController`
+  (registered as shared services in `CoreProvider`); the `serveFrontend()` signature and behavior are
+  unchanged. Apps mounting an SPA regain route caching automatically — no code or config change and
+  no new env vars.
+
 ## [1.66.1] - 2026-07-06 — Adhara
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.66.2] - 2026-07-06 — Adhara
+
 ### Fixed
 - **Serving an SPA via `serveFrontend()` silently disabled route caching for the whole
   application.** `ServiceProvider::serveFrontend()` registered its mount root and `/{rest}`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,17 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.66.2 — Adhara (Patch, Released 2026-07-06)
+- **`serveFrontend()` no longer disables route caching.** Mounting an admin/SPA bundle registered
+  the mount root and `/{rest}` catch-all as closures, and `RouteCache` rejects any route table that
+  contains a closure — so every SPA-mounting app ran uncached and logged a `[RouteCache]` warning on
+  each boot. The seam now registers controller handlers (`SpaMountController::root`/`asset`) backed by
+  a new `FrontendMountRegistry` that resolves the mount from the request path by longest-prefix match
+  (multiple mounts supported). Asset/index serving is byte-for-byte identical (mime, security headers,
+  immutable-vs-revalidate cache split, ETag/304, path-traversal/dotfile/`.php` denial, SPA fallback).
+- Notes: no `serveFrontend()` signature/behavior change, no new env vars; SPA-mounting apps regain
+  route caching automatically.
+
 ### 1.66.1 — Adhara (Patch, Released 2026-07-06)
 - **The extension installer is now synchronous.** The 1.66.0 detached/background-job installer was
   unreliable under a web SAPI (`PHP_BINARY` is not a CLI interpreter behind Apache/php-cgi/nginx+FPM,

--- a/src/Container/Providers/CoreProvider.php
+++ b/src/Container/Providers/CoreProvider.php
@@ -556,6 +556,13 @@ final class CoreProvider extends BaseServiceProvider
         // Router + supporting services
         $defs[\Glueful\Routing\RouteCache::class] = $this->autowire(\Glueful\Routing\RouteCache::class);
         $defs[\Glueful\Routing\RouteCompiler::class] = $this->autowire(\Glueful\Routing\RouteCompiler::class);
+        // SPA/frontend mounts (ServiceProvider::serveFrontend). The registry is a
+        // shared singleton so serveFrontend() (boot) and SpaMountController (dispatch)
+        // see the same mounts within a request.
+        $defs[\Glueful\Routing\FrontendMountRegistry::class] =
+            $this->autowire(\Glueful\Routing\FrontendMountRegistry::class);
+        $defs[\Glueful\Routing\SpaMountController::class] =
+            $this->autowire(\Glueful\Routing\SpaMountController::class);
         $defs[\Glueful\Routing\Router::class] = new FactoryDefinition(
             \Glueful\Routing\Router::class,
             fn(\Psr\Container\ContainerInterface $c) => new \Glueful\Routing\Router($c)

--- a/src/Extensions/ServiceProvider.php
+++ b/src/Extensions/ServiceProvider.php
@@ -273,154 +273,23 @@ abstract class ServiceProvider
             return;
         }
 
+        // Record the mount so SpaMountController can resolve it by request path at
+        // dispatch time. serveFrontend() runs on every boot (provider boot() always
+        // runs, even when the route table is loaded from the compiled cache), so the
+        // registry is always populated before dispatch.
+        /** @var \Glueful\Routing\FrontendMountRegistry $registry */
+        $registry = $this->app->get(\Glueful\Routing\FrontendMountRegistry::class);
+        $registry->register($path, $realDir, $spaFallback, $name);
+
+        // Register controller-array handlers, NOT closures: the route table must stay
+        // serializable so RouteCache can cache it (closures disable route caching for
+        // the whole application). The controller reproduces the exact asset/index
+        // serving behaviour previously inlined here.
         /** @var \Glueful\Routing\Router $router */
         $router = $this->app->get(\Glueful\Routing\Router::class);
-
-        $serveAsset = $this->frontendAssetServer($realDir);
-        $serveIndex = $this->frontendIndexServer($realDir);
-
-        $router->get($path, function (
-            \Symfony\Component\HttpFoundation\Request $request
-        ) use (
-            $spaFallback,
-            $serveIndex
-) {
-            return $spaFallback
-                ? $serveIndex($request)
-                : new \Symfony\Component\HttpFoundation\Response('', 404);
-        });
-
-        $router->get($path . '/{rest}', function (
-            \Symfony\Component\HttpFoundation\Request $request,
-            string $rest
-        ) use (
-            $realDir,
-            $spaFallback,
-            $serveAsset,
-            $serveIndex
-) {
-            if (headers_sent()) {
-                return new \Symfony\Component\HttpFoundation\Response('', 404);
-            }
-
-            $basename = basename($rest);
-            if ($basename === '' || $basename[0] === '.' || str_ends_with(strtolower($basename), '.php')) {
-                return new \Symfony\Component\HttpFoundation\Response('', 404);
-            }
-
-            // Reject path-traversal sequences outright — a `..` segment must 404, never
-            // fall through to the SPA shell (the realpath check below also rejects an
-            // escaped *file*, but an extension-less traversal path would otherwise reach
-            // the index.html fallback).
-            if (preg_match('#(^|/)\.\.(/|$)#', $rest) === 1) {
-                return new \Symfony\Component\HttpFoundation\Response('', 404);
-            }
-
-            $requested = realpath($realDir . DIRECTORY_SEPARATOR . $rest);
-            if (
-                $requested !== false
-                && str_starts_with($requested, $realDir . DIRECTORY_SEPARATOR)
-                && is_file($requested)
-            ) {
-                return $serveAsset($request, $requested, $basename);
-            }
-
-            if (!$spaFallback) {
-                return new \Symfony\Component\HttpFoundation\Response('', 404);
-            }
-            // "A dot means an asset": a missing asset is a 404, never the HTML shell.
-            if (pathinfo($rest, PATHINFO_EXTENSION) !== '') {
-                return new \Symfony\Component\HttpFoundation\Response('', 404);
-            }
-            return $serveIndex($request);
-        })->where('rest', '.+');
-    }
-
-    /**
-     * Closure that streams a built asset with mime, security headers, the cache
-     * split, ETag/Last-Modified and 304 handling.
-     *
-     * @return \Closure(\Symfony\Component\HttpFoundation\Request, string, string):
-     *     \Symfony\Component\HttpFoundation\Response
-     */
-    private function frontendAssetServer(string $realDir): \Closure
-    {
-        return function (
-            \Symfony\Component\HttpFoundation\Request $request,
-            string $realPath,
-            string $basename
-        ): \Symfony\Component\HttpFoundation\Response {
-            $mtime = filemtime($realPath) !== false ? filemtime($realPath) : time();
-            $etag = md5_file($realPath) !== false ? md5_file($realPath) : sha1($realPath);
-
-            $guesser = \Symfony\Component\Mime\MimeTypes::getDefault();
-            // Extension map FIRST: content sniffing cannot identify text formats
-            // (css/js/svg carry no magic bytes — finfo calls them text/plain), and
-            // these responses send X-Content-Type-Options: nosniff, so a wrong
-            // type makes browsers REFUSE stylesheets and module scripts outright.
-            // Sniffing remains the fallback for extensionless files.
-            $ext = strtolower(pathinfo($realPath, PATHINFO_EXTENSION));
-            $byExtension = $ext !== '' ? ($guesser->getMimeTypes($ext)[0] ?? null) : null;
-            $mimeGuess = mime_content_type($realPath);
-            $mime = $byExtension
-                ?? $guesser->guessMimeType($realPath)
-                ?? ($mimeGuess !== false ? $mimeGuess : 'application/octet-stream');
-
-            $resp = new \Symfony\Component\HttpFoundation\BinaryFileResponse($realPath);
-            $resp->headers->set('Content-Type', $mime);
-            foreach (\Glueful\Security\SecurityHeaders::defaultStaticAssetHeaders() as $header => $value) {
-                $resp->headers->set($header, $value);
-            }
-            $resp->headers->set('Cache-Control', $this->frontendCacheControl($basename));
-            $resp->setEtag('"' . $etag . '"');
-            $resp->setLastModified((new \DateTimeImmutable())->setTimestamp($mtime));
-            $resp->setContentDisposition(
-                \Symfony\Component\HttpFoundation\ResponseHeaderBag::DISPOSITION_INLINE,
-                $basename
-            );
-            $resp->isNotModified($request);
-            return $resp;
-        };
-    }
-
-    /**
-     * Cache-Control for a served file: content-hashed assets are immutable;
-     * everything else (incl. index.html) revalidates so deploys are seen.
-     */
-    private function frontendCacheControl(string $basename): string
-    {
-        return preg_match('/[.\-_][A-Za-z0-9]{8,}\.[A-Za-z0-9]+$/', $basename) === 1
-            ? 'public, max-age=31536000, immutable'
-            : 'no-cache';
-    }
-
-    /**
-     * Closure that serves index.html (200, no-cache, hardened headers, revalidatable).
-     *
-     * @return \Closure(\Symfony\Component\HttpFoundation\Request): \Symfony\Component\HttpFoundation\Response
-     */
-    private function frontendIndexServer(string $realDir): \Closure
-    {
-        return function (
-            \Symfony\Component\HttpFoundation\Request $request
-        ) use ($realDir): \Symfony\Component\HttpFoundation\Response {
-            $index = $realDir . DIRECTORY_SEPARATOR . 'index.html';
-            if (!is_file($index)) {
-                return new \Symfony\Component\HttpFoundation\Response('', 404);
-            }
-            $resp = new \Symfony\Component\HttpFoundation\BinaryFileResponse($index);
-            $resp->headers->set('Content-Type', 'text/html; charset=UTF-8');
-            foreach (\Glueful\Security\SecurityHeaders::defaultStaticAssetHeaders() as $header => $value) {
-                $resp->headers->set($header, $value);
-            }
-            $resp->headers->set('Cache-Control', 'no-cache');
-            $mtime = filemtime($index) !== false ? filemtime($index) : time();
-            $etag = md5_file($index) !== false ? md5_file($index) : sha1($index);
-            $resp->setEtag('"' . $etag . '"');
-            $resp->setLastModified((new \DateTimeImmutable())->setTimestamp($mtime));
-            $resp->isNotModified($request);
-            return $resp;
-        };
+        $router->get($path, [\Glueful\Routing\SpaMountController::class, 'root']);
+        $router->get($path . '/{rest}', [\Glueful\Routing\SpaMountController::class, 'asset'])
+            ->where('rest', '.+');
     }
 
     /** Emit a boot-time warning through the container's logger when available. */

--- a/src/Routing/FrontendMountRegistry.php
+++ b/src/Routing/FrontendMountRegistry.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Routing;
+
+/**
+ * Registry of SPA/frontend mounts declared via ServiceProvider::serveFrontend().
+ *
+ * serveFrontend() populates this on every boot — provider boot() runs on every
+ * request, even when the route table was reconstructed from the compiled route
+ * cache — so the mount metadata is always available at dispatch time. The SPA
+ * controller resolves which mount a request belongs to by longest-prefix match
+ * on the request path (never from a route parameter). That keeps a single,
+ * mount-agnostic controller serializable into the route cache, which closures
+ * are not.
+ */
+final class FrontendMountRegistry
+{
+    /**
+     * Mounts keyed by normalized prefix (leading slash, no trailing slash).
+     *
+     * @var array<string, array{dir: string, spaFallback: bool, name: string}>
+     */
+    private array $mounts = [];
+
+    /**
+     * Record a mount. $dir must be an already-resolved realpath (serveFrontend
+     * resolves and validates it before registering), so the controller can
+     * safely use it as the containment boundary for path-traversal checks.
+     */
+    public function register(string $path, string $dir, bool $spaFallback, string $name): void
+    {
+        $this->mounts[$this->normalize($path)] = [
+            'dir' => $dir,
+            'spaFallback' => $spaFallback,
+            'name' => $name,
+        ];
+    }
+
+    /**
+     * Resolve the mount that owns a request path by longest matching prefix.
+     * Returns null when no mount matches.
+     *
+     * @return array{prefix: string, dir: string, spaFallback: bool, name: string}|null
+     */
+    public function match(string $requestPath): ?array
+    {
+        $requestPath = '/' . ltrim($requestPath, '/');
+        $best = null;
+        foreach ($this->mounts as $prefix => $mount) {
+            // The mount root itself ('/admin') or anything beneath it ('/admin/...').
+            if ($requestPath === $prefix || str_starts_with($requestPath, $prefix . '/')) {
+                if ($best === null || strlen($prefix) > strlen((string) $best['prefix'])) {
+                    $best = ['prefix' => $prefix] + $mount;
+                }
+            }
+        }
+        return $best;
+    }
+
+    /**
+     * All registered mounts keyed by prefix (introspection/testing).
+     *
+     * @return array<string, array{dir: string, spaFallback: bool, name: string}>
+     */
+    public function all(): array
+    {
+        return $this->mounts;
+    }
+
+    private function normalize(string $path): string
+    {
+        $path = '/' . trim($path, '/');
+        return $path === '/' ? '/' : rtrim($path, '/');
+    }
+}

--- a/src/Routing/SpaMountController.php
+++ b/src/Routing/SpaMountController.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Routing;
+
+use Glueful\Security\SecurityHeaders;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\Mime\MimeTypes;
+
+/**
+ * Serves compiled SPA/frontend bundles mounted via ServiceProvider::serveFrontend().
+ *
+ * Registered as [SpaMountController::class, 'root'|'asset'] so the route table
+ * carries no closures and stays cacheable. The mount a request belongs to is
+ * resolved from the request path via {@see FrontendMountRegistry} (longest-prefix
+ * match), NOT from a route parameter — so one mount-agnostic controller serves
+ * any number of mounts (/admin, /portal, …). The asset/index serving behaviour
+ * (mime, security headers, ETag/Last-Modified, cache split, path-traversal
+ * rejection, SPA deep-link fallback) is identical to the previous closure-based
+ * implementation.
+ */
+final class SpaMountController
+{
+    public function __construct(private readonly FrontendMountRegistry $mounts)
+    {
+    }
+
+    /**
+     * Serve the SPA shell at a mount root (e.g. GET /admin).
+     */
+    public function root(Request $request): Response
+    {
+        $mount = $this->mounts->match($request->getPathInfo());
+        if ($mount === null) {
+            return new Response('', 404);
+        }
+
+        return $mount['spaFallback']
+            ? $this->serveIndex($request, $mount['dir'])
+            : new Response('', 404);
+    }
+
+    /**
+     * Serve an asset, or the SPA shell as a deep-link fallback, under a mount
+     * (e.g. GET /admin/{rest}).
+     */
+    public function asset(Request $request, string $rest): Response
+    {
+        $mount = $this->mounts->match($request->getPathInfo());
+        if ($mount === null) {
+            return new Response('', 404);
+        }
+        $realDir = $mount['dir'];
+        $spaFallback = $mount['spaFallback'];
+
+        if (headers_sent()) {
+            return new Response('', 404);
+        }
+
+        $basename = basename($rest);
+        if ($basename === '' || $basename[0] === '.' || str_ends_with(strtolower($basename), '.php')) {
+            return new Response('', 404);
+        }
+
+        // Reject path-traversal sequences outright — a `..` segment must 404, never
+        // fall through to the SPA shell (the realpath check below also rejects an
+        // escaped *file*, but an extension-less traversal path would otherwise reach
+        // the index.html fallback).
+        if (preg_match('#(^|/)\.\.(/|$)#', $rest) === 1) {
+            return new Response('', 404);
+        }
+
+        $requested = realpath($realDir . DIRECTORY_SEPARATOR . $rest);
+        if (
+            $requested !== false
+            && str_starts_with($requested, $realDir . DIRECTORY_SEPARATOR)
+            && is_file($requested)
+        ) {
+            return $this->serveAsset($request, $requested, $basename);
+        }
+
+        if (!$spaFallback) {
+            return new Response('', 404);
+        }
+        // "A dot means an asset": a missing asset is a 404, never the HTML shell.
+        if (pathinfo($rest, PATHINFO_EXTENSION) !== '') {
+            return new Response('', 404);
+        }
+        return $this->serveIndex($request, $realDir);
+    }
+
+    /**
+     * Stream a built asset with mime, security headers, the cache split,
+     * ETag/Last-Modified and 304 handling.
+     */
+    private function serveAsset(Request $request, string $realPath, string $basename): Response
+    {
+        $mtime = filemtime($realPath) !== false ? filemtime($realPath) : time();
+        $etag = md5_file($realPath) !== false ? md5_file($realPath) : sha1($realPath);
+
+        $guesser = MimeTypes::getDefault();
+        // Extension map FIRST: content sniffing cannot identify text formats
+        // (css/js/svg carry no magic bytes — finfo calls them text/plain), and
+        // these responses send X-Content-Type-Options: nosniff, so a wrong
+        // type makes browsers REFUSE stylesheets and module scripts outright.
+        // Sniffing remains the fallback for extensionless files.
+        $ext = strtolower(pathinfo($realPath, PATHINFO_EXTENSION));
+        $byExtension = $ext !== '' ? ($guesser->getMimeTypes($ext)[0] ?? null) : null;
+        $mimeGuess = mime_content_type($realPath);
+        $mime = $byExtension
+            ?? $guesser->guessMimeType($realPath)
+            ?? ($mimeGuess !== false ? $mimeGuess : 'application/octet-stream');
+
+        $resp = new BinaryFileResponse($realPath);
+        $resp->headers->set('Content-Type', $mime);
+        foreach (SecurityHeaders::defaultStaticAssetHeaders() as $header => $value) {
+            $resp->headers->set($header, $value);
+        }
+        $resp->headers->set('Cache-Control', $this->cacheControl($basename));
+        $resp->setEtag('"' . $etag . '"');
+        $resp->setLastModified((new \DateTimeImmutable())->setTimestamp($mtime));
+        $resp->setContentDisposition(
+            ResponseHeaderBag::DISPOSITION_INLINE,
+            $basename
+        );
+        $resp->isNotModified($request);
+        return $resp;
+    }
+
+    /**
+     * Serve index.html (200, no-cache, hardened headers, revalidatable).
+     */
+    private function serveIndex(Request $request, string $realDir): Response
+    {
+        $index = $realDir . DIRECTORY_SEPARATOR . 'index.html';
+        if (!is_file($index)) {
+            return new Response('', 404);
+        }
+        $resp = new BinaryFileResponse($index);
+        $resp->headers->set('Content-Type', 'text/html; charset=UTF-8');
+        foreach (SecurityHeaders::defaultStaticAssetHeaders() as $header => $value) {
+            $resp->headers->set($header, $value);
+        }
+        $resp->headers->set('Cache-Control', 'no-cache');
+        $mtime = filemtime($index) !== false ? filemtime($index) : time();
+        $etag = md5_file($index) !== false ? md5_file($index) : sha1($index);
+        $resp->setEtag('"' . $etag . '"');
+        $resp->setLastModified((new \DateTimeImmutable())->setTimestamp($mtime));
+        $resp->isNotModified($request);
+        return $resp;
+    }
+
+    /**
+     * Cache-Control for a served file: content-hashed assets are immutable;
+     * everything else (incl. index.html) revalidates so deploys are seen.
+     */
+    private function cacheControl(string $basename): string
+    {
+        return preg_match('/[.\-_][A-Za-z0-9]{8,}\.[A-Za-z0-9]+$/', $basename) === 1
+            ? 'public, max-age=31536000, immutable'
+            : 'no-cache';
+    }
+}

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,7 +13,7 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.66.1';
+    public const VERSION = '1.66.2';
 
 
     /** Release code name */

--- a/tests/Integration/Extensions/ServeFrontendDispatchTest.php
+++ b/tests/Integration/Extensions/ServeFrontendDispatchTest.php
@@ -6,8 +6,11 @@ namespace Glueful\Tests\Integration\Extensions;
 
 use Glueful\Bootstrap\ApplicationContext;
 use Glueful\Extensions\ServiceProvider;
+use Glueful\Routing\FrontendMountRegistry;
 use Glueful\Routing\RouteCache;
+use Glueful\Routing\RouteCompiler;
 use Glueful\Routing\Router;
+use Glueful\Routing\SpaMountController;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -16,6 +19,7 @@ use Symfony\Component\HttpFoundation\Response;
 class ServeFrontendDispatchTest extends TestCase
 {
     private string $dir;
+    private ApplicationContext $ctx;
 
     protected function setUp(): void
     {
@@ -36,6 +40,7 @@ class ServeFrontendDispatchTest extends TestCase
     private function mountedRouter(): Router
     {
         $context = new ApplicationContext(sys_get_temp_dir() . '/sfd_ctx_' . uniqid());
+        $this->ctx = $context;
         (new RouteCache($context))->clear();
 
         $container = new class implements ContainerInterface {
@@ -59,6 +64,12 @@ class ServeFrontendDispatchTest extends TestCase
         $container->services[ApplicationContext::class] = $context;
         $router = new Router($container);
         $container->services[Router::class] = $router;
+
+        // serveFrontend populates the registry (boot) and SpaMountController reads it
+        // (dispatch); both resolve from the container as shared singletons in production.
+        $registry = new FrontendMountRegistry();
+        $container->services[FrontendMountRegistry::class] = $registry;
+        $container->services[SpaMountController::class] = new SpaMountController($registry);
 
         $provider = new class ($container) extends ServiceProvider {
             public function expose(string $path, string $dir): void
@@ -109,5 +120,29 @@ class ServeFrontendDispatchTest extends TestCase
 
         $resp = $router->dispatch(Request::create('/admin/config.json', 'GET'));
         self::assertSame('CONFIG', (string) $resp->getContent());
+    }
+
+    /**
+     * Regression: mounting an SPA via serveFrontend() must NOT introduce closure
+     * handlers, because a single closure makes RouteCache reject the ENTIRE route
+     * table (disabling route caching app-wide and logging a warning). This proves
+     * the controller-based mount keeps the table cacheable.
+     */
+    public function testMountedRouteTableHasNoClosuresAndSaves(): void
+    {
+        $router = $this->mountedRouter();
+
+        $compiler = new RouteCompiler();
+        $issues = $compiler->validateHandlers($router);
+        self::assertFalse(
+            $compiler->hasClosures($issues),
+            'serveFrontend() must register controller handlers, not closures: '
+                . implode(', ', $compiler->getClosureRoutes($issues)),
+        );
+
+        // The cache writer returns false (and logs the warning) when it finds a
+        // closure; a true return proves the SPA-mounted table is cacheable.
+        $saved = (new RouteCache($this->ctx))->save($router);
+        self::assertTrue($saved, 'RouteCache::save() must succeed with an SPA mounted');
     }
 }

--- a/tests/Integration/Extensions/ServeFrontendDispatchTest.php
+++ b/tests/Integration/Extensions/ServeFrontendDispatchTest.php
@@ -19,7 +19,6 @@ use Symfony\Component\HttpFoundation\Response;
 class ServeFrontendDispatchTest extends TestCase
 {
     private string $dir;
-    private ApplicationContext $ctx;
 
     protected function setUp(): void
     {
@@ -40,7 +39,6 @@ class ServeFrontendDispatchTest extends TestCase
     private function mountedRouter(): Router
     {
         $context = new ApplicationContext(sys_get_temp_dir() . '/sfd_ctx_' . uniqid());
-        $this->ctx = $context;
         (new RouteCache($context))->clear();
 
         $container = new class implements ContainerInterface {
@@ -71,12 +69,7 @@ class ServeFrontendDispatchTest extends TestCase
         $container->services[FrontendMountRegistry::class] = $registry;
         $container->services[SpaMountController::class] = new SpaMountController($registry);
 
-        $provider = new class ($container) extends ServiceProvider {
-            public function expose(string $path, string $dir): void
-            {
-                $this->serveFrontend($path, $dir);
-            }
-        };
+        $provider = new FrontendDispatchTestProvider($container);
         $provider->expose('/admin', $this->dir);
 
         return $router;
@@ -143,5 +136,14 @@ class ServeFrontendDispatchTest extends TestCase
             'serveFrontend() must register controller handlers, not closures: '
                 . implode(', ', $compiler->getClosureRoutes($issues)),
         );
+    }
+}
+
+/** Exposes the protected serveFrontend() seam so the test can mount a bundle. */
+class FrontendDispatchTestProvider extends ServiceProvider // phpcs:ignore PSR1.Classes.ClassDeclaration.MultipleClasses
+{
+    public function expose(string $path, string $dir): void
+    {
+        $this->serveFrontend($path, $dir);
     }
 }

--- a/tests/Integration/Extensions/ServeFrontendDispatchTest.php
+++ b/tests/Integration/Extensions/ServeFrontendDispatchTest.php
@@ -6,8 +6,11 @@ namespace Glueful\Tests\Integration\Extensions;
 
 use Glueful\Bootstrap\ApplicationContext;
 use Glueful\Extensions\ServiceProvider;
+use Glueful\Routing\FrontendMountRegistry;
 use Glueful\Routing\RouteCache;
+use Glueful\Routing\RouteCompiler;
 use Glueful\Routing\Router;
+use Glueful\Routing\SpaMountController;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -60,6 +63,12 @@ class ServeFrontendDispatchTest extends TestCase
         $router = new Router($container);
         $container->services[Router::class] = $router;
 
+        // serveFrontend populates the registry (boot) and SpaMountController reads it
+        // (dispatch); both resolve from the container as shared singletons in production.
+        $registry = new FrontendMountRegistry();
+        $container->services[FrontendMountRegistry::class] = $registry;
+        $container->services[SpaMountController::class] = new SpaMountController($registry);
+
         $provider = new class ($container) extends ServiceProvider {
             public function expose(string $path, string $dir): void
             {
@@ -109,5 +118,28 @@ class ServeFrontendDispatchTest extends TestCase
 
         $resp = $router->dispatch(Request::create('/admin/config.json', 'GET'));
         self::assertSame('CONFIG', (string) $resp->getContent());
+    }
+
+    /**
+     * Regression: mounting an SPA via serveFrontend() must NOT introduce closure
+     * handlers, because a single closure makes RouteCache reject the ENTIRE route
+     * table (disabling route caching app-wide and logging a warning).
+     *
+     * `RouteCompiler::hasClosures()` is the exact predicate `RouteCache::save()`
+     * checks to decide rejection (save() returns false when it is true), so
+     * asserting it directly proves the table stays cacheable — without depending on
+     * save()'s environment-specific OPcache warm step.
+     */
+    public function testMountedRouteTableHasNoClosures(): void
+    {
+        $router = $this->mountedRouter();
+
+        $compiler = new RouteCompiler();
+        $issues = $compiler->validateHandlers($router);
+        self::assertFalse(
+            $compiler->hasClosures($issues),
+            'serveFrontend() must register controller handlers, not closures: '
+                . implode(', ', $compiler->getClosureRoutes($issues)),
+        );
     }
 }

--- a/tests/Integration/Extensions/ServeFrontendTest.php
+++ b/tests/Integration/Extensions/ServeFrontendTest.php
@@ -79,13 +79,7 @@ class ServeFrontendTest extends TestCase
             },
         );
 
-        $provider = new class ($this->container) extends ServiceProvider {
-            /** @param array<string, mixed> $options */
-            public function expose(string $path, string $dir, array $options): void
-            {
-                $this->serveFrontend($path, $dir, $options);
-            }
-        };
+        $provider = new FrontendTestProvider($this->container);
         $provider->expose($path, $dir, $options);
 
         return [$routes, $calls];
@@ -145,5 +139,15 @@ class ServeFrontendTest extends TestCase
         self::assertSame('/admin', $mount['prefix']);
         self::assertSame(realpath($this->dir), $mount['dir']);
         self::assertTrue($mount['spaFallback']);
+    }
+}
+
+/** Exposes the protected serveFrontend() seam (with options) for registration assertions. */
+class FrontendTestProvider extends ServiceProvider // phpcs:ignore PSR1.Classes.ClassDeclaration.MultipleClasses
+{
+    /** @param array<string, mixed> $options */
+    public function expose(string $path, string $dir, array $options): void
+    {
+        $this->serveFrontend($path, $dir, $options);
     }
 }

--- a/tests/Integration/Extensions/ServeFrontendTest.php
+++ b/tests/Integration/Extensions/ServeFrontendTest.php
@@ -5,31 +5,34 @@ declare(strict_types=1);
 namespace Glueful\Tests\Integration\Extensions;
 
 use Glueful\Extensions\ServiceProvider;
+use Glueful\Routing\FrontendMountRegistry;
 use Glueful\Routing\Route;
 use Glueful\Routing\Router;
+use Glueful\Routing\SpaMountController;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * serveFrontend() REGISTRATION behaviour: path validation, no-op guards, and the
+ * controller-array handlers it registers (never closures — see the "no closures"
+ * assertion below and the RouteCache regression in ServeFrontendDispatchTest).
+ * The asset/index SERVING behaviour now lives in {@see SpaMountController} and is
+ * covered by SpaMountControllerTest.
+ */
 class ServeFrontendTest extends TestCase
 {
     private string $dir;
     private ContainerInterface&MockObject $container;
+    private FrontendMountRegistry $registry;
 
     protected function setUp(): void
     {
         $this->dir = sys_get_temp_dir() . '/serve_frontend_' . uniqid();
-        mkdir($this->dir . '/assets', 0755, true);
+        mkdir($this->dir, 0755, true);
         file_put_contents($this->dir . '/index.html', '<!doctype html><title>App</title>');
-        file_put_contents($this->dir . '/favicon.ico', 'ico');
-        file_put_contents($this->dir . '/assets/app-C5kJ8nQ2.js', 'console.log(1)');
-        file_put_contents($this->dir . '/style.css', 'body{}');
-        file_put_contents($this->dir . '/.env', 'SECRET=1');
-        file_put_contents($this->dir . '/config.php', '<?php');
 
+        $this->registry = new FrontendMountRegistry();
         $this->container = $this->createMock(ContainerInterface::class);
         $this->container->method('has')->willReturnCallback(
             static fn (string $id): bool => $id === Router::class,
@@ -54,7 +57,7 @@ class ServeFrontendTest extends TestCase
      * Mount and capture the two registered route handlers.
      *
      * @param  array<string, mixed> $options
-     * @return array{0: array<string, callable>, 1: int}
+     * @return array{0: array<string, mixed>, 1: int}
      */
     private function mount(string $path, string $dir, array $options = []): array
     {
@@ -68,7 +71,13 @@ class ServeFrontendTest extends TestCase
             $route->method('where')->willReturnSelf();
             return $route;
         });
-        $this->container->method('get')->with(Router::class)->willReturn($router);
+        $this->container->method('get')->willReturnCallback(
+            fn (string $id): mixed => match ($id) {
+                Router::class => $router,
+                FrontendMountRegistry::class => $this->registry,
+                default => throw new \RuntimeException("unexpected get($id)"),
+            },
+        );
 
         $provider = new class ($this->container) extends ServiceProvider {
             /** @param array<string, mixed> $options */
@@ -85,29 +94,31 @@ class ServeFrontendTest extends TestCase
     public function testInvalidMountPathThrows(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        [$routes] = $this->mount('admin', $this->dir); // no leading slash
+        $this->mount('admin', $this->dir); // no leading slash
     }
 
     public function testTrailingSlashMountArgumentThrows(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        [$routes] = $this->mount('/admin/', $this->dir);
+        $this->mount('/admin/', $this->dir);
     }
 
     public function testMissingDirIsNoOp(): void
     {
-        [$routes, $calls] = $this->mount('/admin', $this->dir . '/does-not-exist');
+        [, $calls] = $this->mount('/admin', $this->dir . '/does-not-exist');
         self::assertSame(0, $calls);
+        self::assertSame([], $this->registry->all());
     }
 
     public function testMissingIndexWithSpaFallbackIsNoOp(): void
     {
         unlink($this->dir . '/index.html');
-        [$routes, $calls] = $this->mount('/admin', $this->dir);
+        [, $calls] = $this->mount('/admin', $this->dir);
         self::assertSame(0, $calls, 'No index.html + spaFallback => no routes registered');
+        self::assertSame([], $this->registry->all());
     }
 
-    public function testValidMountRegistersTwoRoutes(): void
+    public function testValidMountRegistersTwoControllerRoutes(): void
     {
         [$routes, $calls] = $this->mount('/admin', $this->dir);
         self::assertSame(2, $calls);
@@ -115,99 +126,24 @@ class ServeFrontendTest extends TestCase
         self::assertArrayHasKey('/admin/{rest}', $routes);
     }
 
-    public function testTraversalDotfileAndPhpAreDenied(): void
+    public function testHandlersAreControllerArraysNotClosures(): void
     {
+        // The whole point of the seam: no closures reach the router, so RouteCache
+        // can serialize the table. Handlers must be [SpaMountController::class, ...].
         [$routes] = $this->mount('/admin', $this->dir);
-        $serve = $routes['/admin/{rest}'];
-        foreach (['../../../etc/passwd', '../.env', '.env', 'config.php'] as $bad) {
-            $resp = $serve(Request::create("/admin/$bad"), $bad);
-            self::assertSame(404, $resp->getStatusCode(), "$bad must be denied");
-        }
+        self::assertSame([SpaMountController::class, 'root'], $routes['/admin']);
+        self::assertSame([SpaMountController::class, 'asset'], $routes['/admin/{rest}']);
+        self::assertNotInstanceOf(\Closure::class, $routes['/admin']);
+        self::assertNotInstanceOf(\Closure::class, $routes['/admin/{rest}']);
     }
 
-    public function testNonHashedAssetServedWithNoCacheAndSecurityHeaders(): void
+    public function testMountIsRecordedInRegistry(): void
     {
-        [$routes] = $this->mount('/admin', $this->dir);
-        $resp = $routes['/admin/{rest}'](Request::create('/admin/style.css'), 'style.css');
-
-        self::assertSame(200, $resp->getStatusCode());
-        self::assertInstanceOf(BinaryFileResponse::class, $resp);
-        self::assertSame('nosniff', $resp->headers->get('X-Content-Type-Options'));
-        self::assertStringContainsString('no-cache', (string) $resp->headers->get('Cache-Control'));
-    }
-
-    public function testTextAssetsGetExtensionMimeNotSniffedTextPlain(): void
-    {
-        // finfo content-sniffing calls css/js "text/plain" (no magic bytes), and
-        // these responses carry X-Content-Type-Options: nosniff — so a wrong
-        // type makes browsers REFUSE stylesheets/module scripts outright. The
-        // extension map must win for known extensions; sniffing is only the
-        // fallback for extensionless files.
-        [$routes] = $this->mount('/admin', $this->dir);
-        $css = $routes['/admin/{rest}'](Request::create('/admin/style.css'), 'style.css');
-        self::assertSame('text/css', $css->headers->get('Content-Type'));
-        $js = $routes['/admin/{rest}'](
-            Request::create('/admin/assets/app-C5kJ8nQ2.js'),
-            'assets/app-C5kJ8nQ2.js',
-        );
-        self::assertStringContainsString('javascript', (string) $js->headers->get('Content-Type'));
-    }
-
-    public function testHashedAssetServedImmutable(): void
-    {
-        [$routes] = $this->mount('/admin', $this->dir);
-        $resp = $routes['/admin/{rest}'](Request::create('/admin/assets/app-C5kJ8nQ2.js'), 'assets/app-C5kJ8nQ2.js');
-
-        self::assertSame(200, $resp->getStatusCode());
-        self::assertStringContainsString('immutable', (string) $resp->headers->get('Cache-Control'));
-        self::assertStringContainsString('max-age=31536000', (string) $resp->headers->get('Cache-Control'));
-        self::assertNotEmpty($resp->headers->get('ETag'));
-    }
-
-    public function testRootServesIndexWithNoCache(): void
-    {
-        [$routes] = $this->mount('/admin', $this->dir);
-        $resp = $routes['/admin'](Request::create('/admin'));
-
-        self::assertSame(200, $resp->getStatusCode());
-        self::assertStringContainsString('no-cache', (string) $resp->headers->get('Cache-Control'));
-    }
-
-    public function testRouteLikeDeepLinkFallsBackToIndex(): void
-    {
-        [$routes] = $this->mount('/admin', $this->dir);
-        $resp = $routes['/admin/{rest}'](Request::create('/admin/posts/123'), 'posts/123');
-
-        self::assertSame(200, $resp->getStatusCode());
-        self::assertStringContainsString('no-cache', (string) $resp->headers->get('Cache-Control'));
-    }
-
-    public function testMissingAssetIsA404NotIndex(): void
-    {
-        [$routes] = $this->mount('/admin', $this->dir);
-        $resp = $routes['/admin/{rest}'](Request::create('/admin/missing.js'), 'missing.js');
-        self::assertSame(404, $resp->getStatusCode());
-    }
-
-    public function testDotRuleTreatsDottedPathAsAsset(): void
-    {
-        [$routes] = $this->mount('/admin', $this->dir);
-        $resp = $routes['/admin/{rest}'](Request::create('/admin/docs.v1'), 'docs.v1');
-        self::assertSame(404, $resp->getStatusCode());
-    }
-
-    public function testSpaFallbackFalseReturns404OnMissAndRoot(): void
-    {
-        [$routes] = $this->mount('/downloads', $this->dir, ['spaFallback' => false]);
-
-        $miss = $routes['/downloads/{rest}'](Request::create('/downloads/nope'), 'nope');
-        self::assertSame(404, $miss->getStatusCode());
-
-        $root = $routes['/downloads'](Request::create('/downloads'));
-        self::assertSame(404, $root->getStatusCode());
-
-        // A real file is still served with spaFallback:false.
-        $hit = $routes['/downloads/{rest}'](Request::create('/downloads/style.css'), 'style.css');
-        self::assertSame(200, $hit->getStatusCode());
+        $this->mount('/admin', $this->dir);
+        $mount = $this->registry->match('/admin/posts/123');
+        self::assertNotNull($mount);
+        self::assertSame('/admin', $mount['prefix']);
+        self::assertSame(realpath($this->dir), $mount['dir']);
+        self::assertTrue($mount['spaFallback']);
     }
 }

--- a/tests/Integration/Routing/SpaMountControllerTest.php
+++ b/tests/Integration/Routing/SpaMountControllerTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Integration\Routing;
+
+use Glueful\Routing\FrontendMountRegistry;
+use Glueful\Routing\SpaMountController;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Asset/index SERVING behaviour of the SPA mount controller: mime typing, the
+ * cache split (immutable hashed assets vs revalidatable shell), security headers,
+ * path-traversal/dotfile/php denial, and the SPA deep-link fallback. This logic
+ * previously lived in ServiceProvider::serveFrontend() closures and moved here so
+ * the route table stays cacheable; these tests are ported byte-for-byte in intent.
+ */
+class SpaMountControllerTest extends TestCase
+{
+    private string $dir;
+    private SpaMountController $controller;
+
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/spa_mount_' . uniqid();
+        mkdir($this->dir . '/assets', 0755, true);
+        file_put_contents($this->dir . '/index.html', '<!doctype html><title>App</title>');
+        file_put_contents($this->dir . '/favicon.ico', 'ico');
+        file_put_contents($this->dir . '/assets/app-C5kJ8nQ2.js', 'console.log(1)');
+        file_put_contents($this->dir . '/style.css', 'body{}');
+        file_put_contents($this->dir . '/.env', 'SECRET=1');
+        file_put_contents($this->dir . '/config.php', '<?php');
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->dir)) {
+            $it = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($this->dir, \FilesystemIterator::SKIP_DOTS),
+                \RecursiveIteratorIterator::CHILD_FIRST,
+            );
+            foreach ($it as $f) {
+                $f->isDir() ? rmdir($f->getPathname()) : unlink($f->getPathname());
+            }
+            rmdir($this->dir);
+        }
+    }
+
+    /** Controller with a mount at $prefix pointing at the fixture bundle. */
+    private function mount(string $prefix = '/admin', bool $spaFallback = true): SpaMountController
+    {
+        $registry = new FrontendMountRegistry();
+        $registry->register($prefix, (string) realpath($this->dir), $spaFallback, $prefix);
+        return new SpaMountController($registry);
+    }
+
+    public function testUnknownMountReturns404(): void
+    {
+        $controller = $this->mount('/admin');
+        // No mount owns /portal — must 404, never leak the /admin bundle.
+        self::assertSame(404, $controller->asset(Request::create('/portal/x'), 'x')->getStatusCode());
+        self::assertSame(404, $controller->root(Request::create('/portal'))->getStatusCode());
+    }
+
+    public function testTraversalDotfileAndPhpAreDenied(): void
+    {
+        $controller = $this->mount('/admin');
+        foreach (['../../../etc/passwd', '../.env', '.env', 'config.php'] as $bad) {
+            $resp = $controller->asset(Request::create("/admin/$bad"), $bad);
+            self::assertSame(404, $resp->getStatusCode(), "$bad must be denied");
+        }
+    }
+
+    public function testNonHashedAssetServedWithNoCacheAndSecurityHeaders(): void
+    {
+        $resp = $this->mount('/admin')->asset(Request::create('/admin/style.css'), 'style.css');
+
+        self::assertSame(200, $resp->getStatusCode());
+        self::assertInstanceOf(BinaryFileResponse::class, $resp);
+        self::assertSame('nosniff', $resp->headers->get('X-Content-Type-Options'));
+        self::assertStringContainsString('no-cache', (string) $resp->headers->get('Cache-Control'));
+    }
+
+    public function testTextAssetsGetExtensionMimeNotSniffedTextPlain(): void
+    {
+        // finfo content-sniffing calls css/js "text/plain" (no magic bytes), and
+        // these responses carry X-Content-Type-Options: nosniff — so a wrong
+        // type makes browsers REFUSE stylesheets/module scripts outright. The
+        // extension map must win for known extensions; sniffing is only the
+        // fallback for extensionless files.
+        $controller = $this->mount('/admin');
+        $css = $controller->asset(Request::create('/admin/style.css'), 'style.css');
+        self::assertSame('text/css', $css->headers->get('Content-Type'));
+        $js = $controller->asset(
+            Request::create('/admin/assets/app-C5kJ8nQ2.js'),
+            'assets/app-C5kJ8nQ2.js',
+        );
+        self::assertStringContainsString('javascript', (string) $js->headers->get('Content-Type'));
+    }
+
+    public function testHashedAssetServedImmutable(): void
+    {
+        $resp = $this->mount('/admin')->asset(
+            Request::create('/admin/assets/app-C5kJ8nQ2.js'),
+            'assets/app-C5kJ8nQ2.js',
+        );
+
+        self::assertSame(200, $resp->getStatusCode());
+        self::assertStringContainsString('immutable', (string) $resp->headers->get('Cache-Control'));
+        self::assertStringContainsString('max-age=31536000', (string) $resp->headers->get('Cache-Control'));
+        self::assertNotEmpty($resp->headers->get('ETag'));
+    }
+
+    public function testRootServesIndexWithNoCache(): void
+    {
+        $resp = $this->mount('/admin')->root(Request::create('/admin'));
+
+        self::assertSame(200, $resp->getStatusCode());
+        self::assertStringContainsString('no-cache', (string) $resp->headers->get('Cache-Control'));
+    }
+
+    public function testRouteLikeDeepLinkFallsBackToIndex(): void
+    {
+        $resp = $this->mount('/admin')->asset(Request::create('/admin/posts/123'), 'posts/123');
+
+        self::assertSame(200, $resp->getStatusCode());
+        self::assertStringContainsString('no-cache', (string) $resp->headers->get('Cache-Control'));
+    }
+
+    public function testMissingAssetIsA404NotIndex(): void
+    {
+        $resp = $this->mount('/admin')->asset(Request::create('/admin/missing.js'), 'missing.js');
+        self::assertSame(404, $resp->getStatusCode());
+    }
+
+    public function testDotRuleTreatsDottedPathAsAsset(): void
+    {
+        $resp = $this->mount('/admin')->asset(Request::create('/admin/docs.v1'), 'docs.v1');
+        self::assertSame(404, $resp->getStatusCode());
+    }
+
+    public function testSpaFallbackFalseReturns404OnMissAndRoot(): void
+    {
+        $controller = $this->mount('/downloads', spaFallback: false);
+
+        $miss = $controller->asset(Request::create('/downloads/nope'), 'nope');
+        self::assertSame(404, $miss->getStatusCode());
+
+        $root = $controller->root(Request::create('/downloads'));
+        self::assertSame(404, $root->getStatusCode());
+
+        // A real file is still served with spaFallback:false.
+        $hit = $controller->asset(Request::create('/downloads/style.css'), 'style.css');
+        self::assertSame(200, $hit->getStatusCode());
+    }
+
+    public function testLongestPrefixWinsWhenMountsNest(): void
+    {
+        // Two mounts, one nested under the other; a request under the deeper mount
+        // must resolve to it, not the shallower parent.
+        $registry = new FrontendMountRegistry();
+        $registry->register('/admin', (string) realpath($this->dir), true, 'admin');
+        $registry->register('/admin/reports', (string) realpath($this->dir), true, 'reports');
+        $match = $registry->match('/admin/reports/q3');
+        self::assertNotNull($match);
+        self::assertSame('/admin/reports', $match['prefix']);
+    }
+}

--- a/tests/Unit/Extensions/ServiceProviderTest.php
+++ b/tests/Unit/Extensions/ServiceProviderTest.php
@@ -127,12 +127,18 @@ class ServiceProviderTest extends TestCase
                ->method('get')
                ->willReturn($mockRoute);
 
+        $registry = new \Glueful\Routing\FrontendMountRegistry();
         $this->container->method('has')
                        ->with(\Glueful\Routing\Router::class)
                        ->willReturn(true);
+        // serveFrontend resolves the mount registry (boot-time side effect) and the
+        // Router; both must come from the container.
         $this->container->method('get')
-                       ->with(\Glueful\Routing\Router::class)
-                       ->willReturn($router);
+                       ->willReturnCallback(static fn (string $id): mixed => match ($id) {
+                           \Glueful\Routing\Router::class => $router,
+                           \Glueful\Routing\FrontendMountRegistry::class => $registry,
+                           default => throw new \RuntimeException("unexpected get($id)"),
+                       });
 
         $provider = new TestServiceProvider($this->container);
 
@@ -150,6 +156,10 @@ class ServiceProviderTest extends TestCase
             unlink($staticDir . '/index.html');
             rmdir($staticDir);
         }
+
+        // The mount was recorded, and the two registered handlers are the SPA
+        // controller (never closures — that is what keeps the route table cacheable).
+        self::assertArrayHasKey('/valid-mount', $registry->all());
     }
 
     public function testRunningInConsole(): void


### PR DESCRIPTION
### Fixed
- **Serving an SPA via `serveFrontend()` silently disabled route caching for the whole
  application.** `ServiceProvider::serveFrontend()` registered its mount root and `/{rest}`
  catch-all as **closures**, and `RouteCache` refuses to cache a route table containing any
  closure — so every app that mounts an admin/SPA bundle ran with route caching off and logged
  `[RouteCache] Skipping cache: N route(s) use closure handlers … Convert to [Controller::class,
  "method"] syntax.` on each boot. The seam now registers controller handlers
  (`[SpaMountController::class, 'root'|'asset']`) backed by a new `FrontendMountRegistry` that
  resolves the owning mount from the request path by longest-prefix match (so multiple mounts —
  `/admin`, `/portal`, … — are supported by one mount-agnostic controller). Asset/index serving is
  byte-for-byte identical: mime typing, static-asset security headers, the immutable-vs-revalidate
  cache split, ETag/`304`, path-traversal + dotfile + `.php` denial, and the SPA deep-link fallback.
  New public classes `Glueful\Routing\FrontendMountRegistry` and `Glueful\Routing\SpaMountController`
  (registered as shared services in `CoreProvider`); the `serveFrontend()` signature and behavior are
  unchanged. Apps mounting an SPA regain route caching automatically — no code or config change and
  no new env vars.