### PR TITLE
Add process-level write hooks and independent session handling, feat(uploader): blob lifecycle + authorization seams with deterministic compensation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,37 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.67.0] - 2026-07-10 — Adhil
+
+**Theme: extension seams** — four opt-in extension points (independent DB sessions, around-execution
+wrappers, write-side row hooks, and blob lifecycle/authorization hooks) that are exact pass-throughs
+until an application binds them. No new env vars, no migrations, no default changes.
+
 ### Added
+- **Blob lifecycle + authorization seams on the upload pipeline.** Two optional contracts let an
+  application observe and gate the framework's blob endpoints without replacing the controller:
+  - `Glueful\Uploader\Contracts\BlobCreatedHook::onBlobCreated(string $blobUuid, ?string $uploaderUserUuid)`
+    runs after a blob row is persisted; **throwing rejects the upload** and the controller compensates —
+    it deletes the stored object (checked, not assumed) and hard-deletes the blob row via the new
+    `BlobRepository::forceDelete()`, falling back to a verified `status='deleted'` quarantine so a failed
+    hook can never leave a servable, unattributed blob.
+  - `Glueful\Uploader\Contracts\BlobAccessPolicy::authorizeAccess(array $blob, BlobAccessContext $ctx)`
+    runs after the framework's own visibility/auth/signature checks on `show`/`info`/`delete`/`signedUrl`,
+    receiving a `BlobAccessContext {action: BlobAction, authenticatedUserUuid, signatureValid}` (the
+    signature is computed once per request and reused). Returning `false` yields a 404.
+  Both resolve softly from the container (`NullBlobCreatedHook`/`NullBlobAccessPolicy` pass-through
+  defaults — the framework binds nothing), so existing applications are byte-for-byte unaffected.
+- **Deferred thumbnail generation.** `FileUploader::generateThumbnailFor()` generates an upload's
+  thumbnail *after* the fact; the upload controller now defers thumbnail creation until the
+  `BlobCreatedHook` has accepted the blob, so a rejected upload never leaves an orphaned public
+  thumbnail. Thumbnail failures after acceptance are logged and degrade to `thumb_url: null` — a
+  committed upload never 500s on a thumbnail error.
+- **Independent database sessions.** `Connection::newPdo()` opens a non-pooled PDO using the
+  connection's resolved configuration for advisory locks and other session-scoped infrastructure.
+- **Around-execution database wrappers.** `QueryExecutor::addExecutionWrapper()` composes generic
+  `ExecutionWrapperInterface` implementations around the actual prepare/execute operation, allowing
+  extensions to hold locks or other resources for the full statement boundary. The registry is
+  process-level and resettable through `clearExecutionWrappers()`.
 - **Process-level write hooks on `Connection` — the write-side counterpart to the existing `table()`
   read hooks.** `Connection::addInsertHook(\Closure $hook)` registers a
   `fn(string $table, array $data): array` that runs, in registration order, over the row of every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Added
+- **Process-level write hooks on `Connection` — the write-side counterpart to the existing `table()`
+  read hooks.** `Connection::addInsertHook(\Closure $hook)` registers a
+  `fn(string $table, array $data): array` that runs, in registration order, over the row of every
+  `QueryBuilder` `insert()`, `insertBatch()`, and `upsert()`, so an extension can transparently stamp or
+  transform columns (a tenant key, `created_by`, an encrypted field, …) in one place instead of in every
+  repository. `clearInsertHooks()` resets the process-global registry (mirrors `clearTableHooks()`) and
+  `applyInsertHooks()` is the seam the query builder calls. Batch inserts are hardened around hook
+  output: a hook that produces a non-uniform column set across the batch, or a list-shaped
+  (non-associative) row, raises `\UnexpectedValueException` before SQL generation, and each row's key
+  order is normalized to the first row's so a reordered-but-equal column set cannot misalign positional
+  binding. When no hook is registered the seam is a pass-through — no behavior change for existing code.
+
 ## [1.66.3] - 2026-07-06 — Adhara
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,24 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.67.0 — Adhil (Minor, Released 2026-07-10)
+- **Extension seams: four opt-in extension points, all exact pass-throughs until bound.**
+  - `Connection::newPdo()` — a fresh, non-pooled, independent PDO session (advisory locks and other
+    session-scoped infrastructure can no longer be poisoned by the shared statement session).
+  - `QueryExecutor::addExecutionWrapper()` (`ExecutionWrapperInterface::around()`) — composes wrappers
+    around the *actual* prepare/execute, so a lock or resource can be held across the full statement
+    boundary (the before-only interceptor seam cannot span execution).
+  - `Connection::addInsertHook()` — write-side row hooks over `insert()`/`insertBatch()`/`upsert()` for
+    transparent column stamping/transforming, with batch-shape hardening.
+  - Blob lifecycle + authorization: `BlobCreatedHook` (post-persist accept/reject with checked
+    compensation — object delete + `BlobRepository::forceDelete()` + verified quarantine fallback) and
+    `BlobAccessPolicy` (post-core-checks authorization for `show`/`info`/`delete`/`signedUrl` via
+    `BlobAccessContext`/`BlobAction`); thumbnails defer until the hook accepts
+    (`FileUploader::generateThumbnailFor()`), so a rejected upload never leaves an orphaned thumbnail.
+- Notes: **Minor release** — no new env vars, no migrations, no default changes; the framework binds
+  none of the seams, so unbound behavior is byte-for-byte identical. Built for (and consumed by) the
+  Thallo multi-tenancy runtime; the seams are deliberately tenancy-agnostic.
+
 ### 1.66.3 — Adhara (Patch, Released 2026-07-06)
 - **Route caching no longer crashes routes with parenthesized `where()` constraints.** Reconstructing
   a dynamic route from the compiled cache reverse-engineered its path from the regex, mistaking a

