### PR TITLE
Fix route-cache reconstruction for dynamic routes with constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.66.3] - 2026-07-06 — Adhara
+
 ### Fixed
 - **Route caching crashed dynamic routes whose `where()` constraint contained parentheses
   (e.g. a non-capturing `(?:…)` group).** When the compiled route table was reconstructed from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Fixed
+- **Route caching crashed dynamic routes whose `where()` constraint contained parentheses
+  (e.g. a non-capturing `(?:…)` group).** When the compiled route table was reconstructed from
+  cache, each dynamic route's path was reverse-engineered from its compiled regex by
+  `Router::patternToPath()`, whose group-matching regex mistook the constraint's inner `(?:…)`
+  group for the parameter's own capture group. The reconstructed route then compiled to a pattern
+  with more capture groups than parameter names, so the first matching request raised
+  `ValueError: array_combine(): Argument #1 ($keys) and argument #2 ($values) must have the same
+  number of elements` in `Route::match()`. This surfaced in 1.66.2, which re-enabled route caching
+  for apps that mount an SPA (caching had been silently disabled by the closure handlers 1.66.2
+  removed). Reconstruction now rebuilds each route from its **authoritative original path and
+  `where` constraints** — newly serialized into the compiled cache — and recompiles the pattern
+  identically to registration, instead of reverse-engineering it from the regex. The compiled
+  cache format version is bumped so any pre-existing route cache regenerates automatically on
+  upgrade.
+
 ## [1.66.2] - 2026-07-06 — Adhara
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,17 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.66.3 — Adhara (Patch, Released 2026-07-06)
+- **Route caching no longer crashes routes with parenthesized `where()` constraints.** Reconstructing
+  a dynamic route from the compiled cache reverse-engineered its path from the regex, mistaking a
+  constraint's non-capturing `(?:…)` group for the parameter's capture group; the rebuilt route then
+  had more capture groups than parameter names, raising `ValueError` from `array_combine()` in
+  `Route::match()` on the first request. Exposed by 1.66.2, which re-enabled route caching for
+  SPA-mounting apps. Reconstruction now rebuilds each route from its authoritative original path +
+  `where` constraints (serialized into the cache) and recompiles identically to registration.
+- Notes: the compiled cache format is bumped, so stale route caches regenerate automatically on
+  upgrade; no code or config change required.
+
 ### 1.66.2 — Adhara (Patch, Released 2026-07-06)
 - **`serveFrontend()` no longer disables route caching.** Mounting an admin/SPA bundle registered
   the mount root and `/{rest}` catch-all as closures, and `RouteCache` rejects any route table that

