### PR TITLE
Release 1.69.0 — Albali

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.69.0] - 2026-07-14 — Albali
+
+**Theme: boot-time config override seam** — one additive `ApplicationContext` method that lets
+applications and extensions override configuration during boot, with a hard freeze once boot
+completes. No new env vars, no migrations, no default changes; existing apps are unaffected.
+
+### Added
+- **Process-local config overrides.** `ApplicationContext::overrideConfig(string $key, mixed $value)`
+  applies a config override that wins over file/env/default config (precedence: extension defaults <
+  file/env < override). Overrides accept dot-path keys, deep-merge into nested config, and survive
+  `clearConfigCache()` (which only empties the loaded/cached layers). The window is **boot-only**:
+  `Framework::boot()` calls `ApplicationContext::markBooted()` once all boot phases (including
+  extension/provider boot) complete, after which `overrideConfig()` throws — mid-request config
+  mutation would create split-brain services that read config at different times. Built for (and
+  consumed by) the Thallo tenancy public-origin surface, which persists a base domain + default hosts
+  and applies them over config at boot; the seam itself is application-agnostic.
+
 ## [1.68.0] - 2026-07-10 — Ain
 
 **Theme: blob route extensibility** — two generic, unbound-by-default seams over the blob

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,18 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.69.0 — Albali (Minor, Released 2026-07-14)
+- **Boot-time config override seam.**
+  - `ApplicationContext::overrideConfig(string $key, mixed $value)` — a process-local config override
+    that wins over file/env/default config (precedence: extension defaults < file/env < override).
+    Dot-path keys deep-merge into nested config and survive `clearConfigCache()`.
+  - Boot-only window: `Framework::boot()` calls `ApplicationContext::markBooted()` after all boot
+    phases complete, after which `overrideConfig()` throws — mid-request config mutation would create
+    split-brain services reading config at different times.
+- Notes: **Minor release** — additive API only, no new env vars, no migrations, no default changes;
+  existing apps are unaffected. Built for (and consumed by) the Thallo tenancy public-origin surface;
+  the seam is deliberately application-agnostic.
+
 ### 1.68.0 — Ain (Minor, Released 2026-07-10)
 - **Blob route extensibility.**
   - `BlobRouteMiddlewareProvider` + `BlobRouteAction` — applications contribute per-action blob

--- a/src/Bootstrap/ApplicationContext.php
+++ b/src/Bootstrap/ApplicationContext.php
@@ -18,6 +18,9 @@ final class ApplicationContext
 
     /** @var array<string, array<string, mixed>> Extension-provided config defaults, merged under file config */
     private array $configDefaults = [];
+
+    /** @var array<string, mixed> Process-local config overrides applied over file/default config. */
+    private array $configOverrides = [];
     private ?ContainerInterface $container = null;
     private ?ConfigurationLoader $configLoader = null;
     private bool $booted = false;
@@ -133,6 +136,16 @@ final class ApplicationContext
 
         $config = $this->loadedConfigs[$configName];
 
