### PR TITLE
Release 1.70.0 — Albireo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,56 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.70.0] - 2026-07-16 — Albireo
+
+**Theme: blob-policy composition + two long-standing database fixes** — a registry seam that
+lets multiple extensions contribute blob access policies simultaneously, plus `whereIn()` on
+write operations and plain create-table indexes on SQLite/PostgreSQL now actually working.
+Additive API; no new env vars, no migrations, no default changes. One operational note for
+pre-existing dev databases (see Upgrade Notes).
+
+### Added
+- **`BlobAccessPolicyRegistry` + `CompositeBlobAccessPolicy`** — a composition seam over the
+  existing `BlobAccessPolicy` extension point. Applications and extensions register named
+  contributors into the shared `BlobAccessPolicyRegistry` (a normal DI service bound by
+  `StorageProvider`; no static accessor, no process-global fallback); `UploadController` now
+  always receives a `CompositeBlobAccessPolicy` wrapping today's primary policy (bound
+  `BlobAccessPolicy`, or the `Null` fallback) AND-composed with every current registry
+  contributor (veto semantics — any denial denies, short-circuiting in primary-then-insertion
+  order). The composite holds the registry object itself, not a snapshot, so a contributor
+  registered during a later extension's `boot()` is enforced immediately, even though the
+  controller was already constructed. With zero contributors, behavior is byte-identical to
+  the previous unwrapped primary-or-Null policy.
+
+### Fixed
+- **`whereIn()`/`whereNotIn()` now work on `update()`/`delete()`.** The write path's condition
+  reparser only recognized single-placeholder raw conditions, so `whereIn`'s multi-placeholder
+  `col IN (?, ?, …)` was rejected with "Complex WHERE conditions … not yet supported" — even
+  though the UPDATE/DELETE builders already emit `IN`/`NOT IN` for array-valued conditions.
+  The reparser now recovers the column, operator, and bound values (binding offsets preserved
+  when composed with other predicates). `whereIn(col, [])` on a write still throws, as before
+  (the always-false raw condition has no simple-map representation).
+- **`createTable()` no longer silently discards plain (non-unique) indexes on SQLite and
+  PostgreSQL.** Inline `->index(...)` definitions in a create-table callback were only ever
+  emitted by the MySQL generator (as inline `KEY` clauses); the SQLite/PostgreSQL generators
+  inlined UNIQUE constraints only, so plain indexes vanished without error. `TableBuilder::create()`
+  now emits every plain index as a follow-up `CREATE INDEX` statement uniformly across drivers
+  (the same artifact kind the `alterTable()` path produces — real and droppable), and the MySQL
+  generator no longer inlines plain indexes (unique/fulltext stay inline) so nothing is created
+  twice. Existing SQLite/PostgreSQL databases migrated before this fix are missing those indexes;
+  re-running the relevant `CREATE INDEX` statements (or re-migrating dev databases) restores them.
+  Performance-only: query results were never affected.
+
+### Upgrade Notes
+- **SQLite/PostgreSQL databases migrated before 1.70.0 are missing every plain index declared
+  inline in a `createTable()` callback** (they were silently discarded — see Fixed). Fresh
+  migrations are correct automatically. For existing databases, re-run the relevant
+  `CREATE INDEX` statements or re-migrate dev databases. Performance-only; no data or query
+  results were ever affected.
+- No other action required: the registry seam is additive (zero contributors is byte-identical
+  to the previous unwrapped policy), and the `whereIn()` write fix turns a previously throwing
+  call into the behavior its builders already advertised.
+
 ## [1.69.0] - 2026-07-14 — Albali
 
 **Theme: boot-time config override seam** — one additive `ApplicationContext` method that lets

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,24 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.70.0 — Albireo (Minor, Released 2026-07-16)
+- **Blob-policy composition seam.**
+  - `BlobAccessPolicyRegistry` + `CompositeBlobAccessPolicy` — applications and extensions register
+    named `BlobAccessPolicy` contributors into a shared registry (normal DI service bound by
+    `StorageProvider`); `UploadController` receives a composite wrapping the primary policy AND-composed
+    with every contributor (veto semantics, primary-then-insertion order). The composite holds the live
+    registry, so contributors registered during a later extension's `boot()` are enforced immediately.
+    Zero contributors = byte-identical to the previous unwrapped primary-or-Null policy.
+- **Database fixes.**
+  - `whereIn()`/`whereNotIn()` now work on `update()`/`delete()` — the write path's condition reparser
+    recovers multi-placeholder `IN (?, ?, …)` conditions (binding offsets preserved).
+  - `createTable()` no longer silently discards plain indexes on SQLite/PostgreSQL — every plain index
+    is emitted as a follow-up `CREATE INDEX` uniformly across drivers; MySQL stops inlining them so
+    nothing is created twice.
+- Notes: **Minor release** — additive API + fixes; no new env vars, no migrations, no default changes.
+  Operational note: SQLite/PostgreSQL dev databases migrated pre-1.70.0 are missing the previously
+  discarded plain indexes (performance-only); re-run the `CREATE INDEX` statements or re-migrate.
+
 ### 1.69.0 — Albali (Minor, Released 2026-07-14)
 - **Boot-time config override seam.**
   - `ApplicationContext::overrideConfig(string $key, mixed $value)` — a process-local config override

--- a/src/Container/Providers/StorageProvider.php
+++ b/src/Container/Providers/StorageProvider.php
@@ -115,6 +115,15 @@ final class StorageProvider extends BaseServiceProvider
             }
         );
 
+        // Shared registry of named BlobAccessPolicy contributors. Available before
+        // any extension's boot() runs; CompositeBlobAccessPolicy below holds this
+        // exact instance (not a snapshot), so late registration stays live.
+        $defs[\Glueful\Uploader\Contracts\BlobAccessPolicyRegistry::class] = new FactoryDefinition(
+            \Glueful\Uploader\Contracts\BlobAccessPolicyRegistry::class,
+            fn(): \Glueful\Uploader\Contracts\BlobAccessPolicyRegistry
+                => new \Glueful\Uploader\Contracts\BlobAccessPolicyRegistry()
+        );
+
         // Image security validator (kept resolvable after ImageProvider removal;
         // reads image.security/image.limits which the media extension merges in,
         // defaulting to [] when the extension is absent)