--- a/docs/BASEREPOSITORY_SHARED_CONNECTION.md
+++ b/docs/BASEREPOSITORY_SHARED_CONNECTION.md
@@ -1,0 +1,118 @@
+# BaseRepository `$sharedConnection` — lifecycle debt
+
+**Status:** open / captured, not scheduled
+**Area:** `src/Repository/BaseRepository.php`
+**Origin:** surfaced while fixing a Thallo multi-tenancy two-boot test-harness bug (a dropped
+throwaway DB left a dead process-global connection that the next boot reused →
+`PDOException: no connection to the server`).
+
+## The static
+
+`BaseRepository` memoises **one** `Connection` for the whole process and never resets it between
+framework boots or across a long-running worker's lifetime:
+
+```php
+private static ?Connection $sharedConnection = null;
+
+protected static function getSharedConnection(?ApplicationContext $context = null): Connection
+{
+    if (self::$sharedConnection === null) {
+        self::$sharedConnection = Connection::fromContext($context);
+        return self::$sharedConnection;
+    }
+    if ($context !== null && self::$sharedConnection->hasContext() === false) {
+        self::$sharedConnection = Connection::fromContext($context);
+    }
+    return self::$sharedConnection;
+}
+
+public function __construct(?Connection $connection = null, ?ApplicationContext $context = null)
+{
+    $this->context = $context;
+    if ($connection !== null) {
+        self::$sharedConnection = $connection;
+    }
+    $this->db = self::getSharedDb($context);
+}
+```
+
+Its whole lifecycle is "born on the first repository, lives until the process dies." Nothing in the
+framework ever resets or invalidates it.
+
+## Why it exists (it is load-bearing, not an accident)
+
+Measured across framework + extensions + a dependent app:
+
+| Signal | Count |
+|---|---|
+| Classes extending `BaseRepository` | 59 |
+| `new *Repository(...)` call sites | 519 |
+| …of those, **zero-arg** `new XRepository()` (rely entirely on the static) | 264 |
+| Subclasses defining their own `__construct` | 32 |
+| Repositories registered as container services | 0 |
+
+The static is what makes `new XRepository()` "just work" with no args and no container in hand. There
+is **no DI path for repositories today** — they are hand-instantiated everywhere.
+
+## Impact
+
+- **Request-per-process (PHP-FPM / CLI):** benign. The process exits, the static dies with it.
+- **Tests:** real. A memoised connection outlives the DB/context it was built for. The Thallo retrofit
+  harness currently works around this with reflection
+  (`RetrofitHarnessTestCase::resetSharedRepositoryConnection()`), nulling the static in
+  `setUpBeforeClass`/`tearDownAfterClass`. Reflection because there is no public reset seam.
+- **Long-running workers (`QueueWorker`, `SchedulerCommand`, `WorkCommand` — `while(true)` loops):**
+  latent. If the shared PDO goes stale or the server drops it, there is no seam to force a rebuild; the
+  worker keeps handing out a dead connection (a milder cousin of the test failure above).
+
+## Fix ladder (cheap → expensive)
+
+### (a) Reflection in the test harness — DONE
+Cost: ~0. Test-only. Already in place in the Thallo retrofit harness. Not a framework change.
+
+### (b) Public reset seam — SMALL, recommended
+Add a public method so tests (and workers) can force a rebuild without reflection:
+
+```php
+/**
+ * Drop the process-global shared connection so the next repository rebuilds it from its own
+ * live context. For test isolation (a boot whose DB was dropped) and long-running workers that
+ * need to shed a stale/terminated connection between jobs.
+ */
+public static function resetSharedConnection(): void
+{
+    self::$sharedConnection = null;
+}
+```
+
+- ~10 lines + one unit test.
+- Replaces the harness reflection with a supported call.
+- Gives workers a lifecycle seam they lack today.
+- Does **not** touch any of the 519 call sites.
+
+Follow-up: swap `RetrofitHarnessTestCase::resetSharedRepositoryConnection()` (reflection) to call this.
+
+### (c) Key the memo by context/connection instead of a single global — MEDIUM
+Replace the single `?Connection` with a small map keyed by context/connection identity, so a second
+boot with a different context gets its own connection instead of inheriting the first. Kills the
+cross-boot-leak *class* of bug without rewriting call sites — but it is still a mutable process-static.
+
+### (d) Remove the static; resolve `Connection` per scope from the container — LARGE
+The "right" architecture, but a deliberate, phased initiative — not a task:
+
+1. Register all 59 repositories as container services **or** build a repository factory/resolver.
+2. Rewrite the ~264 zero-arg `new XRepository()` sites (audit the other 255) to resolve via the
+   container/factory.
+3. Update the 32 subclass constructors.
+4. Solve the hard cases: repos built inside helpers, static methods, and other repos — code holding no
+   container reference.
+5. Design the real per-scope lifecycle (fresh/validated connection per request or per worker job).
+6. Regression-test across framework + every extension + dependent apps.
+
+Multi-day, cross-repo, real breakage risk in the data-access layer.
+
+## Recommendation
+
+Ship **(b)** next time the framework is open; consider **(c)** only if worker connection-staleness
+actually bites; log **(d)** as a roadmap item and do not let its elegance pull it into unrelated work.
+Until **(b)** lands, the harness reflection is the accepted workaround.

--- a/src/Container/Providers/StorageProvider.php
+++ b/src/Container/Providers/StorageProvider.php
@@ -146,7 +146,16 @@ final class StorageProvider extends BaseServiceProvider
                 $c->has(\Glueful\Uploader\Contracts\MediaProcessorInterface::class)
                     ? $c->get(\Glueful\Uploader\Contracts\MediaProcessorInterface::class)
                     : null,
-                $c->get(\Glueful\Services\ImageSecurityValidator::class)
+                $c->get(\Glueful\Services\ImageSecurityValidator::class),
+                $c->has(\Glueful\Uploader\Contracts\BlobCreatedHook::class)
+                    ? $c->get(\Glueful\Uploader\Contracts\BlobCreatedHook::class)
+                    : new \Glueful\Uploader\Contracts\NullBlobCreatedHook(),
+                $c->has(\Glueful\Uploader\Contracts\BlobAccessPolicy::class)
+                    ? $c->get(\Glueful\Uploader\Contracts\BlobAccessPolicy::class)
+                    : new \Glueful\Uploader\Contracts\NullBlobAccessPolicy(),
+                $c->has(\Psr\Log\LoggerInterface::class)
+                    ? $c->get(\Psr\Log\LoggerInterface::class)
+                    : new \Psr\Log\NullLogger(),
             )
         );
 