--- a/src/Routing/RouteCache.php
+++ b/src/Routing/RouteCache.php
@@ -8,6 +8,13 @@ use Glueful\Bootstrap\ApplicationContext;
 
 class RouteCache
 {
+    /**
+     * Bumped when the compiled cache schema changes, so upgrading the framework
+     * invalidates any cache written by an older format. v2 added per-route
+     * 'path' + 'where' for lossless dynamic-route reconstruction.
+     */
+    private const CACHE_FORMAT = 2;
+
     private string $cacheDir;
     private ApplicationContext $context;
 
@@ -214,6 +221,7 @@ class RouteCache
         sort($files);
 
         $ctx = hash_init('sha256');
+        hash_update($ctx, 'fmt:' . self::CACHE_FORMAT);
         foreach ($files as $file) {
             if (!is_file($file)) {
                 continue;

--- a/src/Routing/RouteCompiler.php
+++ b/src/Routing/RouteCompiler.php
@@ -44,10 +44,18 @@ class RouteCompiler
                 $handlerMeta = $this->normalizeHandler($route->getHandler());
                 $params = var_export($route->getParamNames(), true);
                 $middleware = var_export($route->getMiddleware(), true);
+                // Serialize the authoritative original path + constraints so the
+                // route can be reconstructed exactly (see Router::reconstructDynamicRoutes).
+                // Reverse-engineering the path from the compiled pattern is lossy when a
+                // constraint contains parentheses (e.g. a non-capturing '(?:…)' group).
+                $path = var_export($route->getPath(), true);
+                $where = var_export($route->getConstraints(), true);
                 $code .= "            [\n";
+                $code .= "                'path' => {$path},\n";
                 $code .= "                'pattern' => '{$pattern}',\n";
                 $code .= "                'handler' => " . var_export($handlerMeta, true) . ",\n";
                 $code .= "                'params' => {$params},\n";
+                $code .= "                'where' => {$where},\n";
                 $code .= "                'middleware' => {$middleware}\n";
                 $code .= "            ],\n";
             }

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -1343,12 +1343,24 @@ class Router
                 // Reconstruct the handler from cached metadata
                 $handler = $this->reconstructHandler($routeData['handler']);
 
-                // Create a new Route object with the cached data
-                // Need to create path from pattern for Route constructor
-                // Use cached param names when reconstructing path
+                // Reconstruct from the authoritative original path + constraints.
+                // Falling back to reverse-engineering the path from the compiled
+                // pattern (patternToPath) is lossy when a constraint contains
+                // parentheses — a non-capturing '(?:…)' group is mistaken for the
+                // param's capture group, desyncing the group count from the param
+                // names and raising a ValueError from array_combine() on match.
                 $paramNames = is_array($routeData['params'] ?? null) ? $routeData['params'] : [];
-                $path = $this->patternToPath($routeData['pattern'], $paramNames);
+                $path = is_string($routeData['path'] ?? null)
+                    ? $routeData['path']
+                    : $this->patternToPath($routeData['pattern'], $paramNames);
                 $route = new Route($this, $method, $path, $handler);
+
+                // Re-apply constraints so the pattern recompiles identically to
+                // registration (with the correct capture-group/param-name count).
+                $where = $routeData['where'] ?? null;
+                if (is_array($where) && count($where) > 0) {
+                    $route->where($where);
+                }
 
                 // Apply middleware if present
                 if (isset($routeData['middleware']) && count($routeData['middleware']) > 0) {

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,7 +13,7 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.66.2';
+    public const VERSION = '1.66.3';
 
 
     /** Release code name */

--- a/tests/Integration/Routing/RouteCacheReconstructionTest.php
+++ b/tests/Integration/Routing/RouteCacheReconstructionTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Integration\Routing;
+
+use Glueful\Bootstrap\ApplicationContext;
+use Glueful\Routing\RouteCache;
+use Glueful\Routing\RouteCompiler;
+use Glueful\Routing\Router;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Route-cache round-trip fidelity: a route reconstructed from the compiled cache
+ * must match identically to the freshly-registered route — including its param
+ * extraction. Reconstructing the path by reverse-engineering the compiled regex
+ * (patternToPath) desynced the capture-group count from the param names whenever a
+ * where() constraint contained parentheses (e.g. a non-capturing '(?:…)' group),
+ * which raised a ValueError from array_combine() on the first request.
+ */
+class RouteCacheReconstructionTest extends TestCase
+{
+    private function container(ApplicationContext $context): ContainerInterface
+    {
+        $c = new class implements ContainerInterface {
+            /** @var array<string, mixed> */
+            public array $services = [];
+            public function has(string $id): bool
+            {
+                return array_key_exists($id, $this->services);
+            }
+            public function get(string $id): mixed
+            {
+                if ($this->has($id)) {
+                    return $this->services[$id];
+                }
+                throw new class ("no $id")
+                    extends \RuntimeException
+                    implements \Psr\Container\NotFoundExceptionInterface {
+                };
+            }
+        };
+        $c->services[ApplicationContext::class] = $context;
+        return $c;
+    }
+
+    public function testRouteWithNonCapturingConstraintSurvivesCacheRoundTrip(): void
+    {
+        $context = new ApplicationContext(sys_get_temp_dir() . '/rcr_' . uniqid());
+        $cache = new RouteCache($context);
+        $cache->clear();
+
+        $container = $this->container($context);
+        $router = new Router($container);
+
+        // Controller-array handler keeps the table cacheable (no closures). The
+        // constraint carries a non-capturing group — exactly the render asset route
+        // that regressed once 1.66.2 enabled route caching.
+        $router->get('/assets/{path}', ['App\\SomeController', 'serve'])
+            ->where('path', '.+\.(?:css|js|json)');
+
+        // Write the cache file directly from the compiler output, bypassing
+        // RouteCache::save()'s OPcache warm step (environment-dependent under CLI/CI).
+        $code = (new RouteCompiler())->compile($router, $cache->getSignature());
+        file_put_contents($cache->getCacheFilePath(), $code);
+
+        // A fresh Router reconstructs the whole table from the cache file.
+        $cachedRouter = new Router($container);
+        self::assertTrue($cachedRouter->wasLoadedFromCache(), 'precondition: routes loaded from cache');
+
+        $route = $cachedRouter->getDynamicRoutes()['GET'][0] ?? null;
+        self::assertNotNull($route, 'the dynamic route must survive reconstruction');
+
+        // Before the fix this threw ValueError: array_combine() keys/values mismatch.
+        self::assertSame(['path' => 'blocks.css'], $route->match('/assets/blocks.css'));
+
+        $cache->clear();
+    }
+}


### PR DESCRIPTION

### Fixed
- **Route caching crashed dynamic routes whose `where()` constraint contained parentheses
  (e.g. a non-capturing `(?:…)` group).** When the compiled route table was reconstructed from
  cache, each dynamic route's path was reverse-engineered from its compiled regex by
  `Router::patternToPath()`, whose group-matching regex mistook the constraint's inner `(?:…)`
  group for the parameter's own capture group. The reconstructed route then compiled to a pattern
  with more capture groups than parameter names, so the first matching request raised
  `ValueError: array_combine(): Argument #1 ($keys) and argument #2 ($values) must have the same
  number of elements` in `Route::match()`. This surfaced in 1.66.2, which re-enabled route caching
  for apps that mount an SPA (caching had been silently disabled by the closure handlers 1.66.2
  removed). Reconstruction now rebuilds each route from its **authoritative original path and
  `where` constraints** — newly serialized into the compiled cache — and recompiles the pattern
  identically to registration, instead of reverse-engineering it from the regex. The compiled
  cache format version is bumped so any pre-existing route cache regenerates automatically on
  upgrade.