@@ -150,9 +159,19 @@ final class StorageProvider extends BaseServiceProvider
                 $c->has(\Glueful\Uploader\Contracts\BlobCreatedHook::class)
                     ? $c->get(\Glueful\Uploader\Contracts\BlobCreatedHook::class)
                     : new \Glueful\Uploader\Contracts\NullBlobCreatedHook(),
-                $c->has(\Glueful\Uploader\Contracts\BlobAccessPolicy::class)
-                    ? $c->get(\Glueful\Uploader\Contracts\BlobAccessPolicy::class)
-                    : new \Glueful\Uploader\Contracts\NullBlobAccessPolicy(),
+                // The controller always receives a CompositeBlobAccessPolicy: today's
+                // primary (bound BlobAccessPolicy, or the Null fallback) AND-composed
+                // with every current BlobAccessPolicyRegistry contributor. The
+                // composite holds the registry live, so contributors registered
+                // during extension boot() — even after this controller is
+                // constructed — are still enforced. Zero contributors + no bound
+                // primary is byte-identical to the old unwrapped Null policy.
+                new \Glueful\Uploader\Contracts\CompositeBlobAccessPolicy(
+                    $c->has(\Glueful\Uploader\Contracts\BlobAccessPolicy::class)
+                        ? $c->get(\Glueful\Uploader\Contracts\BlobAccessPolicy::class)
+                        : new \Glueful\Uploader\Contracts\NullBlobAccessPolicy(),
+                    $c->get(\Glueful\Uploader\Contracts\BlobAccessPolicyRegistry::class)
+                ),
                 $c->has(\Psr\Log\LoggerInterface::class)
                     ? $c->get(\Psr\Log\LoggerInterface::class)
                     : new \Psr\Log\NullLogger(),

--- a/src/Database/Query/WhereClause.php
+++ b/src/Database/Query/WhereClause.php
@@ -460,6 +460,35 @@ class WhereClause implements WhereClauseInterface
                     continue;
                 }
 
+                // Handle whereIn()/whereNotIn(): "<column> [NOT ]IN (?, ?, ...)". The
+                // UPDATE/DELETE builders already emit IN/NOT IN for array-valued
+                // conditions ('__op' + array '__value'); this reparse recovers the
+                // column, operator, and the N bound values so multi-placeholder IN
+                // no longer falls through to the complex-conditions rejection.
+                if (preg_match('/^(.+?)\s+(NOT\s+)?IN\s*\(\s*\?(?:\s*,\s*\?)*\s*\)$/i', $sql, $matches)) {
+                    $column = trim($matches[1], '`"[]');
+                    if (strpos($column, '.') !== false) {
+                        $parts = explode('.', $column);
+                        // Re-strip wrap chars (see the null-check branch above).
+                        $column = trim(end($parts), '`"[]');
+                    }
+
+                    // The regex anchors the whole raw string, so every placeholder
+                    // in it belongs to the IN list.
+                    $count = substr_count($sql, '?');
+                    $values = array_slice($this->bindings, $bindingIndex, $count);
+                    if (count($values) === $count) {
+                        $this->assignSimpleCondition($simpleConditions, $column, [
+                            '__op' => isset($matches[2]) && trim($matches[2]) !== '' ? 'NOT IN' : 'IN',
+                            '__value' => $values,
+                        ]);
+                    } else {
+                        $complexConditions[] = $condition;
+                    }
+                    $bindingIndex += $count;
+                    continue;
+                }
+
                 // Handle simple raw comparisons with single placeholder: "<column> <op> ?"
                 if (preg_match('/^(.+?)\s+([=!<>]+|LIKE|NOT LIKE|IN|NOT IN|IS|IS NOT)\s+\?$/i', $sql, $matches)) {
                     $column = trim($matches[1], '`"[]');

--- a/src/Database/Schema/Builders/TableBuilder.php
+++ b/src/Database/Schema/Builders/TableBuilder.php
@@ -664,6 +664,20 @@ class TableBuilder implements TableBuilderInterface, TableBuilderContextInterfac
         $sql = $this->sqlGenerator->createTable($tableDefinition);
         $this->schemaBuilder->addPendingOperation($sql);
 
+        // Plain (non-unique) indexes are emitted as follow-up CREATE INDEX operations on
+        // every driver. Only UNIQUE constraints belong inside CREATE TABLE: SQLite and
+        // PostgreSQL never supported inline plain indexes (they were silently discarded),
+        // and standalone statements make create-time indexes real, droppable artifacts —
+        // identical to the alterTable path. Fulltext stays generator-specific (MySQL
+        // inlines it; other drivers do not support it).
+        foreach ($this->indexes as $index) {
+            if ($index->type === 'index') {
+                $this->schemaBuilder->addPendingOperation(
+                    $this->sqlGenerator->createIndex($this->tableName, $index)
+                );
+            }
+        }
+
         return $this->schemaBuilder;
     }
 

--- a/src/Database/Schema/Generators/MySQLSqlGenerator.php
+++ b/src/Database/Schema/Generators/MySQLSqlGenerator.php
@@ -63,9 +63,12 @@ class MySQLSqlGenerator implements SqlGeneratorInterface
             $parts[] = '  PRIMARY KEY (' . implode(', ', $quotedColumns) . ')';
         }
 