--- a/src/Controllers/UploadController.php
+++ b/src/Controllers/UploadController.php
@@ -25,6 +25,12 @@ use Glueful\Storage\Contracts\StorageDriverRegistryInterface;
 use Glueful\Storage\StorageManager;
 use Glueful\Storage\Support\UrlGenerator;
 use Glueful\Uploader\Contracts\MediaProcessorInterface;
+use Glueful\Uploader\Contracts\BlobAccessContext;
+use Glueful\Uploader\Contracts\BlobAction;
+use Glueful\Uploader\Contracts\BlobAccessPolicy;
+use Glueful\Uploader\Contracts\BlobCreatedHook;
+use Glueful\Uploader\Contracts\NullBlobAccessPolicy;
+use Glueful\Uploader\Contracts\NullBlobCreatedHook;
 use Glueful\Uploader\FileUploader;
 use Glueful\Uploader\UploadException;
 use Glueful\Validation\ValidationException;
@@ -33,6 +39,8 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpFoundation\StreamedResponse;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 class UploadController extends BaseController
 {
@@ -42,6 +50,9 @@ class UploadController extends BaseController
     private UrlGenerator $urls;
     /** @var CacheStore<mixed>|null */
     private ?CacheStore $cache;
+    private BlobCreatedHook $createdHook;
+    private BlobAccessPolicy $accessPolicy;
+    private LoggerInterface $logger;
 
     public function __construct(
         ApplicationContext $context,
@@ -50,13 +61,19 @@ class UploadController extends BaseController
         StorageManager $storage,
         UrlGenerator $urls,
         private readonly ?MediaProcessorInterface $media = null,
-        private readonly ?ImageSecurityValidator $imageSecurity = null
+        private readonly ?ImageSecurityValidator $imageSecurity = null,
+        ?BlobCreatedHook $createdHook = null,
+        ?BlobAccessPolicy $accessPolicy = null,
+        ?LoggerInterface $logger = null,
     ) {
         parent::__construct($context);
         $this->uploader = $uploader;
         $this->blobs = $blobRepository;
         $this->storage = $storage;
         $this->urls = $urls;
+        $this->createdHook = $createdHook ?? new NullBlobCreatedHook();
+        $this->accessPolicy = $accessPolicy ?? new NullBlobAccessPolicy();
+        $this->logger = $logger ?? new NullLogger();
         $this->cache = $this->resolveCache();
     }
 
@@ -139,13 +156,51 @@ class UploadController extends BaseController
 
             $thumbCfg = (array) $this->getConfig('uploads.thumbnails', []);
             $result = $uploader->uploadMedia($fileInput, $pathPrefix, [
-                'generate_thumbnail' => (bool) ($thumbCfg['enabled'] ?? true),
+                'generate_thumbnail' => false,
                 'thumbnail_width' => $thumbCfg['width'] ?? null,
                 'thumbnail_height' => $thumbCfg['height'] ?? null,
                 'thumbnail_quality' => $thumbCfg['quality'] ?? null,
                 'save_to_blobs' => true,
                 'visibility' => $visibility,
             ]);
+
+            $blobUuid = (string) ($result['blob_uuid'] ?? '');
+            try {
+                $this->createdHook->onBlobCreated($blobUuid, $this->authenticatedUserUuid());
+            } catch (\Throwable $exception) {
+                $this->compensateOwnerlessBlob($uploader, $blobUuid, (string) ($result['path'] ?? ''));
+                $this->logger->error('upload.tenant_attribution_failed', [
+                    'blob_uuid' => $blobUuid,
+                    'error' => $exception->getMessage(),
+                ]);
+
+                return Response::error(
+                    'Upload could not be attributed to a tenant',
+                    Response::HTTP_INTERNAL_SERVER_ERROR,
+                );
+            }
+
+            if ((bool) ($thumbCfg['enabled'] ?? true)) {
+                try {
+                    $result['thumb_url'] = $uploader->generateThumbnailFor(
+                        $fileInput,
+                        $pathPrefix,
+                        (string) ($result['filename'] ?? ''),
+                        (string) ($result['mime_type'] ?? ''),
+                        [
+                            'thumbnail_width' => $thumbCfg['width'] ?? null,
+                            'thumbnail_height' => $thumbCfg['height'] ?? null,
+                            'thumbnail_quality' => $thumbCfg['quality'] ?? null,
+                        ],
+                    );
+                } catch (\Throwable $exception) {
+                    $this->logger->warning('upload.thumbnail.deferred_failed', [
+                        'blob_uuid' => $blobUuid,
+                        'error' => $exception->getMessage(),
+                    ]);
+                    $result['thumb_url'] = null;
+                }
+            }
 
             // Add visibility to response
             $result['visibility'] = $visibility;
@@ -178,6 +233,14 @@ class UploadController extends BaseController
 
         $blob = $this->blobs->findByUuidWithDeleteFilter($uuid);
         if ($blob === null) {
+            return Response::notFound('Blob not found');
+        }
+
+        $allowed = $this->accessPolicy->authorizeAccess(
+            $blob,
+            new BlobAccessContext(BlobAction::INFO, $this->authenticatedUserUuid(), false),
+        );
+        if (!$allowed) {
             return Response::notFound('Blob not found');
         }
 
@@ -223,9 +286,17 @@ class UploadController extends BaseController
         }
 
         // Check access based on visibility and auth
-        $accessDenied = $this->checkBlobAccess($request, $blob);
+        $signatureValid = $this->hasValidSignature($request);
+        $accessDenied = $this->checkBlobAccess($request, $blob, $signatureValid);
         if ($accessDenied !== null) {
             return $accessDenied;
+        }
+        $allowed = $this->accessPolicy->authorizeAccess(
+            $blob,
+            new BlobAccessContext(BlobAction::VIEW, $this->authenticatedUserUuid(), $signatureValid),
+        );
+        if (!$allowed) {
+            return Response::notFound('Blob not found');
         }
 
         $disk = $this->resolveDisk($blob);
@@ -288,6 +359,14 @@ class UploadController extends BaseController
             return Response::notFound('Blob not found');
         }
 