+        // Process override layer wins over file/default config (precedence:
+        // extension defaults < file/env < override). Applied here so overrides
+        // survive clearConfigCache() (which only empties the loaded/cached layers).
+        if (array_key_exists($configName, $this->configOverrides)) {
+            $override = $this->configOverrides[$configName];
+            $config = is_array($config) && is_array($override)
+                ? self::deepMerge($config, $override)
+                : $override;
+        }
+
         // Traverse nested keys
         foreach ($segments as $segment) {
             if (!is_array($config) || !array_key_exists($segment, $config)) {
@@ -163,6 +176,52 @@ final class ApplicationContext
         unset($this->loadedConfigs[$name]);
         foreach (array_keys($this->configCache) as $cachedKey) {
             if ($cachedKey === $name || str_starts_with($cachedKey, $name . '.')) {
+                unset($this->configCache[$cachedKey]);
+            }
+        }
+    }
+
+    /**
+     * Apply a process-local config override that wins over file/env/default config.
+     *
+     * Boot-only: overrides shape the container's view of config once, before the app is
+     * booted. Calling after {@see markBooted()} is a programming error — mid-request config
+     * changes would create split-brain services that read config at different times.
+     *
+     * A nested key invalidates the entire top-level namespace cache (including cached parent
+     * reads), and the override persists across {@see clearConfigCache()}.
+     */
+    public function overrideConfig(string $key, mixed $value): void
+    {
+        if ($this->booted) {
+            throw new \LogicException(
+                'overrideConfig() must be called before boot completes (after markBooted()).'
+            );
+        }
+
+        $segments = explode('.', $key);
+        if ($segments === [] || in_array('', $segments, true)) {
+            throw new \InvalidArgumentException('Config override keys must be non-empty dot paths.');
+        }
+        $configName = array_shift($segments);
+
+        if ($segments === []) {
+            $this->configOverrides[$configName] = $value;
+        } else {
+            $nested = $value;
+            foreach (array_reverse($segments) as $segment) {
+                $nested = [$segment => $nested];
+            }
+            $existing = $this->configOverrides[$configName] ?? [];
+            $this->configOverrides[$configName] = is_array($existing)
+                ? self::deepMerge($existing, $nested)
+                : $nested;
+        }
+
+        // Invalidate the whole top-level namespace so parent + child cached reads re-resolve.
+        unset($this->loadedConfigs[$configName]);
+        foreach (array_keys($this->configCache) as $cachedKey) {
+            if ($cachedKey === $configName || str_starts_with($cachedKey, $configName . '.')) {
                 unset($this->configCache[$cachedKey]);
             }
         }

--- a/src/Framework.php
+++ b/src/Framework.php
@@ -141,6 +141,10 @@ class Framework
         // Create Application instance
         $this->application = new Application($this->context);
 
+        // All boot phases (incl. extension/provider boot) are complete; freeze the config
+        // override window so overrideConfig() can no longer mutate the container's config view.
+        $this->context->markBooted();
+
         $this->booted = true;
 
         // Log boot performance

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,15 +13,15 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.68.0';
+    public const VERSION = '1.69.0';
 
 
     /** Release code name */
-    public const NAME = 'Ain';
+    public const NAME = 'Albali';
 
 
     /** Release date */
-    public const RELEASE_DATE = '2026-07-10';
+    public const RELEASE_DATE = '2026-07-14';
 
     /** Minimum required PHP version */
     public const MIN_PHP_VERSION = '8.3.0';

--- a/tests/Integration/FrameworkBootTest.php
+++ b/tests/Integration/FrameworkBootTest.php
@@ -67,6 +67,7 @@ final class FrameworkBootTest extends TestCase
 
         $this->assertInstanceOf(Application::class, $app);
         $this->assertTrue($framework->isBooted());
+        $this->assertTrue($app->getContext()->isBooted());
     }
 
     public function testFrameworkBootIdempotency(): void

--- a/tests/Unit/Bootstrap/ApplicationContextOverrideTest.php
+++ b/tests/Unit/Bootstrap/ApplicationContextOverrideTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Bootstrap;
+
+use Glueful\Bootstrap\ApplicationContext;
+use Glueful\Bootstrap\ConfigurationLoader;
+use PHPUnit\Framework\TestCase;
+
+final class ApplicationContextOverrideTest extends TestCase
+{
+    /** @param array<string,mixed> $file */
+    private function context(array $file): ApplicationContext
+    {
+        $loader = new class ($file) extends ConfigurationLoader {
+            /** @param array<string,mixed> $file */
+            public function __construct(private readonly array $file)
+            {
+            }
+
+            public function loadConfig(string $name): array
+            {
+                return $this->file[$name] ?? [];
+            }
+        };
+        $ctx = new ApplicationContext('/tmp/glueful-config-test', 'testing');
+        $ctx->setConfigLoader($loader);
+
+        return $ctx;
+    }
+
+    public function testOverrideWinsOverFileConfig(): void
+    {
+        $ctx = $this->context(['tenancy' => ['public_origin' => ['base_domain' => 'file.example']]]);
+        self::assertSame('file.example', $ctx->getConfig('tenancy.public_origin.base_domain'));
+
+        $ctx->overrideConfig('tenancy.public_origin.base_domain', 'override.example');
+        self::assertSame('override.example', $ctx->getConfig('tenancy.public_origin.base_domain'));
+    }
+
+    public function testOverrideInvalidatesParentAndChildCachedReads(): void
+    {
+        $ctx = $this->context(['tenancy' => ['public_origin' => ['base_domain' => 'file.example']]]);
+        // Prime both the parent-key and child-key caches.
+        self::assertSame(['base_domain' => 'file.example'], $ctx->getConfig('tenancy.public_origin'));
+        self::assertSame('file.example', $ctx->getConfig('tenancy.public_origin.base_domain'));
+
+        $ctx->overrideConfig('tenancy.public_origin.base_domain', 'override.example');
+
+        self::assertSame('override.example', $ctx->getConfig('tenancy.public_origin.base_domain'));
+        self::assertSame(['base_domain' => 'override.example'], $ctx->getConfig('tenancy.public_origin'));
+    }
+
+    public function testOverrideSurvivesClearConfigCache(): void
+    {
+        $ctx = $this->context(['tenancy' => ['public_origin' => ['base_domain' => 'file.example']]]);
+        $ctx->overrideConfig('tenancy.public_origin.base_domain', 'override.example');
+        $ctx->clearConfigCache();
+        self::assertSame('override.example', $ctx->getConfig('tenancy.public_origin.base_domain'));
+    }
+
+    public function testOverrideRejectedAfterBoot(): void
+    {
+        $ctx = $this->context([]);
+        $ctx->markBooted();
+        $this->expectException(\LogicException::class);
+        $ctx->overrideConfig('tenancy.public_origin.base_domain', 'x.example');
+    }
+
+    public function testOverrideRejectsAnEmptyDotPath(): void
+    {
+        $ctx = $this->context([]);
+        $this->expectException(\InvalidArgumentException::class);
+        $ctx->overrideConfig('tenancy..base_domain', 'x.example');
+    }
+}


### PR DESCRIPTION
Boot-time config override seam: add ApplicationContext::overrideConfig(), a process-local config override that wins over file/env/default config (precedence: extension defaults < file/env < override). Dot-path keys deep-merge into nested config and survive clearConfigCache(). The window is boot-only — Framework::boot() calls markBooted() after all boot phases run, after which overrideConfig() throws.

Additive API only: no new env vars, no migrations, no default changes; existing apps are unaffected.