-        // Add indexes
+        // Add unique/fulltext constraints inline. Plain indexes are deliberately NOT
+        // inlined: TableBuilder::create() emits them as follow-up CREATE INDEX
+        // statements uniformly across drivers (SQLite/PostgreSQL cannot inline them),
+        // so inlining here would raise a duplicate-index-name error.
         foreach ($table->indexes as $index) {
-            if ($index->type !== 'primary') {
+            if ($index->type !== 'primary' && $index->type !== 'index') {
                 $parts[] = '  ' . $this->buildIndexDefinition($index);
             }
         }

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,15 +13,15 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.69.0';
+    public const VERSION = '1.70.0';
 
 
     /** Release code name */
-    public const NAME = 'Albali';
+    public const NAME = 'Albireo';
 
 
     /** Release date */
-    public const RELEASE_DATE = '2026-07-14';
+    public const RELEASE_DATE = '2026-07-16';
 
     /** Minimum required PHP version */
     public const MIN_PHP_VERSION = '8.3.0';

--- a/src/Uploader/Contracts/BlobAccessPolicyRegistry.php
+++ b/src/Uploader/Contracts/BlobAccessPolicyRegistry.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Uploader\Contracts;
+
+/**
+ * Shared, framework-bound registry of named BlobAccessPolicy contributors.
+ *
+ * Registered as a normal shared service by StorageProvider — available before
+ * any extension's boot() runs, with no static accessor and no process-global
+ * fallback. Extensions register their policy under a stable id during boot();
+ * CompositeBlobAccessPolicy holds this registry object (not a copy) and reads
+ * all() fresh on every authorization call, so registration order relative to
+ * controller construction never matters.
+ */
+final class BlobAccessPolicyRegistry
+{
+    /** @var array<string, BlobAccessPolicy> */
+    private array $policies = [];
+
+    /**
+     * @throws \LogicException when $id is already registered
+     */
+    public function register(string $id, BlobAccessPolicy $policy): void
+    {
+        if (isset($this->policies[$id])) {
+            throw new \LogicException(
+                sprintf('A blob access policy is already registered under id "%s".', $id)
+            );
+        }
+
+        $this->policies[$id] = $policy;
+    }
+
+    public function has(string $id): bool
+    {
+        return isset($this->policies[$id]);
+    }
+
+    /**
+     * @return array<string, BlobAccessPolicy> insertion-ordered
+     */
+    public function all(): array
+    {
+        return $this->policies;
+    }
+}

--- a/src/Uploader/Contracts/CompositeBlobAccessPolicy.php
+++ b/src/Uploader/Contracts/CompositeBlobAccessPolicy.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Uploader\Contracts;
+
+/**
+ * AND/veto-composes the host application's primary BlobAccessPolicy with every
+ * current contributor in a BlobAccessPolicyRegistry: authorization succeeds
+ * only when the primary AND every registered contributor return true.
+ *
+ * The registry is held by reference, not snapshotted at construction time, so
+ * a contributor registered after this composite (or the controller holding
+ * it) was built is still enforced on the next call — this is what lets
+ * extension boot() order stay irrelevant. Evaluation short-circuits on the
+ * first denial, primary first, then contributors in registry insertion order.
+ *
+ * With an empty registry and the framework's NullBlobAccessPolicy as primary
+ * (StorageProvider's default when nothing is bound), behavior is
+ * byte-identical to having no policy at all.
+ */
+final class CompositeBlobAccessPolicy implements BlobAccessPolicy
+{
+    public function __construct(
+        private BlobAccessPolicy $primary,
+        private BlobAccessPolicyRegistry $registry,
+    ) {
+    }
+
+    /** @param array<string,mixed> $blob */
+    public function authorizeAccess(array $blob, BlobAccessContext $context): bool
+    {
+        if (!$this->primary->authorizeAccess($blob, $context)) {
+            return false;
+        }
+
+        foreach ($this->registry->all() as $contributor) {
+            if (!$contributor->authorizeAccess($blob, $context)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/tests/Unit/Container/Providers/StorageProviderBlobAccessPolicyTest.php
+++ b/tests/Unit/Container/Providers/StorageProviderBlobAccessPolicyTest.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Container\Providers;
+
+use Glueful\Application;
+use Glueful\Bootstrap\ApplicationContext;
+use Glueful\Container\Definition\ValueDefinition;
+use Glueful\Controllers\UploadController;
+use Glueful\Framework;
+use Glueful\Routing\RouteManifest;
+use Glueful\Uploader\Contracts\BlobAccessContext;
+use Glueful\Uploader\Contracts\BlobAccessPolicy;
+use Glueful\Uploader\Contracts\BlobAccessPolicyRegistry;
+use Glueful\Uploader\Contracts\BlobAction;
+use Glueful\Uploader\Contracts\CompositeBlobAccessPolicy;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Layer 3 / Task 1 — proves StorageProvider actually wires the composition
+ * seam end-to-end through the real DI container, not just at the unit level:
+ *
+ *  - BlobAccessPolicyRegistry is a normal SHARED service (same instance on
+ *    every resolution).
+ *  - UploadController is constructed with a CompositeBlobAccessPolicy that
+ *    holds that exact shared registry instance.
+ *  - Because it's the live registry (not a snapshot), registering a
+ *    contributor AFTER the controller has already been resolved from the
+ *    container still changes the next authorization outcome.
+ *
+ * Reuses the Framework-boot harness established by
+ * StorageProviderFileUploaderMediaTest (real boot + file-backed SQLite +
+ * local `uploads` disk + BaseRepository shared-connection reset + a
+ * container-bound `request` carrying a `user` attribute).
+ */
+final class StorageProviderBlobAccessPolicyTest extends TestCase
+{
+    private string $appPath;
+    private string $uploadsRoot;
+    private string $dbFile;
+    private Application $app;
+    private ApplicationContext $context;
+
+    protected function setUp(): void
+    {
+        RouteManifest::reset();
+
+        $this->appPath = sys_get_temp_dir() . '/glueful-blob-policy-' . uniqid('', true);
+        $this->uploadsRoot = $this->appPath . '/disk';
+        $this->dbFile = $this->appPath . '/app.sqlite';
+        $cfg = $this->appPath . '/config';
+        mkdir($cfg, 0755, true);
+        mkdir($this->uploadsRoot, 0755, true);
+
+        // File-backed SQLite so every Connection shares one database.
+        putenv('DB_DATABASE=' . $this->dbFile);
+        putenv('DB_SQLITE_DATABASE=' . $this->dbFile);
+        $_ENV['DB_DATABASE'] = $this->dbFile;
+        $_ENV['DB_SQLITE_DATABASE'] = $this->dbFile;
+
+        file_put_contents(
+            $cfg . '/app.php',
+            "<?php\nreturn ['name' => 'T', 'version_full' => '1.0.0', 'env' => 'testing', 'debug' => true];\n"
+        );
+        file_put_contents(
+            $cfg . '/database.php',
+            "<?php\nreturn ['engine' => 'sqlite', 'sqlite' => ['primary' => '" . $this->dbFile . "'], "
+            . "'pooling' => ['enabled' => false]];\n"
+        );
+        file_put_contents(
+            $cfg . '/cache.php',
+            "<?php\nreturn ['enabled' => true, 'default' => 'array', 'stores' => ['array' => ['driver' => 'array']]];\n"
+        );
+        file_put_contents($cfg . '/security.php', "<?php\nreturn ['csrf' => ['enabled' => false]];\n");
+        file_put_contents($cfg . '/session.php', "<?php\nreturn ['jwt_key' => 'test'];\n");
+
+        file_put_contents(
+            $cfg . '/storage.php',
+            "<?php\nreturn ['default' => 'uploads', 'disks' => ['uploads' => "
+            . "['driver' => 'local', 'root' => '" . $this->uploadsRoot . "', 'visibility' => 'private']]];\n"
+        );
+        file_put_contents(
+            $cfg . '/uploads.php',
+            "<?php\nreturn ['enabled' => true, 'disk' => 'uploads', 'path_prefix' => '', "
+            . "'allowed_types' => ['image/*', 'video/*', 'audio/*'], 'max_size' => 10485760];\n"
+        );
+
+        $this->resetSharedConnection();
+
+        $this->app = Framework::create($this->appPath)->boot(allowReboot: true);
+        $this->context = $this->app->getContext();
+
+        $this->runBlobsMigration();
+
+        $request = new Request();
+        $request->attributes->set('user', ['uuid' => 'usr123456789']);
+        /** @var \Glueful\Container\Container $container */
+        $container = $this->context->getContainer();
+        $container->load([
+            'request' => new ValueDefinition('request', $request),
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        putenv('DB_DATABASE=:memory:');
+        putenv('DB_SQLITE_DATABASE');
+        $_ENV['DB_DATABASE'] = ':memory:';
+        unset($_ENV['DB_SQLITE_DATABASE']);
+
+        if (isset($this->appPath) && is_dir($this->appPath)) {
+            $this->recursiveRemove($this->appPath);
+        }
+        parent::tearDown();
+    }
+
+    public function testRegistryIsSharedAcrossResolutions(): void
+    {
+        /** @var \Glueful\Container\Container $container */
+        $container = $this->context->getContainer();
+
+        $first = $container->get(BlobAccessPolicyRegistry::class);
+        $second = $container->get(BlobAccessPolicyRegistry::class);
+
+        self::assertInstanceOf(BlobAccessPolicyRegistry::class, $first);
+        self::assertSame($first, $second, 'BlobAccessPolicyRegistry must be a shared singleton.');
+    }
+
+    public function testControllerReceivesTheLiveCompositeHoldingTheSharedRegistry(): void
+    {
+        /** @var \Glueful\Container\Container $container */
+        $container = $this->context->getContainer();
+
+        /** @var UploadController $controller */
+        $controller = $container->get(UploadController::class);
+
+        $policy = $this->readPrivateProperty($controller, 'accessPolicy');
+        self::assertInstanceOf(CompositeBlobAccessPolicy::class, $policy);
+
+        $registryInsideComposite = $this->readPrivateProperty($policy, 'registry');
+        $registryFromContainer = $container->get(BlobAccessPolicyRegistry::class);
+
+        self::assertSame(
+            $registryFromContainer,
+            $registryInsideComposite,
+            'The composite must hold the exact container-bound registry instance, not a copy.'
+        );
+    }
+
+    /**
+     * Nothing is bound (no primary BlobAccessPolicy, zero contributors) so the
+     * controller's composite must behave exactly like the old unwrapped
+     * NullBlobAccessPolicy: always allow.
+     */
+    public function testUnboundIsByteIdenticalAllow(): void
+    {
+        /** @var \Glueful\Container\Container $container */
+        $container = $this->context->getContainer();
+
+        /** @var UploadController $controller */
+        $controller = $container->get(UploadController::class);
+        $policy = $this->readPrivateProperty($controller, 'accessPolicy');
+
+        self::assertTrue($policy->authorizeAccess(
+            ['uuid' => 'blob123456', 'visibility' => 'private'],
+            new BlobAccessContext(BlobAction::VIEW, 'usr123456789', false)
+        ));
+    }
+
+    /**
+     * The key liveness proof: register a denying contributor into the
+     * container's shared registry AFTER UploadController has already been
+     * resolved (and therefore its composite already constructed) — the very
+     * next authorization call must still see it.
+     */
+    public function testLateExtensionRegistrationAffectsAnAlreadyResolvedController(): void
+    {
+        /** @var \Glueful\Container\Container $container */
+        $container = $this->context->getContainer();
+
+        /** @var UploadController $controller */
+        $controller = $container->get(UploadController::class);
+        $policy = $this->readPrivateProperty($controller, 'accessPolicy');
+
+        $blob = ['uuid' => 'blob123456', 'visibility' => 'private'];
+        $context = new BlobAccessContext(BlobAction::VIEW, 'usr123456789', false);
+
+        self::assertTrue($policy->authorizeAccess($blob, $context));
+
+        /** @var BlobAccessPolicyRegistry $registry */
+        $registry = $container->get(BlobAccessPolicyRegistry::class);
+        $registry->register('layer3-late-contributor', new class implements BlobAccessPolicy {
+            public function authorizeAccess(array $blob, BlobAccessContext $context): bool
+            {
+                return false;
+            }
+        });
+
+        self::assertFalse($policy->authorizeAccess($blob, $context));
+    }
+
+    private function readPrivateProperty(object $object, string $property): mixed
+    {
+        $ref = new \ReflectionProperty($object, $property);
+        $ref->setAccessible(true);
+        return $ref->getValue($object);
+    }
+
+    private function resetSharedConnection(): void
+    {
+        $ref = new \ReflectionClass(\Glueful\Repository\BaseRepository::class);
+        if ($ref->hasProperty('sharedConnection')) {
+            $prop = $ref->getProperty('sharedConnection');
+            $prop->setAccessible(true);
+            $prop->setValue(null, null);
+        }
+    }
+
+    private function runBlobsMigration(): void
+    {
+        $schema = \Glueful\Database\Connection::fromContext($this->context)->getSchemaBuilder();
+
+        $schema->createTable('blobs', function ($table): void {
+            $table->bigInteger('id')->primary()->autoIncrement();
+            $table->string('uuid', 12);
+            $table->string('name', 255);
+            $table->text('description')->nullable();
+            $table->string('mime_type', 127);
+            $table->bigInteger('size');
+            $table->string('url', 2048);
+            $table->string('storage_type', 20)->default('local');
+            $table->string('visibility', 10)->default('private');
+            $table->string('status', 20)->default('active');
+            $table->string('created_by', 12);
+            $table->timestamp('created_at')->nullable();
+            $table->timestamp('updated_at')->nullable();
+            $table->timestamp('deleted_at')->nullable();
+
+            $table->unique('uuid');
+        });
+    }
+
+    private function recursiveRemove(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $items = scandir($dir);
+        if ($items === false) {
+            return;
+        }
+
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path)) {
+                $this->recursiveRemove($path);
+            } else {
+                @unlink($path);
+            }
+        }
+
+        @rmdir($dir);
+    }
+}

--- a/tests/Unit/Database/Query/WhereInWriteOperationsTest.php
+++ b/tests/Unit/Database/Query/WhereInWriteOperationsTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Database\Query;
+
+use Glueful\Database\Connection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * whereIn()/whereNotIn() on UPDATE and DELETE.
+ *
+ * Regression coverage: WhereClause::getConditionsArray() only reparsed
+ * single-placeholder raw conditions, so whereIn's multi-placeholder
+ * `col IN (?, ?, ?)` was classified "complex" and UPDATE/DELETE threw
+ * "Complex WHERE conditions ... not yet supported" — even though the
+ * write builders already emit IN/NOT IN for array-valued conditions.
+ */
+final class WhereInWriteOperationsTest extends TestCase
+{
+    private ?string $dbPath = null;
+
+    protected function tearDown(): void
+    {
+        if ($this->dbPath !== null && is_file($this->dbPath)) {
+            @unlink($this->dbPath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_where_in_delete_removes_only_matching_rows(): void
+    {
+        $conn = $this->seededConnection();
+
+        $affected = $conn->table('items')
+            ->whereIn('code', ['a', 'c'])
+            ->delete();
+
+        self::assertSame(2, $affected);
+        self::assertSame(['b', 'd'], $this->codes($conn));
+    }
+
+    public function test_where_not_in_delete_keeps_listed_rows(): void
+    {
+        $conn = $this->seededConnection();
+
+        $affected = $conn->table('items')
+            ->whereNotIn('code', ['a', 'b'])
+            ->delete();
+
+        self::assertSame(2, $affected);
+        self::assertSame(['a', 'b'], $this->codes($conn));
+    }
+
+    public function test_where_in_update_touches_only_matching_rows(): void
+    {
+        $conn = $this->seededConnection();
+
+        $affected = $conn->table('items')
+            ->whereIn('code', ['b', 'd'])
+            ->update(['grade' => 9]);
+
+        self::assertSame(2, $affected);
+        $grades = [];
+        foreach ($conn->table('items')->orderBy('code')->get() as $row) {
+            $grades[$row['code']] = (int) $row['grade'];
+        }
+        self::assertSame(['a' => 0, 'b' => 9, 'c' => 0, 'd' => 9], $grades);
+    }
+
+    public function test_where_in_composes_with_preceding_basic_condition(): void
+    {
+        // Binding-order accounting: the basic condition consumes one binding
+        // BEFORE the IN condition's slice; a mis-offset would shift values.
+        $conn = $this->seededConnection();
+
+        $affected = $conn->table('items')
+            ->where('grade', '=', 0)
+            ->whereIn('code', ['a', 'b'])
+            ->update(['grade' => 5]);
+
+        self::assertSame(2, $affected);
+        self::assertSame(
+            2,
+            count(array_filter(
+                $conn->table('items')->get(),
+                static fn (array $r): bool => (int) $r['grade'] === 5
+            ))
+        );
+    }
+
+    public function test_where_in_after_null_check_keeps_binding_offsets(): void
+    {
+        // whereNull consumes zero bindings; the IN slice must still start at 0.
+        $conn = $this->seededConnection();
+
+        $affected = $conn->table('items')
+            ->whereNull('note')
+            ->whereIn('code', ['c'])
+            ->delete();
+
+        self::assertSame(1, $affected);
+        self::assertSame(['a', 'b', 'd'], $this->codes($conn));
+    }
+
+    public function test_empty_where_in_still_rejects_write_operations(): void
+    {
+        // whereIn([]) becomes the raw always-false '1 = 0', which the simple
+        // conditions map cannot express — the guarded throw stays (documented).
+        $conn = $this->seededConnection();
+
+        $this->expectException(\RuntimeException::class);
+        $conn->table('items')->whereIn('code', [])->delete();
+    }
+
+    private function seededConnection(): Connection
+    {
+        $this->dbPath = tempnam(sys_get_temp_dir(), 'wherein-write-');
+        self::assertIsString($this->dbPath);
+
+        $conn = new Connection([
+            'engine' => 'sqlite',
+            'sqlite' => ['primary' => $this->dbPath],
+            'pooling' => ['enabled' => false],
+        ]);
+
+        $conn->getSchemaBuilder()->createTable('items', function ($table): void {
+            $table->bigInteger('id')->primary()->autoIncrement();
+            $table->string('code', 8);
+            $table->integer('grade')->default(0);
+            $table->string('note', 32)->nullable();
+        });
+
+        foreach (['a', 'b', 'c', 'd'] as $code) {
+            $conn->table('items')->insert(['code' => $code, 'grade' => 0, 'note' => null]);
+        }
+
+        return $conn;
+    }
+
+    /** @return list<string> remaining codes, ordered */
+    private function codes(Connection $conn): array
+    {
+        $codes = array_map(
+            static fn (array $r): string => (string) $r['code'],
+            $conn->table('items')->orderBy('code')->get()
+        );
+
+        return array_values($codes);
+    }
+}

--- a/tests/Unit/Database/Schema/CreateTableIndexTest.php
+++ b/tests/Unit/Database/Schema/CreateTableIndexTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Database\Schema;
+
+use Glueful\Database\Connection;
+use Glueful\Database\Schema\DTOs\IndexDefinition;
+use Glueful\Database\Schema\Generators\MySQLSqlGenerator;
+use Glueful\Database\Schema\Generators\PostgreSQLSqlGenerator;
+use Glueful\Database\Schema\Generators\SQLiteSqlGenerator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Non-unique indexes declared inside a createTable() callback must actually
+ * exist after the table is created — on every driver.
+ *
+ * Regression coverage: the SQLite/PostgreSQL createTable generators only ever
+ * inlined UNIQUE constraints, so plain ->index(...) definitions were silently
+ * discarded at create time (only the alterTable path emitted CREATE INDEX).
+ */
+final class CreateTableIndexTest extends TestCase
+{
+    private ?string $dbPath = null;
+
+    protected function tearDown(): void
+    {
+        if ($this->dbPath !== null && is_file($this->dbPath)) {
+            @unlink($this->dbPath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_create_table_creates_plain_indexes_on_sqlite(): void
+    {
+        $conn = $this->sqliteConnection();
+
+        $conn->getSchemaBuilder()->createTable('orders', function ($table): void {
+            $table->bigInteger('id')->primary()->autoIncrement();
+            $table->string('tenant_uuid', 12)->default('');
+            $table->string('status', 20);
+            $table->string('reference', 64);
+
+            $table->unique('reference');
+            $table->index('tenant_uuid', 'idx_orders_tenant');
+            $table->index(['tenant_uuid', 'status'], 'idx_orders_tenant_status');
+        });
+
+        self::assertTrue(
+            $this->sqliteIndexExists($conn, 'idx_orders_tenant'),
+            'Plain single-column index from createTable() must exist'
+        );
+        self::assertTrue(
+            $this->sqliteIndexExists($conn, 'idx_orders_tenant_status'),
+            'Plain composite index from createTable() must exist'
+        );
+    }
+
+    public function test_create_table_index_is_droppable_via_alter_table(): void
+    {
+        $conn = $this->sqliteConnection();
+        $schema = $conn->getSchemaBuilder();
+
+        $schema->createTable('things', function ($table): void {
+            $table->bigInteger('id')->primary()->autoIncrement();
+            $table->string('kind', 20);
+            $table->index('kind', 'idx_things_kind');
+        });
+
+        self::assertTrue($this->sqliteIndexExists($conn, 'idx_things_kind'));
+
+        $schema->alterTable('things', function ($table): void {
+            $table->dropIndex('idx_things_kind');
+        });
+
+        self::assertFalse(
+            $this->sqliteIndexExists($conn, 'idx_things_kind'),
+            'Create-time plain index must be a real, droppable artifact'
+        );
+    }
+
+    public function test_unique_constraints_still_reject_duplicates_on_sqlite(): void
+    {
+        $conn = $this->sqliteConnection();
+
+        $conn->getSchemaBuilder()->createTable('refs', function ($table): void {
+            $table->bigInteger('id')->primary()->autoIncrement();
+            $table->string('reference', 64);
+            $table->unique('reference');
+            $table->index('reference', 'idx_refs_reference_lookup');
+        });
+
+        $pdo = $conn->getPDO();
+        $pdo->exec("INSERT INTO refs (reference) VALUES ('abc')");
+
+        $this->expectException(\PDOException::class);
+        $pdo->exec("INSERT INTO refs (reference) VALUES ('abc')");
+    }
+
+    public function test_postgresql_generator_pairs_create_table_with_create_index(): void
+    {
+        $generator = new PostgreSQLSqlGenerator();
+        $index = new IndexDefinition(['tenant_uuid'], 'idx_orders_tenant', 'index');
+
+        $sql = $generator->createIndex('orders', $index);
+
+        self::assertStringContainsString('CREATE INDEX', $sql);
+        self::assertStringContainsString('"idx_orders_tenant"', $sql);
+        self::assertStringContainsString('"orders"', $sql);
+    }
+
+    public function test_mysql_create_table_does_not_inline_plain_indexes(): void
+    {
+        // Plain indexes are emitted as follow-up CREATE INDEX operations on all
+        // drivers; MySQL must not ALSO inline them (duplicate index name error).
+        $generator = new MySQLSqlGenerator();
+
+        $createSql = $this->generateCreateTable($generator);
+
+        self::assertStringNotContainsString(
+            'KEY `idx_orders_tenant`',
+            $createSql,
+            'MySQL createTable must not inline the plain index that will be created as a follow-up statement'
+        );
+        self::assertStringContainsString(
+            'UNIQUE KEY',
+            $createSql,
+            'Unique constraints stay inline in MySQL createTable'
+        );
+    }
+
+    public function test_sqlite_create_index_sql_for_plain_index(): void
+    {
+        $generator = new SQLiteSqlGenerator();
+        $index = new IndexDefinition(['tenant_uuid', 'status'], 'idx_orders_tenant_status', 'index');
+
+        $sql = $generator->createIndex('orders', $index);
+
+        self::assertStringContainsString('CREATE INDEX', $sql);
+        self::assertStringNotContainsString('UNIQUE', $sql);
+    }
+
+    private function generateCreateTable(MySQLSqlGenerator $generator): string
+    {
+        $definition = new \Glueful\Database\Schema\DTOs\TableDefinition(
+            name: 'orders',
+            columns: [
+                new \Glueful\Database\Schema\DTOs\ColumnDefinition(
+                    name: 'reference',
+                    type: 'string',
+                    length: 64,
+                ),
+                new \Glueful\Database\Schema\DTOs\ColumnDefinition(
+                    name: 'tenant_uuid',
+                    type: 'string',
+                    length: 12,
+                ),
+            ],
+            indexes: [
+                new IndexDefinition(['reference'], 'uniq_orders_reference', 'unique', true),
+                new IndexDefinition(['tenant_uuid'], 'idx_orders_tenant', 'index'),
+            ],
+            foreignKeys: [],
+            primaryKey: [],
+            options: [],
+            comment: null
+        );
+
+        return $generator->createTable($definition);
+    }
+
+    private function sqliteConnection(): Connection
+    {
+        $this->dbPath = tempnam(sys_get_temp_dir(), 'schema-create-index-');
+        self::assertIsString($this->dbPath);
+
+        return new Connection([
+            'engine' => 'sqlite',
+            'sqlite' => ['primary' => $this->dbPath],
+            'pooling' => ['enabled' => false],
+        ]);
+    }
+
+    private function sqliteIndexExists(Connection $conn, string $indexName): bool
+    {
+        $stmt = $conn->getPDO()->prepare(
+            'SELECT COUNT(*) FROM sqlite_master WHERE type = "index" AND name = ?'
+        );
+        $stmt->execute([$indexName]);
+
+        return (int) $stmt->fetchColumn() === 1;
+    }
+}

--- a/tests/Unit/Uploader/BlobAccessPolicyCompositionTest.php
+++ b/tests/Unit/Uploader/BlobAccessPolicyCompositionTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Uploader;
+
+use Glueful\Uploader\Contracts\BlobAccessContext;
+use Glueful\Uploader\Contracts\BlobAccessPolicy;
+use Glueful\Uploader\Contracts\BlobAccessPolicyRegistry;
+use Glueful\Uploader\Contracts\BlobAction;
+use Glueful\Uploader\Contracts\CompositeBlobAccessPolicy;
+use Glueful\Uploader\Contracts\NullBlobAccessPolicy;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Layer 3 / Task 1 — BlobAccessPolicyRegistry + CompositeBlobAccessPolicy.
+ *
+ * The composite gives StorageProvider a single BlobAccessPolicy to hand
+ * UploadController: today's primary policy (bound BlobAccessPolicy, or the
+ * Null fallback) AND-composed with every contributor an extension registers
+ * into the shared registry. The composite holds the registry object itself
+ * (not a snapshot), so registry->all() is read fresh on every call — a
+ * contributor registered after the composite (or the controller) was built
+ * is still enforced on the very next authorization check.
+ */
+final class BlobAccessPolicyCompositionTest extends TestCase
+{
+    public function testPrimaryOnlyAllowPassesThrough(): void
+    {
+        $composite = new CompositeBlobAccessPolicy(
+            new FixedBlobAccessPolicy(true),
+            new BlobAccessPolicyRegistry()
+        );
+
+        self::assertTrue($composite->authorizeAccess($this->blob(), $this->context()));
+    }
+
+    public function testPrimaryOnlyDenyPassesThrough(): void
+    {
+        $composite = new CompositeBlobAccessPolicy(
+            new FixedBlobAccessPolicy(false),
+            new BlobAccessPolicyRegistry()
+        );
+
+        self::assertFalse($composite->authorizeAccess($this->blob(), $this->context()));
+    }
+
+    public function testContributorOnlyDenyDenies(): void
+    {
+        $registry = new BlobAccessPolicyRegistry();
+        $registry->register('deny-all', new FixedBlobAccessPolicy(false));
+
+        $composite = new CompositeBlobAccessPolicy(new FixedBlobAccessPolicy(true), $registry);
+
+        self::assertFalse($composite->authorizeAccess($this->blob(), $this->context()));
+    }
+
+    public function testCombinedDenialPrimaryDeniesEvenWhenContributorAllows(): void
+    {
+        $registry = new BlobAccessPolicyRegistry();
+        $registry->register('allow-all', new FixedBlobAccessPolicy(true));
+
+        $composite = new CompositeBlobAccessPolicy(new FixedBlobAccessPolicy(false), $registry);
+
+        self::assertFalse($composite->authorizeAccess($this->blob(), $this->context()));
+    }
+
+    public function testCombinedDenialContributorDeniesEvenWhenPrimaryAllows(): void
+    {
+        $registry = new BlobAccessPolicyRegistry();
+        $registry->register('deny-all', new FixedBlobAccessPolicy(false));
+
+        $composite = new CompositeBlobAccessPolicy(new FixedBlobAccessPolicy(true), $registry);
+
+        self::assertFalse($composite->authorizeAccess($this->blob(), $this->context()));
+    }
+
+    public function testDeterministicInsertionOrderShortCircuitsOnFirstDenial(): void
+    {
+        /** @var list<string> $log */
+        $log = [];
+
+        $primary = new RecordingBlobAccessPolicy($log, 'primary', true);
+        $registry = new BlobAccessPolicyRegistry();
+        $registry->register('a', new RecordingBlobAccessPolicy($log, 'a', true));
+        $registry->register('b', new RecordingBlobAccessPolicy($log, 'b', false));
+        $registry->register('c', new RecordingBlobAccessPolicy($log, 'c', true));
+
+        $composite = new CompositeBlobAccessPolicy($primary, $registry);
+
+        self::assertFalse($composite->authorizeAccess($this->blob(), $this->context()));
+        // 'c' never runs — the composite short-circuits at the first false,
+        // in registry insertion order, after the primary.
+        self::assertSame(['primary', 'a', 'b'], $log);
+    }
+
+    public function testAllOnRegistryPreservesInsertionOrderRegardlessOfId(): void
+    {
+        $registry = new BlobAccessPolicyRegistry();
+        $registry->register('z-first', new FixedBlobAccessPolicy(true));
+        $registry->register('a-second', new FixedBlobAccessPolicy(true));
+
+        self::assertSame(['z-first', 'a-second'], array_keys($registry->all()));
+    }
+
+    public function testDuplicateIdThrowsLogicException(): void
+    {
+        $registry = new BlobAccessPolicyRegistry();
+        $registry->register('dup', new FixedBlobAccessPolicy(true));
+
+        $this->expectException(\LogicException::class);
+        $registry->register('dup', new FixedBlobAccessPolicy(false));
+    }
+
+    public function testHasReflectsRegisteredIds(): void
+    {
+        $registry = new BlobAccessPolicyRegistry();
+
+        self::assertFalse($registry->has('contrib'));
+
+        $registry->register('contrib', new FixedBlobAccessPolicy(true));
+
+        self::assertTrue($registry->has('contrib'));
+    }
+
+    public function testNoContributorAndNullPrimaryIsByteIdenticalAllow(): void
+    {
+        $composite = new CompositeBlobAccessPolicy(new NullBlobAccessPolicy(), new BlobAccessPolicyRegistry());
+
+        self::assertTrue($composite->authorizeAccess($this->blob(), $this->context()));
+    }
+
+    public function testLateRegistrationTakesEffectOnTheSameCompositeInstance(): void
+    {
+        $registry = new BlobAccessPolicyRegistry();
+        $composite = new CompositeBlobAccessPolicy(new NullBlobAccessPolicy(), $registry);
+
+        // Constructed before any contributor exists — must still allow.
+        self::assertTrue($composite->authorizeAccess($this->blob(), $this->context()));
+
+        // Register a denying contributor AFTER the composite (and, in the real
+        // seam, the controller) was already built.
+        $registry->register('late-contributor', new FixedBlobAccessPolicy(false));
+
+        // The same composite instance now denies — proves the live registry
+        // read, not a constructor-time snapshot.
+        self::assertFalse($composite->authorizeAccess($this->blob(), $this->context()));
+    }
+
+    /** @return array<string,mixed> */
+    private function blob(): array
+    {
+        return ['uuid' => 'blob123456', 'visibility' => 'private'];
+    }
+
+    private function context(): BlobAccessContext
+    {
+        return new BlobAccessContext(BlobAction::VIEW, 'usr123456789', false);
+    }
+}
+
+final class FixedBlobAccessPolicy implements BlobAccessPolicy
+{
+    public function __construct(private bool $result)
+    {
+    }
+
+    public function authorizeAccess(array $blob, BlobAccessContext $context): bool
+    {
+        return $this->result;
+    }
+}
+
+final class RecordingBlobAccessPolicy implements BlobAccessPolicy
+{
+    /**
+     * @param list<string> $log
+     */
+    public function __construct(private array &$log, private string $label, private bool $result)
+    {
+    }
+
+    public function authorizeAccess(array $blob, BlobAccessContext $context): bool
+    {
+        $this->log[] = $this->label;
+        return $this->result;
+    }
+}


### PR DESCRIPTION
### Added
- **`BlobAccessPolicyRegistry` + `CompositeBlobAccessPolicy`** — a composition seam over the
  existing `BlobAccessPolicy` extension point. Applications and extensions register named
  contributors into the shared `BlobAccessPolicyRegistry` (a normal DI service bound by
  `StorageProvider`; no static accessor, no process-global fallback); `UploadController` now
  always receives a `CompositeBlobAccessPolicy` wrapping today's primary policy (bound
  `BlobAccessPolicy`, or the `Null` fallback) AND-composed with every current registry
  contributor (veto semantics — any denial denies, short-circuiting in primary-then-insertion
  order). The composite holds the registry object itself, not a snapshot, so a contributor
  registered during a later extension's `boot()` is enforced immediately, even though the
  controller was already constructed. With zero contributors, behavior is byte-identical to
  the previous unwrapped primary-or-Null policy.

### Fixed
- **`whereIn()`/`whereNotIn()` now work on `update()`/`delete()`.** The write path's condition
  reparser only recognized single-placeholder raw conditions, so `whereIn`'s multi-placeholder
  `col IN (?, ?, …)` was rejected with "Complex WHERE conditions … not yet supported" — even
  though the UPDATE/DELETE builders already emit `IN`/`NOT IN` for array-valued conditions.
  The reparser now recovers the column, operator, and bound values (binding offsets preserved
  when composed with other predicates). `whereIn(col, [])` on a write still throws, as before
  (the always-false raw condition has no simple-map representation).
- **`createTable()` no longer silently discards plain (non-unique) indexes on SQLite and
  PostgreSQL.** Inline `->index(...)` definitions in a create-table callback were only ever
  emitted by the MySQL generator (as inline `KEY` clauses); the SQLite/PostgreSQL generators
  inlined UNIQUE constraints only, so plain indexes vanished without error. `TableBuilder::create()`
  now emits every plain index as a follow-up `CREATE INDEX` statement uniformly across drivers
  (the same artifact kind the `alterTable()` path produces — real and droppable), and the MySQL
  generator no longer inlines plain indexes (unique/fulltext stay inline) so nothing is created
  twice. Existing SQLite/PostgreSQL databases migrated before this fix are missing those indexes;
  re-running the relevant `CREATE INDEX` statements (or re-migrating dev databases) restores them.
  Performance-only: query results were never affected.