+        $allowed = $this->accessPolicy->authorizeAccess(
+            $blob,
+            new BlobAccessContext(BlobAction::SIGN, $this->authenticatedUserUuid(), false),
+        );
+        if (!$allowed) {
+            return Response::notFound('Blob not found');
+        }
+
         $ttl = $request->query->getInt('ttl', 0);
         if ($ttl <= 0) {
             $ttl = (int) $this->getConfig('uploads.signed_urls.ttl', 3600);
@@ -329,6 +408,14 @@ class UploadController extends BaseController
 
         $blob = $this->blobs->findByUuidWithDeleteFilter($uuid, true);
         if ($blob === null) {
+            return Response::notFound('Blob not found');
+        }
+
+        $allowed = $this->accessPolicy->authorizeAccess(
+            $blob,
+            new BlobAccessContext(BlobAction::DELETE, $this->authenticatedUserUuid(), false),
+        );
+        if (!$allowed) {
             return Response::notFound('Blob not found');
         }
 
@@ -887,13 +974,46 @@ class UploadController extends BaseController
         return false;
     }
 
+    private function authenticatedUserUuid(): ?string
+    {
+        $user = Utils::getUser();
+        $uuid = is_array($user) ? ($user['uuid'] ?? null) : null;
+
+        return is_string($uuid) && $uuid !== '' ? $uuid : null;
+    }
+
+    private function compensateOwnerlessBlob(FileUploader $uploader, string $blobUuid, string $path): void
+    {
+        if ($path !== '' && !$uploader->getStorage()->delete($path)) {
+            $this->logger->critical('upload.compensation.object_orphaned', [
+                'blob_uuid' => $blobUuid,
+                'path' => $path,
+            ]);
+        }
+
+        if ($blobUuid !== '' && $this->blobs->forceDelete($blobUuid)) {
+            return;
+        }
+
+        $updated = $blobUuid !== '' && $this->blobs->updateStatus($blobUuid, 'deleted');
+        $row = $blobUuid !== ''
+            ? $this->blobs->findByUuidWithDeleteFilter($blobUuid, includeDeleted: true)
+            : null;
+        $quarantined = $updated && $row !== null && ($row['status'] ?? null) === 'deleted';
+
+        $this->logger->critical('upload.compensation.blob_quarantined', [
+            'blob_uuid' => $blobUuid,
+            'quarantined' => $quarantined,
+        ]);
+    }
+
     /**
      * Check blob access based on visibility, auth, and signed URL.
      *
      * @param array<string, mixed> $blob
      * @return Response|null Null if access allowed, Response if denied
      */
-    private function checkBlobAccess(Request $request, array $blob): ?Response
+    private function checkBlobAccess(Request $request, array $blob, bool $signatureValid): ?Response
     {
         $visibility = (string) ($blob['visibility'] ?? 'private');
         $globalAccess = $this->getConfig('uploads.access', 'private');
@@ -909,7 +1029,7 @@ class UploadController extends BaseController
         }
 
         // Check for valid signed URL
-        if ($this->hasValidSignature($request)) {
+        if ($signatureValid) {
             return null;
         }
 

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -526,6 +526,15 @@ class Connection implements DatabaseInterface
     }
 
     /**
+     * Open a non-pooled, independent PDO session using this connection's resolved configuration.
+     * The caller owns its lifetime; it is never stored in the shared instance or connection pool.
+     */
+    public function newPdo(): PDO
+    {
+        return $this->createPDOConnection($this->getDriverName());
+    }
+
+    /**
      * Access current database driver
      *
      * Returns engine-specific driver instance.

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -594,6 +594,51 @@ class Connection implements DatabaseInterface
         self::$tableHooks = [];
     }
 
+    /**
+     * Chainable, process-level hooks applied to associative row data on write (insert/insertBatch/upsert).
+     *
+     * Registered once at boot (e.g. by an extension's service provider). All run, in registration
+     * order, so multiple extensions can decorate writes without clobbering each other. Each receives
+     * (string $table, array $data) and MUST return the (possibly modified) associative row.
+     *
+     * @var array<int, \Closure(string, array<string,mixed>):array<string,mixed>>
+     */
+    private static array $insertHooks = [];
+
+    public static function addInsertHook(\Closure $hook): void
+    {
+        self::$insertHooks[] = $hook;
+    }
+
+    public static function clearInsertHooks(): void
+    {
+        self::$insertHooks = [];
+    }
+
+    /**
+     * Run every registered insert hook over $data in registration order, returning the final row.
+     *
+     * A hook must return an associative array (column => value); a list-shaped return would be bound
+     * positionally against the wrong columns downstream, so reject it loudly instead of corrupting the
+     * write. An empty row is left untouched (nothing to misbind).
+     *
+     * @param  array<string,mixed> $data
+     * @return array<string,mixed>
+     */
+    public static function applyInsertHooks(string $table, array $data): array
+    {
+        foreach (self::$insertHooks as $hook) {
+            $data = $hook($table, $data);
+            if ($data !== [] && array_is_list($data)) {
+                throw new \UnexpectedValueException(sprintf(
+                    'An insert hook for "%s" returned a non-associative (list-shaped) row.',
+                    $table
+                ));
+            }
+        }
+        return $data;
+    }
+
     public function table(string $table): QueryBuilder
     {
         $qb = $this->createQueryBuilder()->from($table);

--- a/src/Database/Execution/ExecutionWrapperInterface.php
+++ b/src/Database/Execution/ExecutionWrapperInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Database\Execution;
+
+use PDOStatement;
+
+/** Around-execution extension point that can hold a resource across prepare and execute. */
+interface ExecutionWrapperInterface
+{
+    /**
+     * @param array<int|string,mixed> $bindings
+     * @param callable():PDOStatement $proceed
+     */
+    public function around(string $sql, array $bindings, callable $proceed): PDOStatement;
+}

--- a/src/Database/Execution/QueryExecutor.php
+++ b/src/Database/Execution/QueryExecutor.php
@@ -52,6 +52,9 @@ class QueryExecutor implements QueryExecutorInterface
      */
     private static array $interceptors = [];
 
+    /** @var array<int, ExecutionWrapperInterface> */
+    private static array $executionWrappers = [];
+
     public static function addQueryInterceptor(QueryInterceptorInterface $interceptor): void
     {
         self::$interceptors[] = $interceptor;
@@ -81,6 +84,16 @@ class QueryExecutor implements QueryExecutorInterface
     public static function clearQueryInterceptors(): void
     {
         self::$interceptors = [];
+    }
+
+    public static function addExecutionWrapper(ExecutionWrapperInterface $wrapper): void
+    {
+        self::$executionWrappers[] = $wrapper;
+    }
+
+    public static function clearExecutionWrappers(): void
+    {
+        self::$executionWrappers = [];
     }
 
     /**
@@ -229,26 +242,34 @@ class QueryExecutor implements QueryExecutorInterface
         // Flatten bindings to prevent array to string conversion warnings
         $flattenedParams = $this->binder->flattenBindings($bindings);
 
-        try {
-            $stmt = $this->pdo->prepare($sql);
+        $core = function () use ($sql, $flattenedParams, $timerId, $purpose): PDOStatement {
+            try {
+                $stmt = $this->pdo->prepare($sql);
 
-            if (!$stmt) {
-                throw new PDOException('Failed to prepare statement');
+                if (!$stmt) {
+                    throw new PDOException('Failed to prepare statement');
+                }
+
+                $stmt->execute($flattenedParams);
+
+                $sanitizedBindings = $this->binder->sanitizeBindingsForLog($flattenedParams);
+                $this->logger->logQuery($sql, $sanitizedBindings, $timerId, null, $purpose);
+
+                return $stmt;
+            } catch (PDOException $e) {
+                $sanitizedBindings = $this->binder->sanitizeBindingsForLog($flattenedParams);
+                $this->logger->logQuery($sql, $sanitizedBindings, $timerId, $e, $purpose);
+                throw $e;
             }
+        };
 
-            $stmt->execute($flattenedParams);
-
-            // Log successful query with purpose
-            $sanitizedBindings = $this->binder->sanitizeBindingsForLog($flattenedParams);
-            $this->logger->logQuery($sql, $sanitizedBindings, $timerId, null, $purpose);
-
-            return $stmt;
-        } catch (PDOException $e) {
-            // Log failed query with purpose
-            $sanitizedBindings = $this->binder->sanitizeBindingsForLog($flattenedParams);
-            $this->logger->logQuery($sql, $sanitizedBindings, $timerId, $e, $purpose);
-            throw $e;
+        $chain = $core;
+        foreach (array_reverse(self::$executionWrappers) as $wrapper) {
+            $next = $chain;
+            $chain = static fn (): PDOStatement => $wrapper->around($sql, $bindings, $next);
         }
+
+        return $chain();
     }
 
     /**

--- a/src/Database/QueryBuilder.php
+++ b/src/Database/QueryBuilder.php
@@ -622,6 +622,7 @@ class QueryBuilder implements QueryBuilderInterface
     public function insert(array $data): int
     {
         $table = $this->state->getTableOrFail();
+        $data = Connection::applyInsertHooks($table, $data);
         $this->queryValidator->validateInsert($table, $data);
 
         return $this->insertBuilder->insert($table, $data);
@@ -639,6 +640,37 @@ class QueryBuilder implements QueryBuilderInterface
         if ($rows === []) {
             throw new \InvalidArgumentException('No rows provided for batch insert');
         }
+
+        $rows = array_map(
+            static fn (array $row): array => Connection::applyInsertHooks($table, $row),
+            $rows,
+        );
+
+        // The insert builder assumes a uniform column set across a batch and binds values
+        // positionally against the first row's columns. Compare each row's columns as a SET
+        // (order-independent); a hook adding a column to only some rows is an error, so fail
+        // loudly here before SQL generation.
+        $reference = array_keys($rows[0]);
+        $referenceSet = $reference;
+        sort($referenceSet);
+
+        foreach ($rows as $i => $row) {
+            $keys = array_keys($row);
+            sort($keys);
+            if ($keys !== $referenceSet) {
+                throw new \UnexpectedValueException(sprintf(
+                    'Insert hooks produced an inconsistent column set for batch insert into "%s" at row %d.',
+                    $table,
+                    $i,
+                ));
+            }
+        }
+
+        // Every row has exactly the reference columns (set equality above), so normalize each
+        // row's key ORDER to the first row's, so a hook returning the same columns in a
+        // different order cannot misalign the insert builder's positional binding.
+        $template = array_fill_keys($reference, null);
+        $rows = array_map(static fn (array $row): array => array_replace($template, $row), $rows);
 
         return $this->insertBuilder->insertBatch($table, $rows);
     }
@@ -682,6 +714,7 @@ class QueryBuilder implements QueryBuilderInterface
     public function upsert(array $data, array $updateColumns): int
     {
         $table = $this->state->getTableOrFail();
+        $data = Connection::applyInsertHooks($table, $data);
         $this->queryValidator->validateInsert($table, $data);
 
         return $this->insertBuilder->upsert($table, $data, $updateColumns);

--- a/src/Repository/BlobRepository.php
+++ b/src/Repository/BlobRepository.php
@@ -23,6 +23,14 @@ use Glueful\Database\Connection;
  */
 class BlobRepository extends BaseRepository
 {
+    /** Permanently remove a blob row, bypassing the table's soft-delete behavior. */
+    public function forceDelete(string $uuid): bool
+    {
+        return $this->db->table($this->table)
+            ->where([$this->primaryKey => $uuid])
+            ->forceDelete() > 0;
+    }
+
     /** @var array<string> Default fields to retrieve for blob operations */
     private array $defaultBlobFields = [
         'uuid', 'name', 'description', 'mime_type', 'size',

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,15 +13,15 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.66.3';
+    public const VERSION = '1.67.0';
 
 
     /** Release code name */
-    public const NAME = 'Adhara';
+    public const NAME = 'Adhil';
 
 
     /** Release date */
-    public const RELEASE_DATE = '2026-07-06';
+    public const RELEASE_DATE = '2026-07-10';
 
     /** Minimum required PHP version */
     public const MIN_PHP_VERSION = '8.3.0';

--- a/src/Uploader/Contracts/BlobAccessContext.php
+++ b/src/Uploader/Contracts/BlobAccessContext.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Uploader\Contracts;
+
+final class BlobAccessContext
+{
+    public function __construct(
+        public readonly BlobAction $action,
+        public readonly ?string $authenticatedUserUuid,
+        public readonly bool $signatureValid,
+    ) {
+    }
+}

--- a/src/Uploader/Contracts/BlobAccessPolicy.php
+++ b/src/Uploader/Contracts/BlobAccessPolicy.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Uploader\Contracts;
+
+/** Optional synchronous authorization extension point applied after core blob access checks. */
+interface BlobAccessPolicy
+{
+    /** @param array<string,mixed> $blob */
+    public function authorizeAccess(array $blob, BlobAccessContext $context): bool;
+}

--- a/src/Uploader/Contracts/BlobAction.php
+++ b/src/Uploader/Contracts/BlobAction.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Uploader\Contracts;
+
+enum BlobAction: string
+{
+    case VIEW = 'view';
+    case INFO = 'info';
+    case DELETE = 'delete';
+    case SIGN = 'sign';
+}

--- a/src/Uploader/Contracts/BlobCreatedHook.php
+++ b/src/Uploader/Contracts/BlobCreatedHook.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Uploader\Contracts;
+
+/** Optional post-persistence extension point for blob ownership, indexing, or policy checks. */
+interface BlobCreatedHook
+{
+    /** Throw to reject creation; the upload controller compensates the persisted blob and object. */
+    public function onBlobCreated(string $blobUuid, ?string $uploaderUserUuid): void;
+}

--- a/src/Uploader/Contracts/NullBlobAccessPolicy.php
+++ b/src/Uploader/Contracts/NullBlobAccessPolicy.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Uploader\Contracts;
+
+final class NullBlobAccessPolicy implements BlobAccessPolicy
+{
+    public function authorizeAccess(array $blob, BlobAccessContext $context): bool
+    {
+        return true;
+    }
+}

--- a/src/Uploader/Contracts/NullBlobCreatedHook.php
+++ b/src/Uploader/Contracts/NullBlobCreatedHook.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Uploader\Contracts;
+
+final class NullBlobCreatedHook implements BlobCreatedHook
+{
+    public function onBlobCreated(string $blobUuid, ?string $uploaderUserUuid): void
+    {
+    }
+}

--- a/src/Uploader/FileUploader.php
+++ b/src/Uploader/FileUploader.php
@@ -312,6 +312,32 @@ final class FileUploader
         return $this->storage;
     }
 
+    /**
+     * Generate the deferred thumbnail for an upload after external attribution succeeds.
+     *
+     * @param array<string,mixed> $options
+     */
+    public function generateThumbnailFor(
+        mixed $fileInput,
+        string $storagePath,
+        string $filename,
+        string $mime,
+        array $options = [],
+    ): ?string {
+        $file = $this->normalizeFileInput($fileInput);
+        if ($file === null || !isset($file['tmp_name']) || $file['tmp_name'] === '') {
+            throw new UploadException('Invalid file input');
+        }
+
+        return $this->maybeGenerateThumbnail(
+            (string) $file['tmp_name'],
+            $storagePath,
+            $filename,
+            $mime,
+            [...$options, 'generate_thumbnail' => true],
+        );
+    }
+
     // -------------------------------------------------------------------------
     // Private Methods
     // -------------------------------------------------------------------------

--- a/tests/Unit/Controllers/UploadControllerVariantTest.php
+++ b/tests/Unit/Controllers/UploadControllerVariantTest.php
@@ -14,12 +14,19 @@ use Glueful\Services\ImageSecurityValidator;
 use Glueful\Routing\RouteManifest;
 use Glueful\Storage\StorageManager;
 use Glueful\Storage\Support\UrlGenerator;
+use Glueful\Uploader\Contracts\BlobAccessContext;
+use Glueful\Uploader\Contracts\BlobAction;
+use Glueful\Uploader\Contracts\BlobAccessPolicy;
+use Glueful\Uploader\Contracts\BlobCreatedHook;
 use Glueful\Uploader\Contracts\MediaProcessorInterface;
+use Glueful\Uploader\Contracts\NullBlobAccessPolicy;
+use Glueful\Uploader\Contracts\NullBlobCreatedHook;
 use Glueful\Uploader\FileUploader;
 use Glueful\Uploader\MediaMetadata;
 use Glueful\Uploader\Storage\StorageInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 /**
  * Phase B / Task B3 — proves UploadController routes on-demand variant serving
@@ -272,7 +279,84 @@ final class UploadControllerVariantTest extends TestCase
         $this->assertSame(0, $fake->renderCalls);
     }
 
-    private function makeController(?MediaProcessorInterface $media): UploadController
+    public function testTenancyPolicyCanHideAnOtherwisePublicBlob(): void
+    {
+        $policy = new class implements BlobCreatedHook, BlobAccessPolicy {
+            public ?BlobAccessContext $seen = null;
+
+            public function onBlobCreated(string $blobUuid, ?string $uploaderUserUuid): void
+            {
+            }
+
+            public function authorizeAccess(array $blob, BlobAccessContext $context): bool
+            {
+                $this->seen = $context;
+                return false;
+            }
+        };
+
+        $response = $this->makeController(null, $policy)->show(
+            Request::create('/blobs/' . $this->blobUuid),
+            $this->blobUuid,
+        );
+
+        self::assertSame(404, $response->getStatusCode());
+        self::assertSame(BlobAction::VIEW, $policy->seen?->action);
+        self::assertFalse($policy->seen?->signatureValid);
+    }
+
+    public function testUploadAttributesTheCreatedBlob(): void
+    {
+        $policy = new class implements BlobCreatedHook, BlobAccessPolicy {
+            public ?string $blobUuid = null;
+            public ?string $userUuid = null;
+
+            public function onBlobCreated(string $blobUuid, ?string $uploaderUserUuid): void
+            {
+                $this->blobUuid = $blobUuid;
+                $this->userUuid = $uploaderUserUuid;
+            }
+
+            public function authorizeAccess(array $blob, BlobAccessContext $context): bool
+            {
+                return true;
+            }
+        };
+
+        $response = $this->makeController(null, $policy)->upload($this->uploadRequest());
+        $body = json_decode((string) $response->getContent(), true, flags: JSON_THROW_ON_ERROR);
+
+        self::assertSame(201, $response->getStatusCode());
+        self::assertSame($body['data']['blob_uuid'], $policy->blobUuid);
+        self::assertSame('usr123456789', $policy->userUuid);
+    }
+
+    public function testAttributionFailureCompensatesTheCreatedBlob(): void
+    {
+        $policy = new class implements BlobCreatedHook, BlobAccessPolicy {
+            public function onBlobCreated(string $blobUuid, ?string $uploaderUserUuid): void
+            {
+                throw new \RuntimeException('no tenant');
+            }
+
+            public function authorizeAccess(array $blob, BlobAccessContext $context): bool
+            {
+                return true;
+            }
+        };
+        $connection = \Glueful\Database\Connection::fromContext($this->context);
+        $before = $connection->table('blobs')->count();
+
+        $response = $this->makeController(null, $policy)->upload($this->uploadRequest());
+
+        self::assertSame(500, $response->getStatusCode());
+        self::assertSame($before, $connection->table('blobs')->count());
+    }
+
+    private function makeController(
+        ?MediaProcessorInterface $media,
+        (BlobCreatedHook&BlobAccessPolicy)|null $blobExtension = null,
+    ): UploadController
     {
         $c = $this->context->getContainer();
 
@@ -283,7 +367,10 @@ final class UploadControllerVariantTest extends TestCase
             $c->get(StorageManager::class),
             $c->get(UrlGenerator::class),
             $media,
-            new ImageSecurityValidator()
+            new ImageSecurityValidator(),
+            $blobExtension ?? new NullBlobCreatedHook(),
+            $blobExtension ?? new NullBlobAccessPolicy(),
+            new \Psr\Log\NullLogger(),
         );
     }
 
@@ -292,6 +379,16 @@ final class UploadControllerVariantTest extends TestCase
         ob_start();
         $response->sendContent();
         return (string) ob_get_clean();
+    }
+
+    private function uploadRequest(): Request
+    {
+        $source = $this->uploadsRoot . '/upload-source.png';
+        file_put_contents($source, $this->originalBytes);
+        $request = Request::create('/blobs', 'POST');
+        $request->files->set('file', new UploadedFile($source, 'upload.png', 'image/png', null, true));
+
+        return $request;
     }
 
     private function resetSharedConnection(): void

--- a/tests/Unit/Database/ConnectionNewPdoTest.php
+++ b/tests/Unit/Database/ConnectionNewPdoTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Database;
+
+use Glueful\Database\Connection;
+use PHPUnit\Framework\TestCase;
+
+final class ConnectionNewPdoTest extends TestCase
+{
+    public function testNewPdoReturnsAnIndependentSession(): void
+    {
+        $connection = new Connection([
+            'engine' => 'sqlite',
+            'sqlite' => ['primary' => ':memory:'],
+            'pooling' => ['enabled' => false],
+        ]);
+
+        self::assertNotSame($connection->getPDO(), $connection->newPdo());
+    }
+}

--- a/tests/Unit/Database/Execution/ExecutionWrapperTest.php
+++ b/tests/Unit/Database/Execution/ExecutionWrapperTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Database\Execution;
+
+use Glueful\Database\Execution\ExecutionWrapperInterface;
+use Glueful\Database\Execution\ParameterBinder;
+use Glueful\Database\Execution\QueryExecutor;
+use Glueful\Database\QueryLogger;
+use PDO;
+use PDOStatement;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class ExecutionWrapperTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        QueryExecutor::clearExecutionWrappers();
+    }
+
+    protected function tearDown(): void
+    {
+        QueryExecutor::clearExecutionWrappers();
+    }
+
+    public function testWrappersComposeInRegistrationOrderAroundExecution(): void
+    {
+        $events = [];
+        QueryExecutor::addExecutionWrapper($this->recordingWrapper('a', $events));
+        QueryExecutor::addExecutionWrapper($this->recordingWrapper('b', $events));
+
+        $statement = $this->executor()->executeStatement('SELECT 1 AS n');
+
+        self::assertSame(1, (int) $statement->fetchColumn());
+        self::assertSame(['a:before', 'b:before', 'b:after', 'a:after'], $events);
+    }
+
+    public function testWrapperCanPreventExecution(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE t (id INTEGER PRIMARY KEY)');
+        QueryExecutor::addExecutionWrapper(new class implements ExecutionWrapperInterface {
+            public function around(string $sql, array $bindings, callable $proceed): PDOStatement
+            {
+                throw new RuntimeException('blocked');
+            }
+        });
+
+        try {
+            (new QueryExecutor($pdo, new ParameterBinder(), new QueryLogger()))
+                ->executeStatement('INSERT INTO t (id) VALUES (1)');
+            self::fail('Expected the wrapper to reject execution.');
+        } catch (RuntimeException $exception) {
+            self::assertSame('blocked', $exception->getMessage());
+        }
+
+        self::assertSame(0, (int) $pdo->query('SELECT COUNT(*) FROM t')->fetchColumn());
+    }
+
+    public function testClearingWrappersRestoresDirectExecution(): void
+    {
+        QueryExecutor::addExecutionWrapper(new class implements ExecutionWrapperInterface {
+            public function around(string $sql, array $bindings, callable $proceed): PDOStatement
+            {
+                throw new RuntimeException('blocked');
+            }
+        });
+        QueryExecutor::clearExecutionWrappers();
+
+        self::assertSame(1, (int) $this->executor()->executeStatement('SELECT 1')->fetchColumn());
+    }
+
+    private function executor(): QueryExecutor
+    {
+        return new QueryExecutor(new PDO('sqlite::memory:'), new ParameterBinder(), new QueryLogger());
+    }
+
+    /** @param list<string> $events */
+    private function recordingWrapper(string $name, array &$events): ExecutionWrapperInterface
+    {
+        return new class ($name, $events) implements ExecutionWrapperInterface {
+            /** @param list<string> $events */
+            public function __construct(private readonly string $name, private array &$events)
+            {
+            }
+
+            public function around(string $sql, array $bindings, callable $proceed): PDOStatement
+            {
+                $this->events[] = $this->name . ':before';
+                try {
+                    return $proceed();
+                } finally {
+                    $this->events[] = $this->name . ':after';
+                }
+            }
+        };
+    }
+}

--- a/tests/Unit/Database/InsertHookTest.php
+++ b/tests/Unit/Database/InsertHookTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Database;
+
+use Glueful\Database\Connection;
+use PHPUnit\Framework\TestCase;
+
+final class InsertHookTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Connection::clearInsertHooks();
+        parent::tearDown();
+    }
+
+    private function sqliteConnection(): Connection
+    {
+        $conn = new Connection([
+            'engine' => 'sqlite',
+            'sqlite' => ['primary' => ':memory:'],
+            'pooling' => ['enabled' => false],
+        ]);
+        $conn->getPDO()->exec(
+            'CREATE TABLE widgets (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, tenant_uuid TEXT)'
+        );
+        return $conn;
+    }
+
+    public function testInsertHookStampsMissingColumn(): void
+    {
+        Connection::addInsertHook(static function (string $table, array $data): array {
+            if ($table === 'widgets' && !isset($data['tenant_uuid'])) {
+                $data['tenant_uuid'] = 'T-STAMP';
+            }
+            return $data;
+        });
+
+        $conn = $this->sqliteConnection();
+        $conn->table('widgets')->insert(['name' => 'a']);
+
+        self::assertSame('T-STAMP', $conn->table('widgets')->where('name', 'a')->first()['tenant_uuid']);
+    }
+
+    public function testInsertBatchStampsEveryRow(): void
+    {
+        Connection::addInsertHook(static function (string $table, array $data): array {
+            $data['tenant_uuid'] = 'T-BATCH';
+            return $data;
+        });
+
+        $conn = $this->sqliteConnection();
+        $conn->table('widgets')->insertBatch([['name' => 'a'], ['name' => 'b']]);
+
+        $rows = $conn->table('widgets')->orderBy('name', 'asc')->get();
+        self::assertSame(['T-BATCH', 'T-BATCH'], array_column($rows, 'tenant_uuid'));
+    }
+
+    public function testNoHookRegisteredIsNoOp(): void
+    {
+        $conn = $this->sqliteConnection();
+        $conn->table('widgets')->insert(['name' => 'a', 'tenant_uuid' => 'kept']);
+
+        self::assertSame('kept', $conn->table('widgets')->where('name', 'a')->first()['tenant_uuid']);
+    }
+
+    public function testHookReturningNonAssociativeArrayThrows(): void
+    {
+        Connection::addInsertHook(static fn (string $table, array $data): array => array_values($data)); // list-shaped
+
+        $conn = $this->sqliteConnection();
+        $this->expectException(\UnexpectedValueException::class);
+        $conn->table('widgets')->insert(['name' => 'a']);
+    }
+
+    public function testInsertBatchWithInconsistentColumnsAfterHooksThrows(): void
+    {
+        // A hook that adds a column to only some rows makes the batch column set non-uniform.
+        Connection::addInsertHook(static function (string $table, array $data): array {
+            if (($data['name'] ?? null) === 'b') {
+                $data['extra'] = 1;
+            }
+            return $data;
+        });
+
+        $conn = $this->sqliteConnection();
+        $this->expectException(\UnexpectedValueException::class);
+        $conn->table('widgets')->insertBatch([['name' => 'a'], ['name' => 'b']]);
+    }
+
+    public function testInsertBatchNormalizesRowKeyOrderToFirstRow(): void
+    {
+        // Same column SET, different key ORDER per row: uniformity passes (set compare) and
+        // normalization must reorder row 2 to the first row's column order, so values land in
+        // the right columns rather than being bound positionally by the wrong order.
+        $conn = $this->sqliteConnection();
+        $conn->table('widgets')->insertBatch([
+            ['name' => 'a', 'tenant_uuid' => 'T1'],
+            ['tenant_uuid' => 'T2', 'name' => 'b'], // deliberately reversed key order
+        ]);
+
+        $rows = $conn->table('widgets')->orderBy('name', 'asc')->get();
+        self::assertSame(['a', 'b'], array_column($rows, 'name'));
+        self::assertSame(['T1', 'T2'], array_column($rows, 'tenant_uuid'), 'values stayed aligned to their columns');
+    }
+}


### PR DESCRIPTION
Add process-level write hooks and independent session handling

Add Connection::addInsertHook() — the write-side counterpart to the existing
table() read hooks. A registered fn(string $table, array $data): array runs, in
registration order, over the row of every QueryBuilder insert/insertBatch/upsert,
so an extension can transparently stamp or transform columns (a tenant key,
created_by, an encrypted field, …) in one place instead of in every repository.

clearInsertHooks() resets the process-global registry (mirrors clearTableHooks());
applyInsertHooks() is the seam the query builder calls. Batch inserts are hardened
around hook output: a non-uniform column set across the batch, or a list-shaped
(non-associative) row, raises \UnexpectedValueException before SQL generation, and
each row's key order is normalized to the first row's so a reordered-but-equal
column set cannot misalign positional binding. No behavior change when no hook is
registered — the seam is a pass-through.

Also captures BaseRepository::$sharedConnection lifecycle debt in
docs/BASEREPOSITORY_SHARED_CONNECTION.md: a process-global connection with no reset
seam (surfaced by multi-tenancy two-boot tests), with a fix ladder from a public
reset seam to full per-scope DI resolution.

- BlobCreatedHook::onBlobCreated() runs post-persist; a throw rejects the upload and the
  controller compensates: checked storage-object delete, hard row delete via the new
  BlobRepository::forceDelete(), verified status='deleted' quarantine fallback — a
  rejected upload can never leave a servable blob.
- BlobAccessPolicy::authorizeAccess() runs after core visibility/auth/signature checks on
  show/info/delete/signedUrl with a BlobAccessContext {action, authenticatedUserUuid,
  signatureValid} (signature computed once per request); false -> 404.
- Thumbnails defer until the hook accepts (FileUploader::generateThumbnailFor()); a
  post-accept thumbnail failure degrades to thumb_url=null, never a 500.
Soft-resolved with null-object defaults; the framework binds neither seam.

- Connection::newPdo() opens a fresh non-pooled PDO from the connection's resolved
  configuration, independent of the shared statement session — for advisory locks and
  other session-scoped infrastructure that a failed app transaction must not poison.
- QueryExecutor::addExecutionWrapper() composes ExecutionWrapperInterface::around()
  implementations around the actual prepare/execute (the before-only interceptor seam
  cannot span execution), with a process-level registry reset via clearExecutionWrappers().
Both are exact pass-throughs when unbound.