### PR TITLE
Enhance event handling, auth key rotation, and HTTP safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,50 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.71.0] - 2026-07-20 — Alcor
+
+**Theme: outbound-webhook security & reliability seams** — three additive, application-agnostic
+building blocks extracted while hardening the commerce marketplace's seller webhooks: a strict
+event-dispatch path that surfaces listener failures instead of swallowing them, a shared SSRF-safe
+outbound-target resolver with a dedicated strict webhook profile, and an API-key rotation that
+returns the successor's identity and can only ever shorten a predecessor's lifetime. No new env
+vars, no migrations, no default changes. One behavioral note for API-key rotation (see Upgrade Notes).
+
+### Added
+- **`EventService::dispatchOrFail()` — strict, at-least-once event dispatch.** Alongside the existing
+  fault-isolating `dispatch()` (which logs and continues past a throwing listener), `dispatchOrFail()`
+  stops at the first failing listener, logs, and rethrows the original exception so the caller's
+  transaction can roll back. `dispatch()` is byte-unchanged — a pure insertion guarded by regression
+  tests; the strict path is opt-in per call site, for events whose delivery is a correctness invariant
+  (e.g. a financial webhook that must not be silently lost). The PSR `EventDispatcherInterface` alias
+  resolves to the concrete `EventDispatcher`, so the strict path is reachable through the container.
+- **`SafeOutboundTargetResolver` + `ResolvedOutboundTarget` (`src/Http/Security/`) — one place that
+  turns a URL into a validated, IP-pinned outbound target.** Two profiles: `resolveSafeFetch()`
+  preserves the exact behavior of the existing `Client::safeRequest*()` SSRF checks (byte-for-byte —
+  existing callers are unaffected), and `resolveWebhook()` applies a stricter third-party-delivery
+  profile: HTTPS only; rejects embedded credentials, fragments, non-default ports, IP-literal hosts,
+  and malformed/ambiguous IDNA; resolves every A/AAAA record and refuses if any resolves into a
+  blocked range (loopback, private, link-local, CGNAT `100.64/10`, and reserved/embedded-v4 IPv6).
+- **`Client::safeWebhookRequestAsync()` — SSRF-safe outbound POST with no TOCTOU window.** Resolves the
+  target exactly once via `resolveWebhook()` and pins the checked IP into the request's resolve map, so
+  the address that was validated is the address that gets connected; redirects are never followed.
+
+### Changed
+- **`ApiKeyService::rotate()` now returns the successor key's `new_uuid`** — an additive field on the
+  returned array, so existing consumers that ignore it are unaffected — and **clamps the predecessor's
+  expiry to `min(existing, now + grace)`** so rotation can only ever shorten a superseded key's life,
+  never extend it (an unparsable/absent existing expiry falls back to `now + grace`). The successor's
+  own expiry is captured before the clamp and is unaffected.
+
+### Upgrade Notes
+- **API-key rotation no longer extends a predecessor's expiry.** Before 1.71.0, rotating a key with a
+  grace window could push a superseded key's `expires_at` later than its original value; it now takes
+  the earlier of the two. If you relied on rotation to lengthen an old key's lifetime, issue a fresh
+  key instead. Otherwise no action is required — the new `new_uuid` field on `rotate()`'s result is
+  purely additive.
+- No new env vars, no migrations, no default changes. The event and HTTP additions are opt-in seams;
+  `dispatch()` and the existing `safeRequest*()` SSRF behavior are byte-identical to 1.70.x.
+
 ## [1.70.0] - 2026-07-16 — Albireo
 
 **Theme: blob-policy composition + two long-standing database fixes** — a registry seam that

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,24 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.71.0 — Alcor (Minor, Released 2026-07-20)
+- **Outbound-webhook security & reliability seams** (extracted while hardening the commerce
+  marketplace's seller webhooks; application-agnostic).
+  - `EventService::dispatchOrFail()` — strict, at-least-once dispatch that stops at the first failing
+    listener and rethrows, so a caller's transaction can roll back. `dispatch()` stays fault-isolating
+    and byte-unchanged.
+  - `SafeOutboundTargetResolver` + `ResolvedOutboundTarget` — one SSRF-safe URL→target resolver with two
+    profiles: `resolveSafeFetch()` (byte-identical to the existing `safeRequest*()` checks) and a stricter
+    `resolveWebhook()` (HTTPS-only; rejects credentials/fragments/non-default-ports/IP-literals/malformed
+    IDNA; resolves every A/AAAA and refuses any blocked range incl. CGNAT `100.64/10`).
+  - `Client::safeWebhookRequestAsync()` — one-resolve-and-pin outbound POST with no TOCTOU window and no
+    redirects.
+  - `ApiKeyService::rotate()` returns the successor `new_uuid` (additive) and clamps a predecessor's
+    expiry to `min(existing, now + grace)` — rotation can only shorten a superseded key, never extend it.
+- Notes: **Minor release** — additive seams plus one behavioral tightening (API-key rotation no longer
+  extends a predecessor's expiry; see CHANGELOG Upgrade Notes); no new env vars, no migrations, no
+  default changes.
+
 ### 1.70.0 — Albireo (Minor, Released 2026-07-16)
 - **Blob-policy composition seam.**
   - `BlobAccessPolicyRegistry` + `CompositeBlobAccessPolicy` — applications and extensions register

--- a/src/Auth/ApiKey/ApiKeyService.php
+++ b/src/Auth/ApiKey/ApiKeyService.php
@@ -179,7 +179,13 @@ final class ApiKeyService
      * Rotate a key with a grace period. Both old and new keys are valid
      * during the grace window.
      *
-     * @return array{old_uuid: string, new_plain: string, old_expires_at: string}
+     * The predecessor's expiry is bounded to the EARLIER of its existing `expires_at` and the
+     * grace deadline (`now + graceHours`) — rotation must never EXTEND a predecessor's expiry.
+     * A null existing expiry is treated as "no earlier bound", so the grace deadline applies.
+     * The successor key is unaffected by this clamp — it inherits `$existing->expires_at` as
+     * captured before the predecessor's expiry is shortened.
+     *
+     * @return array{old_uuid: string, new_uuid: string, new_plain: string, old_expires_at: string}
      */
     public static function rotate(
         ApplicationContext $context,
@@ -202,11 +208,24 @@ final class ApiKeyService
         ], $context);
         $newKey->save();
 
-        $newExpiry = date('Y-m-d H:i:s', time() + ($graceHours * 3600));
+        $graceDeadlineTs = time() + ($graceHours * 3600);
+        $existingExpiresAt = $existing->expires_at ?? null;
+        $existingExpiryTs = is_string($existingExpiresAt) && $existingExpiresAt !== ''
+            ? strtotime($existingExpiresAt)
+            : false;
+
+        // Never extend: if the predecessor already expires sooner than the grace deadline, keep
+        // its earlier expiry. Otherwise (later expiry, or none at all) shorten it to the deadline.
+        $appliedExpiryTs = ($existingExpiryTs !== false && $existingExpiryTs < $graceDeadlineTs)
+            ? $existingExpiryTs
+            : $graceDeadlineTs;
+
+        $newExpiry = date('Y-m-d H:i:s', $appliedExpiryTs);
         $existing->expires_at = $newExpiry;
         $existing->save();
 
-        // Audit: the successor key is created, and the old key's expiry is shortened to the grace window.
+        // Audit: the successor key is created, and the old key's expiry is bounded to the earlier
+        // of its own expiry and the grace deadline.
         self::dispatchEvent($context, new EntityCreatedEvent(self::auditView($newKey), 'api_keys'));
         self::dispatchEvent($context, new EntityUpdatedEvent(
             self::auditView($existing),
@@ -216,6 +235,7 @@ final class ApiKeyService
 
         return [
             'old_uuid'       => $existing->uuid,
+            'new_uuid'       => $newKey->uuid,
             'new_plain'      => $newPlain,
             'old_expires_at' => $newExpiry,
         ];

--- a/src/Events/EventDispatcher.php
+++ b/src/Events/EventDispatcher.php
@@ -67,6 +67,67 @@ final class EventDispatcher implements EventDispatcherInterface
         return $event;
     }
 
+    /**
+     * Strict dispatch: rethrows the ORIGINAL exception from the first listener that throws
+     * (after logging it through the same {@see reportListenerError()} path as {@see dispatch()}),
+     * which stops dispatching — listeners registered after the failing one do not run. Returns
+     * the event unchanged when every listener succeeds.
+     *
+     * Intended for callers that need failure to be observable and re-driveable rather than
+     * fault-isolated — e.g. a durable upstream event store that redelivers on error. This makes
+     * delivery **at-least-once**: a caller may catch the exception and re-dispatch the same
+     * event, so every listener wired to a strictly-dispatched event MUST be idempotent.
+     *
+     * {@see dispatch()} is unaffected and keeps its fault-isolated, always-continues behavior.
+     *
+     * @throws \Throwable the original exception thrown by the first failing listener
+     */
+    public function dispatchOrFail(object $event): object
+    {
+        $listeners = $this->provider->getListenersForEvent($event);
+
+        // Only materialize when tracing to keep hot path lean
+        $materialized = null;
+        if (!$this->tracer instanceof NullEventTracer) {
+            $materialized = is_array($listeners) ? $listeners : iterator_to_array($listeners, false);
+            $this->tracer->startEvent($event::class, count($materialized));
+        }
+
+        try {
+            foreach ($materialized ?? $listeners as $listener) {
+                if ($event instanceof StoppableEventInterface && $event->isPropagationStopped()) {
+                    break;
+                }
+
+                if ($this->tracer instanceof NullEventTracer) {
+                    try {
+                        $listener($event);
+                    } catch (\Throwable $e) {
+                        $this->reportListenerError($event, $e);
+                        throw $e;
+                    }
+                } else {
+                    $start = hrtime(true);
+                    try {
+                        $listener($event);
+                    } catch (\Throwable $e) {
+                        $this->tracer->listenerError($event::class, $listener, $e);
+                        $this->reportListenerError($event, $e);
+                        throw $e;
+                    } finally {
+                        $this->tracer->listenerDone($event::class, $listener, hrtime(true) - $start);
+                    }
+                }
+            }
+        } finally {
+            if (!$this->tracer instanceof NullEventTracer) {
+                $this->tracer->endEvent($event::class);
+            }
+        }
+
+        return $event;
+    }
+
     private function reportListenerError(object $event, \Throwable $e): void
     {
         error_log(sprintf(

--- a/src/Events/EventService.php
+++ b/src/Events/EventService.php
@@ -25,6 +25,33 @@ final class EventService
     }
 
     /**
+     * Strict dispatch: rethrows the ORIGINAL exception from the first listener that fails
+     * (after it has been reported through the same logging path {@see dispatch()} uses), which
+     * stops dispatching — listeners registered after the failing one do not run.
+     *
+     * This is for callers that need a listener failure to be observable and re-driveable rather
+     * than fault-isolated — e.g. a durable event store (payment-provider webhooks/chargebacks)
+     * that redelivers on error. Delivery is therefore **at-least-once**: a caller may catch the
+     * exception and re-dispatch the same event, so every listener wired to a strictly-dispatched
+     * event MUST be idempotent.
+     *
+     * {@see dispatch()} is unaffected and keeps its fault-isolated, always-continues behavior.
+     *
+     * @throws \Throwable the original exception thrown by the first failing listener
+     */
+    public function dispatchOrFail(object $event): object
+    {
+        if (!$this->dispatcher instanceof EventDispatcher) {
+            throw new \LogicException(
+                'EventService::dispatchOrFail() requires the underlying dispatcher to be an instance of '
+                . EventDispatcher::class . ', got ' . get_debug_type($this->dispatcher) . '.'
+            );
+        }
+
+        return $this->dispatcher->dispatchOrFail($event);
+    }
+
+    /**
      * Register a listener.
      * $listener can be:
      *  - callable

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -11,6 +11,7 @@ use Symfony\Component\HttpClient\Retry\GenericRetryStrategy;
 use Symfony\Component\HttpClient\RetryableHttpClient;
 use Glueful\Http\Response\Response;
 use Glueful\Http\Exceptions\HttpClientException;
+use Glueful\Http\Security\SafeOutboundTargetResolver;
 use Glueful\Events\Http\HttpClientFailureEvent;
 use Glueful\Events\EventService;
 use Psr\Log\LoggerInterface;
@@ -26,7 +27,8 @@ class Client
     public function __construct(
         private HttpClientInterface $httpClient,
         private LoggerInterface $logger,
-        private ?ApplicationContext $context = null
+        private ?ApplicationContext $context = null,
+        private SafeOutboundTargetResolver $safeOutboundResolver = new SafeOutboundTargetResolver()
     ) {
     }
 
@@ -101,11 +103,11 @@ class Client
 
         $currentUrl = $url;
         for ($redirects = 0;; $redirects++) {
-            $resolution = $this->assertSafeFetchUrl($currentUrl, $allowPrivateHosts);
+            $resolution = $this->safeOutboundResolver->resolveSafeFetch($currentUrl, $allowPrivateHosts);
 
             $symfonyOptions = $this->transformOptions($options);
             $symfonyOptions['max_redirects'] = 0;
-            $symfonyOptions['resolve'][$resolution['host']] = $resolution['ip'];
+            $symfonyOptions['resolve'][$resolution->host] = $resolution->ip;
 
             try {
                 $response = $this->httpClient->request($method, $currentUrl, $symfonyOptions);
@@ -149,13 +151,40 @@ class Client
         $allowPrivateHosts = (bool) ($options['allow_private_hosts'] ?? false);
         unset($options['max_redirects'], $options['allow_private_hosts']);
 
-        $resolution = $this->assertSafeFetchUrl($url, $allowPrivateHosts);
+        $resolution = $this->safeOutboundResolver->resolveSafeFetch($url, $allowPrivateHosts);
 
         $symfonyOptions = $this->transformOptions($options);
         $symfonyOptions['max_redirects'] = 0;
-        $symfonyOptions['resolve'][$resolution['host']] = $resolution['ip'];
+        $symfonyOptions['resolve'][$resolution->host] = $resolution->ip;
 
         return $this->httpClient->request($method, $url, $symfonyOptions);
+    }
+
+    /**
+     * Start a strictly SSRF-validated request for third-party webhook delivery.
+     *
+     * Unlike safeRequestAsync(), this always enforces the strict webhook profile
+     * (HTTPS only; no credentials/fragment/non-default-port/IP-literal hosts; full
+     * IDNA canonicalization; every resolved A/AAAA address checked). resolveWebhook()
+     * is invoked exactly once, immediately before the request is created, and its
+     * returned {canonicalUrl, host, ip} is installed directly into the resolve map —
+     * there is no separate resolution the connection could race against (no
+     * check-then-second-resolution / DNS-rebinding gap): the address that was
+     * checked is the address that gets pinned. Redirects are never followed.
+     *
+     * @param array<string, mixed> $options
+     */
+    public function safeWebhookRequestAsync(string $method, string $url, array $options = []): ResponseInterface
+    {
+        unset($options['max_redirects'], $options['allow_private_hosts']);
+
+        $resolution = $this->safeOutboundResolver->resolveWebhook($url);
+
+        $symfonyOptions = $this->transformOptions($options);
+        $symfonyOptions['max_redirects'] = 0;
+        $symfonyOptions['resolve'][$resolution->host] = $resolution->ip;
+
+        return $this->httpClient->request($method, $resolution->canonicalUrl, $symfonyOptions);
     }
 
     /**
@@ -226,7 +255,7 @@ class Client
     public function createScopedClient(array $defaultOptions = []): self
     {
         $scopedClient = $this->httpClient->withOptions($defaultOptions);
-        return new self($scopedClient, $this->logger, $this->context);
+        return new self($scopedClient, $this->logger, $this->context, $this->safeOutboundResolver);
     }
 
     /**
@@ -242,7 +271,7 @@ class Client
      */
     public function withHttpClient(HttpClientInterface $httpClient): self
     {
-        return new self($httpClient, $this->logger, $this->context);
+        return new self($httpClient, $this->logger, $this->context, $this->safeOutboundResolver);
     }
 
     /**
@@ -266,7 +295,7 @@ class Client
             maxRetries: $config['max_retries'] ?? 3
         );
 
-        return new self($retrying, $this->logger, $this->context);
+        return new self($retrying, $this->logger, $this->context, $this->safeOutboundResolver);
     }
 
     private function dispatchEvent(object $event): void
@@ -383,85 +412,6 @@ class Client
         }
 
         return $symfonyOptions;
-    }
-
-    /**
-     * Validate a URL for safe fetching and resolve its host for IP pinning.
-     *
-     * With $allowPrivateHosts the private/reserved-range rejection is skipped
-     * (for operator-configured endpoints such as internal health checks); the
-     * scheme allowlist and DNS resolution still apply so the connection can be
-     * pinned to the validated address.
-     *
-     * @return array{host: string, ip: string}
-     */
-    private function assertSafeFetchUrl(string $url, bool $allowPrivateHosts = false): array
-    {
-        $parts = parse_url($url);
-        if ($parts === false) {
-            throw new HttpClientException('Unsafe URL: invalid URL');
-        }
-
-        $scheme = strtolower((string) ($parts['scheme'] ?? ''));
-        if (!in_array($scheme, ['http', 'https'], true)) {
-            throw new HttpClientException('Unsafe URL: only http and https schemes are allowed');
-        }
-
-        $host = strtolower(trim((string) ($parts['host'] ?? ''), "[] \t\n\r\0\x0B"));
-        if ($host === '' || (!$allowPrivateHosts && $host === 'localhost')) {
-            throw new HttpClientException('Unsafe URL: host is not allowed');
-        }
-
-        $ips = $this->resolveHostIps($host);
-        if ($ips === []) {
-            throw new HttpClientException('Unsafe URL: host could not be resolved');
-        }
-
-        if (!$allowPrivateHosts) {
-            foreach ($ips as $ip) {
-                if (
-                    filter_var(
-                        $ip,
-                        FILTER_VALIDATE_IP,
-                        FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
-                    ) === false
-                ) {
-                    throw new HttpClientException('Unsafe URL: host resolves to a private or reserved address');
-                }
-            }
-        }
-
-        return [
-            'host' => $host,
-            'ip' => $ips[0],
-        ];
-    }
-
-    /**
-     * @return array<string>
-     */
-    private function resolveHostIps(string $host): array
-    {
-        if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
-            return [$host];
-        }
-
-        $ips = [];
-        $ipv4 = @gethostbynamel($host);
-        if (is_array($ipv4)) {
-            $ips = array_merge($ips, $ipv4);
-        }
-
-        $aaaa = @dns_get_record($host, DNS_AAAA);
-        if (is_array($aaaa)) {
-            foreach ($aaaa as $record) {
-                if (isset($record['ipv6']) && is_string($record['ipv6'])) {
-                    $ips[] = $record['ipv6'];
-                }
-            }
-        }
-
-        return array_values(array_unique($ips));
     }
 
     private function resolveRedirectUrl(string $baseUrl, string $location): string

--- a/src/Http/Security/ResolvedOutboundTarget.php
+++ b/src/Http/Security/ResolvedOutboundTarget.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Http\Security;
+
+/**
+ * Immutable value object describing a validated, DNS-pinned outbound HTTP target.
+ *
+ * Produced exclusively by SafeOutboundTargetResolver. `host` + `ip` are meant to be
+ * installed into the Symfony HttpClient `resolve` map so the connection is pinned to
+ * the exact address that was checked (closing the DNS-rebinding / TOCTOU gap between
+ * validation and connection), while `canonicalUrl` retains the original hostname so
+ * TLS SNI and certificate verification keep working against that hostname.
+ */
+final class ResolvedOutboundTarget
+{
+    public function __construct(
+        public readonly string $canonicalUrl,
+        public readonly string $host,
+        public readonly int $port,
+        public readonly string $ip
+    ) {
+    }
+}

--- a/src/Http/Security/SafeOutboundTargetResolver.php
+++ b/src/Http/Security/SafeOutboundTargetResolver.php
@@ -32,6 +32,58 @@ final class SafeOutboundTargetResolver
     private const BLOCKED_IP_FLAGS = FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE;
 
     /**
+     * Supplemental IPv4 blocked ranges checked ONLY by resolveWebhook() (belt-and-
+     * suspenders on top of BLOCKED_IP_FLAGS). FILTER_FLAG_NO_PRIV_RANGE and
+     * FILTER_FLAG_NO_RES_RANGE do not cover RFC6598 CGNAT space or several IANA
+     * special-purpose ranges — left open here, a webhook host resolving into one of
+     * them (e.g. 100.64.0.0/10 on CGNAT-routed pod networking) would pass resolution
+     * and connect. resolveSafeFetch() intentionally does NOT use this list — its
+     * blocked-range policy stays exactly BLOCKED_IP_FLAGS, byte-identical to the
+     * pre-extraction Client::assertSafeFetchUrl() behavior.
+     */
+    private const BLOCKED_WEBHOOK_IPV4_CIDRS = [
+        '0.0.0.0/8',        // "this" network
+        '10.0.0.0/8',       // RFC1918 private
+        '100.64.0.0/10',    // RFC6598 CGNAT (shared address space)
+        '127.0.0.0/8',      // loopback
+        '169.254.0.0/16',   // link-local, incl. cloud metadata (169.254.169.254)
+        '172.16.0.0/12',    // RFC1918 private
+        '192.0.0.0/24',     // IANA IETF protocol assignments
+        '192.0.2.0/24',     // TEST-NET-1 documentation
+        '192.168.0.0/16',   // RFC1918 private
+        '198.18.0.0/15',    // RFC2544 benchmarking
+        '198.51.100.0/24',  // TEST-NET-2 documentation
+        '203.0.113.0/24',   // TEST-NET-3 documentation
+        '224.0.0.0/4',      // multicast
+        '240.0.0.0/4',      // reserved for future use
+        '255.255.255.255/32', // limited broadcast
+    ];
+
+    /** Supplemental IPv6 blocked ranges checked ONLY by resolveWebhook() (see above). */
+    private const BLOCKED_WEBHOOK_IPV6_CIDRS = [
+        '::1/128',        // loopback
+        '::/128',          // unspecified
+        '100::/64',        // discard-only
+        '2001:db8::/32',   // documentation
+        'fc00::/7',        // unique local (ULA)
+        'fe80::/10',       // link-local
+    ];
+
+    /**
+     * IPv6 transition ranges that embed an IPv4 address: the resolved address itself
+     * may fall outside BLOCKED_WEBHOOK_IPV6_CIDRS while the address it decodes to is
+     * blocked (e.g. `64:ff9b::7f00:1` is NAT64-wrapped 127.0.0.1). Value is the byte
+     * offset of the embedded 4-byte IPv4 address within the 16-byte IPv6 binary form.
+     *
+     * @var array<string, int>
+     */
+    private const EMBEDDED_IPV4_IPV6_RANGES = [
+        '::ffff:0:0/96' => 12, // IPv4-mapped
+        '64:ff9b::/96' => 12,  // NAT64
+        '2002::/16' => 2,      // 6to4
+    ];
+
+    /**
      * IDNA "dot" look-alike codepoints (ideographic full stop, fullwidth full stop,
      * halfwidth ideographic full stop) that UTS46 silently maps to U+002E during
      * canonicalization. A host containing one of these was not written with a dot
@@ -235,11 +287,128 @@ final class SafeOutboundTargetResolver
     private function rejectIfAnyBlocked(array $ips, string $context = 'safe'): void
     {
         foreach ($ips as $ip) {
-            if (filter_var($ip, FILTER_VALIDATE_IP, self::BLOCKED_IP_FLAGS) === false) {
+            $blocked = filter_var($ip, FILTER_VALIDATE_IP, self::BLOCKED_IP_FLAGS) === false;
+
+            // Supplemental check: webhook only, never applied to resolveSafeFetch().
+            if (!$blocked && $context === 'webhook') {
+                $blocked = $this->isSupplementalBlockedWebhookAddress($ip);
+            }
+
+            if ($blocked) {
                 $prefix = $context === 'webhook' ? 'Unsafe webhook URL' : 'Unsafe URL';
                 throw new HttpClientException($prefix . ': host resolves to a private or reserved address');
             }
         }
+    }
+
+    /**
+     * Belt-and-suspenders check applied only by the webhook profile: covers CGNAT and
+     * IANA special-purpose ranges that BLOCKED_IP_FLAGS leaves open, plus IPv6
+     * transition ranges whose embedded IPv4 address must be decoded and re-checked.
+     */
+    private function isSupplementalBlockedWebhookAddress(string $ip): bool
+    {
+        if (str_contains($ip, ':')) {
+            return $this->isBlockedWebhookIpv6($ip);
+        }
+
+        return $this->isBlockedWebhookIpv4($ip);
+    }
+
+    private function isBlockedWebhookIpv4(string $ip): bool
+    {
+        foreach (self::BLOCKED_WEBHOOK_IPV4_CIDRS as $cidr) {
+            if ($this->ipv4InCidr($ip, $cidr)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isBlockedWebhookIpv6(string $ip): bool
+    {
+        foreach (self::BLOCKED_WEBHOOK_IPV6_CIDRS as $cidr) {
+            if ($this->ipv6InCidr($ip, $cidr)) {
+                return true;
+            }
+        }
+
+        foreach (self::EMBEDDED_IPV4_IPV6_RANGES as $cidr => $byteOffset) {
+            if (!$this->ipv6InCidr($ip, $cidr)) {
+                continue;
+            }
+
+            $embedded = $this->extractEmbeddedIpv4($ip, $byteOffset);
+
+            return $embedded === null || $this->isBlockedWebhookIpv4($embedded);
+        }
+
+        return false;
+    }
+
+    /**
+     * Decodes the 4-byte IPv4 address embedded at $byteOffset within an IPv6
+     * transition-range address (IPv4-mapped, NAT64, or 6to4).
+     */
+    private function extractEmbeddedIpv4(string $ip, int $byteOffset): ?string
+    {
+        $binary = @inet_pton($ip);
+        if ($binary === false || strlen($binary) !== 16) {
+            return null;
+        }
+
+        $embedded = @inet_ntop(substr($binary, $byteOffset, 4));
+
+        return $embedded === false ? null : $embedded;
+    }
+
+    /**
+     * IPv4 CIDR-membership check via ip2long() + bitmask comparison.
+     */
+    private function ipv4InCidr(string $ip, string $cidr): bool
+    {
+        [$subnet, $prefixPart] = explode('/', $cidr, 2);
+        $prefix = (int) $prefixPart;
+
+        $ipLong = ip2long($ip);
+        $subnetLong = ip2long($subnet);
+        if ($ipLong === false || $subnetLong === false) {
+            return false;
+        }
+
+        $mask = $prefix === 0 ? 0 : ((~0 << (32 - $prefix)) & 0xFFFFFFFF);
+
+        return ($ipLong & $mask) === ($subnetLong & $mask);
+    }
+
+    /**
+     * IPv6 CIDR-membership check via inet_pton() + byte-prefix comparison.
+     */
+    private function ipv6InCidr(string $ip, string $cidr): bool
+    {
+        [$subnet, $prefixPart] = explode('/', $cidr, 2);
+        $prefix = (int) $prefixPart;
+
+        $ipBin = @inet_pton($ip);
+        $subnetBin = @inet_pton($subnet);
+        if ($ipBin === false || $subnetBin === false || strlen($ipBin) !== 16 || strlen($subnetBin) !== 16) {
+            return false;
+        }
+
+        $fullBytes = intdiv($prefix, 8);
+        if ($fullBytes > 0 && substr($ipBin, 0, $fullBytes) !== substr($subnetBin, 0, $fullBytes)) {
+            return false;
+        }
+
+        $remainingBits = $prefix % 8;
+        if ($remainingBits === 0) {
+            return true;
+        }
+
+        $mask = (0xFF << (8 - $remainingBits)) & 0xFF;
+
+        return (ord($ipBin[$fullBytes]) & $mask) === (ord($subnetBin[$fullBytes]) & $mask);
     }
 
     /**

--- a/src/Http/Security/SafeOutboundTargetResolver.php
+++ b/src/Http/Security/SafeOutboundTargetResolver.php
@@ -1,0 +1,279 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Http\Security;
+
+use Glueful\Http\Exceptions\HttpClientException;
+
+/**
+ * SSRF-safe outbound target resolution — the single policy for validating and
+ * DNS-pinning outbound HTTP(S) targets.
+ *
+ * Exposes two explicit profiles over one shared parse/canonicalize/resolve/reject
+ * core so the blocked-range policy can never drift between callers:
+ *
+ * - resolveSafeFetch(): the historical `Client::assertSafeFetchUrl()` behavior
+ *   (http/https, optional allow-private-hosts override for operator-configured
+ *   endpoints), preserved byte-for-byte for `Client::safeRequest()`/`safeRequestAsync()`.
+ * - resolveWebhook(): a strict profile for third-party webhook delivery — HTTPS
+ *   only, no credentials/fragment/non-default-port/IP-literal hosts, IDNA
+ *   canonicalization with malformed/ambiguous-encoding rejection, and rejection if
+ *   ANY resolved A/AAAA address falls in blocked space. Owns its own host
+ *   canonicalization; it does not depend on any tenancy `HostNormalizer`.
+ *
+ * Both profiles resolve every A and AAAA record for the host and reject the target
+ * if ANY resolved address is private/loopback/link-local/metadata/reserved (IPv4 or
+ * IPv6) — this all-addresses check is what makes the pinned `resolve[host] = ip`
+ * connection safe against a host that resolves to more than one address.
+ */
+final class SafeOutboundTargetResolver
+{
+    private const BLOCKED_IP_FLAGS = FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE;
+
+    /**
+     * IDNA "dot" look-alike codepoints (ideographic full stop, fullwidth full stop,
+     * halfwidth ideographic full stop) that UTS46 silently maps to U+002E during
+     * canonicalization. A host containing one of these was not written with a dot
+     * by whoever supplied it but resolves as though it were — rejected outright
+     * rather than trusted to canonicalize predictably.
+     */
+    private const IDNA_DOT_LOOKALIKES = ["\u{3002}", "\u{FF0E}", "\u{FF61}"];
+
+    private const IDNA_FLAGS = IDNA_DEFAULT
+        | IDNA_USE_STD3_RULES
+        | IDNA_CHECK_BIDI
+        | IDNA_CHECK_CONTEXTJ
+        | IDNA_NONTRANSITIONAL_TO_ASCII;
+
+    /**
+     * @param (\Closure(string): list<string>)|null $dnsLookup Test seam only: overrides system DNS
+     *        resolution (gethostbynamel()/dns_get_record()) with a caller-supplied A/AAAA lookup
+     *        for a given host. Production callers should leave this null.
+     */
+    public function __construct(private readonly ?\Closure $dnsLookup = null)
+    {
+    }
+
+    /**
+     * Preserves `Client::assertSafeFetchUrl()`'s historical behavior byte-for-byte:
+     * http/https only; `localhost` and private/reserved ranges rejected unless
+     * $allowPrivateHosts is set (for operator-configured internal endpoints, e.g.
+     * internal health checks); every resolved A/AAAA address is checked; the first
+     * resolved address is pinned.
+     *
+     * @throws HttpClientException when the URL, scheme, host, or resolved address(es) are unsafe
+     */
+    public function resolveSafeFetch(string $url, bool $allowPrivateHosts = false): ResolvedOutboundTarget
+    {
+        $parts = parse_url($url);
+        if ($parts === false) {
+            throw new HttpClientException('Unsafe URL: invalid URL');
+        }
+
+        $scheme = strtolower((string) ($parts['scheme'] ?? ''));
+        if (!in_array($scheme, ['http', 'https'], true)) {
+            throw new HttpClientException('Unsafe URL: only http and https schemes are allowed');
+        }
+
+        $host = strtolower(trim((string) ($parts['host'] ?? ''), "[] \t\n\r\0\x0B"));
+        if ($host === '' || (!$allowPrivateHosts && $host === 'localhost')) {
+            throw new HttpClientException('Unsafe URL: host is not allowed');
+        }
+
+        $ips = $this->resolveHostIps($host);
+        if ($ips === []) {
+            throw new HttpClientException('Unsafe URL: host could not be resolved');
+        }
+
+        if (!$allowPrivateHosts) {
+            $this->rejectIfAnyBlocked($ips);
+        }
+
+        $port = $parts['port'] ?? ($scheme === 'https' ? 443 : 80);
+
+        return new ResolvedOutboundTarget(
+            canonicalUrl: $url,
+            host: $host,
+            port: $port,
+            ip: $ips[0]
+        );
+    }
+
+    /**
+     * Strict profile for third-party webhook delivery. Requires HTTPS, rejects
+     * credentials, fragments, non-default ports, and IP-literal hosts, canonicalizes
+     * the host via IDNA/UTS46 (rejecting malformed labels and ambiguous encodings),
+     * and rejects the target if ANY resolved A/AAAA address is blocked space.
+     *
+     * @throws HttpClientException when the URL, scheme, host, or resolved address(es) are unsafe
+     */
+    public function resolveWebhook(string $url): ResolvedOutboundTarget
+    {
+        $parts = $this->parseUrlSafely($url);
+        if ($parts === false) {
+            throw new HttpClientException('Unsafe webhook URL: invalid URL');
+        }
+
+        $scheme = strtolower((string) ($parts['scheme'] ?? ''));
+        if ($scheme !== 'https') {
+            throw new HttpClientException('Unsafe webhook URL: only https is allowed');
+        }
+
+        if (isset($parts['user']) || isset($parts['pass'])) {
+            throw new HttpClientException('Unsafe webhook URL: credentials are not allowed');
+        }
+
+        if (isset($parts['fragment'])) {
+            throw new HttpClientException('Unsafe webhook URL: fragment is not allowed');
+        }
+
+        $port = $parts['port'] ?? null;
+        if ($port !== null && $port !== 443) {
+            throw new HttpClientException('Unsafe webhook URL: only the default HTTPS port is allowed');
+        }
+
+        $rawHost = (string) ($parts['host'] ?? '');
+        if ($rawHost === '') {
+            throw new HttpClientException('Unsafe webhook URL: host is not allowed');
+        }
+
+        $bracketed = str_starts_with($rawHost, '[') && str_ends_with($rawHost, ']');
+        $hostForIpCheck = $bracketed ? substr($rawHost, 1, -1) : $rawHost;
+        if ($bracketed || filter_var($hostForIpCheck, FILTER_VALIDATE_IP) !== false) {
+            throw new HttpClientException('Unsafe webhook URL: IP-literal hosts are not allowed');
+        }
+
+        $asciiHost = $this->canonicalizeIdnaHost(strtolower($rawHost));
+
+        $ips = $this->resolveHostIps($asciiHost);
+        if ($ips === []) {
+            throw new HttpClientException('Unsafe webhook URL: host could not be resolved');
+        }
+
+        $this->rejectIfAnyBlocked($ips, 'webhook');
+
+        $path = (string) ($parts['path'] ?? '');
+        $query = isset($parts['query']) ? '?' . $parts['query'] : '';
+
+        return new ResolvedOutboundTarget(
+            canonicalUrl: 'https://' . $asciiHost . $path . $query,
+            host: $asciiHost,
+            port: 443,
+            ip: $ips[0]
+        );
+    }
+
+    /**
+     * PHP's parse_url() has a long-standing parser quirk where certain multi-byte
+     * UTF-8 sequences in the host component get silently corrupted (specific
+     * continuation bytes replaced) rather than passed through — which would let a
+     * hand-crafted IDN host slip past canonicalization as mangled bytes instead of
+     * being properly rejected or converted. Percent-encoding every non-ASCII byte
+     * before parsing — parse_url is byte-safe for a purely-ASCII string — and then
+     * decoding just the extracted host afterward sidesteps the corruption so an IDN
+     * host is inspected exactly as the caller supplied it.
+     *
+     * @return array<string, int|string>|false
+     */
+    private function parseUrlSafely(string $url): array|false
+    {
+        $asciiUrl = preg_replace_callback(
+            '/[\x80-\xFF]/',
+            static fn(array $m): string => rawurlencode($m[0]),
+            $url
+        );
+
+        $parts = parse_url($asciiUrl ?? $url);
+        if ($parts === false) {
+            return false;
+        }
+
+        if (isset($parts['host']) && is_string($parts['host'])) {
+            $parts['host'] = rawurldecode($parts['host']);
+        }
+
+        return $parts;
+    }
+
+    /**
+     * IDNA/UTS46 canonicalization with rejection of malformed labels, deviant-
+     * processing ambiguity, and dot-lookalike codepoints that UTS46 would silently
+     * fold into label separators.
+     *
+     * @throws HttpClientException when the host is malformed or its encoding is ambiguous
+     */
+    private function canonicalizeIdnaHost(string $host): string
+    {
+        foreach (self::IDNA_DOT_LOOKALIKES as $lookalike) {
+            if (str_contains($host, $lookalike)) {
+                throw new HttpClientException('Unsafe webhook URL: ambiguous host encoding');
+            }
+        }
+
+        $info = [];
+        $ascii = idn_to_ascii($host, self::IDNA_FLAGS, INTL_IDNA_VARIANT_UTS46, $info);
+        if (!is_string($ascii) || ($info['errors'] ?? 0) !== 0) {
+            throw new HttpClientException('Unsafe webhook URL: malformed international domain name');
+        }
+
+        // Idempotency guard: a canonical ASCII host must be stable under re-canonicalization,
+        // otherwise the original input was an ambiguous encoding of more than one host.
+        $reinfo = [];
+        $reascii = idn_to_ascii($ascii, self::IDNA_FLAGS, INTL_IDNA_VARIANT_UTS46, $reinfo);
+        if ($reascii !== $ascii || ($reinfo['errors'] ?? 0) !== 0) {
+            throw new HttpClientException('Unsafe webhook URL: ambiguous host encoding');
+        }
+
+        return $ascii;
+    }
+
+    /**
+     * @param list<string> $ips
+     * @throws HttpClientException when any address is private/loopback/link-local/metadata/reserved
+     */
+    private function rejectIfAnyBlocked(array $ips, string $context = 'safe'): void
+    {
+        foreach ($ips as $ip) {
+            if (filter_var($ip, FILTER_VALIDATE_IP, self::BLOCKED_IP_FLAGS) === false) {
+                $prefix = $context === 'webhook' ? 'Unsafe webhook URL' : 'Unsafe URL';
+                throw new HttpClientException($prefix . ': host resolves to a private or reserved address');
+            }
+        }
+    }
+
+    /**
+     * Resolve every A and AAAA record for a host (or return the literal address for
+     * an IP-literal host). Shared by both profiles so the resolution step — and the
+     * blocked-range check applied to its result — never drifts between them.
+     *
+     * @return list<string>
+     */
+    private function resolveHostIps(string $host): array
+    {
+        if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
+            return [$host];
+        }
+
+        if ($this->dnsLookup !== null) {
+            return array_values(array_unique(($this->dnsLookup)($host)));
+        }
+
+        $ips = [];
+        $ipv4 = @gethostbynamel($host);
+        if (is_array($ipv4)) {
+            $ips = array_merge($ips, $ipv4);
+        }
+
+        $aaaa = @dns_get_record($host, DNS_AAAA);
+        if (is_array($aaaa)) {
+            foreach ($aaaa as $record) {
+                if (isset($record['ipv6']) && is_string($record['ipv6'])) {
+                    $ips[] = $record['ipv6'];
+                }
+            }
+        }
+
+        return array_values(array_unique($ips));
+    }
+}

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,15 +13,15 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.70.0';
+    public const VERSION = '1.71.0';
 
 
     /** Release code name */
-    public const NAME = 'Albireo';
+    public const NAME = 'Alcor';
 
 
     /** Release date */
-    public const RELEASE_DATE = '2026-07-16';
+    public const RELEASE_DATE = '2026-07-20';
 
     /** Minimum required PHP version */
     public const MIN_PHP_VERSION = '8.3.0';

--- a/tests/Integration/Auth/ApiKeyAuthenticationTest.php
+++ b/tests/Integration/Auth/ApiKeyAuthenticationTest.php
@@ -95,6 +95,75 @@ class ApiKeyAuthenticationTest extends TestCase
         $this->assertNotNull(ApiKeyService::verify($this->context, $original['plain'], '1.2.3.4'));
     }
 
+    public function testRotateReturnsNewUuidMatchingSuccessorKey(): void
+    {
+        $original = ApiKeyService::create($this->context, ['user_uuid' => 'u-abc12345abcd', 'name' => 'O']);
+        $rotation = ApiKeyService::rotate($this->context, $original['key'], graceHours: 24);
+
+        $this->assertArrayHasKey('new_uuid', $rotation);
+        $successor = ApiKeyService::verify($this->context, $rotation['new_plain'], '1.2.3.4');
+        $this->assertSame($successor->uuid, $rotation['new_uuid']);
+        $this->assertNotSame($rotation['old_uuid'], $rotation['new_uuid']);
+    }
+
+    public function testRotateNeverExtendsAnEarlierPredecessorExpiry(): void
+    {
+        // Existing key already expires sooner (1h) than the grace deadline (24h) would put it.
+        $earlierExpiry = date('Y-m-d H:i:s', time() + 3600);
+        $original = ApiKeyService::create($this->context, [
+            'user_uuid'  => 'u-abc12345abcd',
+            'name'       => 'Soon',
+            'expires_at' => $earlierExpiry,
+        ]);
+
+        $rotation = ApiKeyService::rotate($this->context, $original['key'], graceHours: 24);
+
+        // The predecessor's own (earlier) expiry must be preserved, not extended to now+24h.
+        $this->assertSame($earlierExpiry, $rotation['old_expires_at']);
+
+        // Both keys are still valid right now — the predecessor has not been extended AND has not expired yet.
+        $this->assertNotNull(ApiKeyService::verify($this->context, $original['plain'], '1.2.3.4'));
+        $this->assertNotNull(ApiKeyService::verify($this->context, $rotation['new_plain'], '1.2.3.4'));
+    }
+
+    public function testRotateShortensLaterPredecessorExpiryToGraceDeadlineWithoutClampingSuccessor(): void
+    {
+        // Existing key expires far later (100h) than the grace deadline (24h) — must be shortened.
+        $laterExpiry = date('Y-m-d H:i:s', time() + (100 * 3600));
+        $original = ApiKeyService::create($this->context, [
+            'user_uuid'  => 'u-abc12345abcd',
+            'name'       => 'Later',
+            'expires_at' => $laterExpiry,
+        ]);
+
+        $graceDeadline = time() + (24 * 3600);
+        $rotation = ApiKeyService::rotate($this->context, $original['key'], graceHours: 24);
+
+        $appliedTs = strtotime($rotation['old_expires_at']);
+        $this->assertIsInt($appliedTs);
+        $this->assertLessThanOrEqual(5, abs($appliedTs - $graceDeadline), 'predecessor expiry not shortened to grace deadline');
+
+        // The successor inherits the ORIGINAL (unshortened) expiry — it is not clamped by the
+        // predecessor's shortening.
+        $successor = ApiKeyService::verify($this->context, $rotation['new_plain'], '1.2.3.4');
+        $this->assertSame($laterExpiry, $successor->expires_at);
+    }
+
+    public function testRotateWithNoOriginalExpiryShortensToGraceDeadlineAndBothKeysVerify(): void
+    {
+        $original = ApiKeyService::create($this->context, ['user_uuid' => 'u-abc12345abcd', 'name' => 'NoExpiry']);
+
+        $graceDeadline = time() + (24 * 3600);
+        $rotation = ApiKeyService::rotate($this->context, $original['key'], graceHours: 24);
+
+        $appliedTs = strtotime($rotation['old_expires_at']);
+        $this->assertIsInt($appliedTs);
+        $this->assertLessThanOrEqual(5, abs($appliedTs - $graceDeadline), 'null predecessor expiry not set to grace deadline');
+
+        $this->assertNotNull(ApiKeyService::verify($this->context, $original['plain'], '1.2.3.4'));
+        $this->assertNotNull(ApiKeyService::verify($this->context, $rotation['new_plain'], '1.2.3.4'));
+    }
+
     public function testRevokedKeyFailsVerify(): void
     {
         $result = ApiKeyService::create($this->context, ['user_uuid' => 'u-abc12345abcd', 'name' => 'Doomed']);

--- a/tests/Unit/Events/EventDispatcherTest.php
+++ b/tests/Unit/Events/EventDispatcherTest.php
@@ -6,8 +6,10 @@ namespace Glueful\Tests\Unit\Events;
 
 use Glueful\Events\EventDispatcher;
 use Glueful\Events\Listeners\ActivityLoggingSubscriber;
+use Glueful\Events\Tracing\EventTracerInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\ListenerProviderInterface;
+use Psr\EventDispatcher\StoppableEventInterface;
 
 final class EventDispatcherTest extends TestCase
 {
@@ -56,5 +58,224 @@ final class EventDispatcherTest extends TestCase
         // the whole subscriber fail to build. It now falls back to the singleton.
         $subscriber = new ActivityLoggingSubscriber();
         self::assertInstanceOf(ActivityLoggingSubscriber::class, $subscriber);
+    }
+
+    /**
+     * dispatchOrFail() is the strict counterpart used by durable-delivery callers (e.g. a
+     * payment-provider event store that needs to redeliver on failure): the FIRST throwing
+     * listener's ORIGINAL exception must propagate out, and any listener registered after it
+     * must not run.
+     */
+    public function testDispatchOrFailRethrowsTheOriginalExceptionAndStopsSubsequentListeners(): void
+    {
+        $ran = [];
+        $original = new \RuntimeException('listener boom');
+        $listeners = [
+            static function (object $e) use ($original): void {
+                throw $original;
+            },
+            function (object $e) use (&$ran): void {
+                $ran[] = 'second';
+            },
+        ];
+
+        $dispatcher = new EventDispatcher($this->providerFor($listeners));
+        $event = new \stdClass();
+
+        try {
+            $dispatcher->dispatchOrFail($event);
+            self::fail('Expected the listener exception to propagate.');
+        } catch (\RuntimeException $caught) {
+            self::assertSame($original, $caught, 'The ORIGINAL exception instance must propagate, not a wrapper.');
+            self::assertSame('listener boom', $caught->getMessage());
+        }
+
+        self::assertSame([], $ran, 'A listener registered after the throwing one must not run.');
+    }
+
+    /**
+     * The failure must still go through the same reporting path dispatch() uses
+     * (reportListenerError() -> error_log()) before it is rethrown.
+     */
+    public function testDispatchOrFailStillReportsTheFailureBeforeRethrowing(): void
+    {
+        $listeners = [
+            static function (object $e): void {
+                throw new \RuntimeException('listener boom');
+            },
+        ];
+
+        $dispatcher = new EventDispatcher($this->providerFor($listeners));
+        $event = new \stdClass();
+
+        $tmp = tempnam(sys_get_temp_dir(), 'glueful-events-');
+        $prevLog = ini_set('error_log', $tmp);
+        try {
+            try {
+                $dispatcher->dispatchOrFail($event);
+                self::fail('Expected the listener exception to propagate.');
+            } catch (\RuntimeException $e) {
+                // expected — assertions happen below on the log file
+            }
+
+            $logged = (string) file_get_contents($tmp);
+            self::assertStringContainsString('Event listener failed for stdClass', $logged);
+            self::assertStringContainsString('listener boom', $logged);
+        } finally {
+            ini_set('error_log', $prevLog);
+            @unlink($tmp);
+        }
+    }
+
+    /**
+     * Regression guard: the exact same event + throwing-then-clean listener pair must still be
+     * fault-isolated under plain dispatch() — dispatchOrFail() must not have changed dispatch().
+     */
+    public function testDispatchStillSwallowsAndContinuesForTheSameListenersThatDispatchOrFailRejects(): void
+    {
+        $ranDispatch = [];
+        $listenersForDispatch = [
+            static function (object $e): void {
+                throw new \RuntimeException('listener boom');
+            },
+            function (object $e) use (&$ranDispatch): void {
+                $ranDispatch[] = 'second';
+            },
+        ];
+
+        $dispatcher = new EventDispatcher($this->providerFor($listenersForDispatch));
+        $event = new \stdClass();
+
+        $result = $dispatcher->dispatch($event);
+
+        self::assertSame($event, $result, 'dispatch() must still return the event, not throw.');
+        self::assertSame(['second'], $ranDispatch, 'dispatch() must still fault-isolate and continue.');
+    }
+
+    public function testDispatchOrFailReturnsTheEventWhenAllListenersSucceed(): void
+    {
+        $ran = [];
+        $listeners = [
+            function (object $e) use (&$ran): void {
+                $ran[] = 'first';
+            },
+            function (object $e) use (&$ran): void {
+                $ran[] = 'second';
+            },
+        ];
+
+        $dispatcher = new EventDispatcher($this->providerFor($listeners));
+        $event = new \stdClass();
+
+        $result = $dispatcher->dispatchOrFail($event);
+
+        self::assertSame($event, $result);
+        self::assertSame(['first', 'second'], $ran);
+    }
+
+    public function testDispatchOrFailHonorsStoppablePropagationShortCircuit(): void
+    {
+        $ran = [];
+        $event = new class implements StoppableEventInterface {
+            private bool $stopped = false;
+
+            public function stop(): void
+            {
+                $this->stopped = true;
+            }
+
+            public function isPropagationStopped(): bool
+            {
+                return $this->stopped;
+            }
+        };
+
+        $listeners = [
+            function (object $e) use (&$ran): void {
+                $ran[] = 'first';
+                $e->stop();
+            },
+            function (object $e) use (&$ran): void {
+                $ran[] = 'second'; // must not run: propagation was stopped by the first listener
+            },
+        ];
+
+        $dispatcher = new EventDispatcher($this->providerFor($listeners));
+
+        $result = $dispatcher->dispatchOrFail($event);
+
+        self::assertSame($event, $result);
+        self::assertSame(['first'], $ran, 'A listener must not run once propagation has been stopped.');
+    }
+
+    public function testDispatchOrFailInvokesTracerHooksLikeDispatch(): void
+    {
+        $tracer = new class implements EventTracerInterface {
+            /** @var list<string> */
+            public array $calls = [];
+            public ?\Throwable $reportedError = null;
+
+            public function startEvent(string $eventClass, int $listenerCount): void
+            {
+                $this->calls[] = "start:{$eventClass}:{$listenerCount}";
+            }
+
+            public function listenerDone(string $eventClass, callable $listener, int $durationNs): void
+            {
+                $this->calls[] = 'done';
+            }
+
+            public function listenerError(string $eventClass, callable $listener, \Throwable $e): void
+            {
+                $this->calls[] = 'error';
+                $this->reportedError = $e;
+            }
+
+            public function endEvent(string $eventClass): void
+            {
+                $this->calls[] = 'end';
+            }
+        };
+
+        $original = new \RuntimeException('listener boom');
+        $listeners = [
+            static function (object $e) use ($original): void {
+                throw $original;
+            },
+            function (object $e): void {
+                self::fail('Must not run: dispatchOrFail should have stopped after the failure.');
+            },
+        ];
+
+        $dispatcher = new EventDispatcher($this->providerFor($listeners), $tracer);
+        $event = new \stdClass();
+
+        try {
+            $dispatcher->dispatchOrFail($event);
+            self::fail('Expected the listener exception to propagate.');
+        } catch (\RuntimeException $e) {
+            self::assertSame($original, $e);
+        }
+
+        self::assertSame($original, $tracer->reportedError);
+        self::assertSame(['start:stdClass:2', 'error', 'done', 'end'], $tracer->calls);
+    }
+
+    /**
+     * @param list<callable> $listeners
+     */
+    private function providerFor(array $listeners): ListenerProviderInterface
+    {
+        return new class ($listeners) implements ListenerProviderInterface {
+            /** @param list<callable> $listeners */
+            public function __construct(private array $listeners)
+            {
+            }
+
+            public function getListenersForEvent(object $event): iterable
+            {
+                return $this->listeners;
+            }
+        };
     }
 }

--- a/tests/Unit/Events/EventServiceTest.php
+++ b/tests/Unit/Events/EventServiceTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Events;
+
+use Glueful\Events\EventDispatcher;
+use Glueful\Events\EventService;
+use Glueful\Events\ListenerProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
+
+final class EventServiceTest extends TestCase
+{
+    /**
+     * dispatchOrFail() must delegate to the concrete EventDispatcher's strict path: the first
+     * listener's ORIGINAL exception propagates and a later listener never runs.
+     */
+    public function testDispatchOrFailDelegatesToTheConcreteEventDispatcherAndRethrowsListenerFailures(): void
+    {
+        $provider = new ListenerProvider();
+        $dispatcher = new EventDispatcher($provider);
+        $service = new EventService($dispatcher, $provider);
+
+        $original = new \RuntimeException('listener boom');
+        $ranAfter = false;
+        $provider->addListener(\stdClass::class, static function () use ($original): void {
+            throw $original;
+        });
+        $provider->addListener(\stdClass::class, function () use (&$ranAfter): void {
+            $ranAfter = true;
+        });
+
+        $event = new \stdClass();
+
+        try {
+            $service->dispatchOrFail($event);
+            self::fail('Expected the listener exception to propagate.');
+        } catch (\RuntimeException $caught) {
+            self::assertSame($original, $caught);
+        }
+
+        self::assertFalse($ranAfter, 'A listener registered after the throwing one must not run.');
+    }
+
+    public function testDispatchOrFailReturnsTheEventWhenAllListenersSucceed(): void
+    {
+        $provider = new ListenerProvider();
+        $dispatcher = new EventDispatcher($provider);
+        $service = new EventService($dispatcher, $provider);
+
+        $event = new \stdClass();
+
+        $result = $service->dispatchOrFail($event);
+
+        self::assertSame($event, $result);
+    }
+
+    /**
+     * EventService's constructor keeps the PSR EventDispatcherInterface type (not downgraded to
+     * the concrete class). dispatchOrFail() must fail closed — cleanly and without invoking the
+     * underlying dispatcher at all — when that interface isn't backed by the concrete
+     * EventDispatcher that actually implements the strict path.
+     */
+    public function testDispatchOrFailRefusesAnUnderlyingDispatcherThatCannotDispatchStrictly(): void
+    {
+        $provider = new ListenerProvider();
+        $fakeDispatcher = new class implements EventDispatcherInterface {
+            public bool $called = false;
+
+            public function dispatch(object $event): object
+            {
+                $this->called = true;
+                return $event;
+            }
+        };
+
+        $service = new EventService($fakeDispatcher, $provider);
+
+        $this->expectException(\LogicException::class);
+
+        try {
+            $service->dispatchOrFail(new \stdClass());
+        } finally {
+            self::assertFalse($fakeDispatcher->called, 'The fake dispatcher must not be invoked at all.');
+        }
+    }
+
+    /**
+     * Regression guard: dispatch() must remain the fault-isolated, always-continues path,
+     * unaffected by the addition of dispatchOrFail().
+     */
+    public function testDispatchStillDelegatesNormallyAndIsUnaffectedByDispatchOrFail(): void
+    {
+        $provider = new ListenerProvider();
+        $dispatcher = new EventDispatcher($provider);
+        $service = new EventService($dispatcher, $provider);
+
+        $ran = [];
+        $provider->addListener(\stdClass::class, static function () use (&$ran): void {
+            throw new \RuntimeException('listener boom');
+        });
+        $provider->addListener(\stdClass::class, function () use (&$ran): void {
+            $ran[] = 'second';
+        });
+
+        $event = new \stdClass();
+        $result = $service->dispatch($event);
+
+        self::assertSame($event, $result);
+        self::assertSame(['second'], $ran);
+    }
+}

--- a/tests/Unit/Http/ClientSafeWebhookRequestAsyncTest.php
+++ b/tests/Unit/Http/ClientSafeWebhookRequestAsyncTest.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Http;
+
+use Glueful\Http\Client;
+use Glueful\Http\Exceptions\HttpClientException;
+use Glueful\Http\Security\SafeOutboundTargetResolver;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\HttpClient\ResponseStreamInterface;
+
+/**
+ * Client::safeWebhookRequestAsync() is the strict-profile counterpart to
+ * safeRequestAsync(): it must call SafeOutboundTargetResolver::resolveWebhook()
+ * exactly once, install the exact resolved address into the resolve map (no
+ * check-then-second-resolution / DNS-rebinding gap), request the canonicalized
+ * (IDNA-ASCII) URL so the resolve-map host matches the request's host, and never
+ * follow redirects.
+ */
+final class ClientSafeWebhookRequestAsyncTest extends TestCase
+{
+    public function testResolvesOnceAndPinsExactResolvedAddress(): void
+    {
+        $dnsCalls = 0;
+        $resolver = new SafeOutboundTargetResolver(function (string $host) use (&$dnsCalls): array {
+            $dnsCalls++;
+            $this->assertSame('seller.example.test', $host);
+            return ['93.184.216.34'];
+        });
+
+        $fake = $this->capturingClient();
+        $client = new Client($fake, new NullLogger(), null, $resolver);
+
+        $response = $client->safeWebhookRequestAsync(
+            'POST',
+            'https://seller.example.test/hooks/orders',
+            ['json' => ['event' => 'order.paid']]
+        );
+
+        $this->assertSame(1, $dnsCalls, 'resolveWebhook must resolve DNS exactly once per call');
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(
+            ['seller.example.test' => '93.184.216.34'],
+            $fake->captured['resolve'] ?? null
+        );
+        $this->assertSame(0, $fake->captured['max_redirects'] ?? null);
+        $this->assertSame('https://seller.example.test/hooks/orders', $fake->capturedUrl);
+        $this->assertSame(['event' => 'order.paid'], $fake->captured['json'] ?? null);
+    }
+
+    public function testRequestsTheCanonicalAsciiUrlSoResolveMapHostMatches(): void
+    {
+        $resolver = new SafeOutboundTargetResolver(function (string $host): array {
+            return ['93.184.216.34'];
+        });
+
+        $fake = $this->capturingClient();
+        $client = new Client($fake, new NullLogger(), null, $resolver);
+
+        // "例え" (Japanese) IDN host — the request MUST go out against the
+        // punycode-canonicalized host, otherwise the resolve[] map (keyed by the
+        // ASCII host) would not match the request URL's host and pinning would
+        // silently not apply.
+        $client->safeWebhookRequestAsync('POST', "https://\u{4F8B}\u{3048}.example.test/hooks");
+
+        $this->assertSame('xn--r8jz45g.example.test', array_key_first($fake->captured['resolve'] ?? []));
+        $this->assertSame('https://xn--r8jz45g.example.test/hooks', $fake->capturedUrl);
+    }
+
+    public function testRejectsHttpBeforeIssuingAnyRequest(): void
+    {
+        $fake = $this->capturingClient();
+        $client = new Client($fake, new NullLogger());
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('only https is allowed');
+
+        try {
+            $client->safeWebhookRequestAsync('POST', 'http://seller.example.test/hooks');
+        } finally {
+            $this->assertSame([], $fake->captured, 'no request should be sent when validation fails');
+        }
+    }
+
+    public function testRejectsWhenResolvedAddressIsPrivateEvenIfHostLooksPublic(): void
+    {
+        // Simulates a DNS-rebind / TOCTOU scenario: the endpoint was public at
+        // registration time but resolves to a private address at delivery time.
+        // Because there is only one resolution point, this is caught right here.
+        $resolver = new SafeOutboundTargetResolver(function (string $host): array {
+            return ['10.0.0.5'];
+        });
+
+        $fake = $this->capturingClient();
+        $client = new Client($fake, new NullLogger(), null, $resolver);
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('private or reserved');
+
+        try {
+            $client->safeWebhookRequestAsync('POST', 'https://seller.example.test/hooks');
+        } finally {
+            $this->assertSame([], $fake->captured);
+        }
+    }
+
+    public function testDoesNotFollowRedirects(): void
+    {
+        $resolver = new SafeOutboundTargetResolver(function (string $host): array {
+            return ['93.184.216.34'];
+        });
+
+        $fake = $this->redirectingClient('https://attacker.example.test/steal');
+        $client = new Client($fake, new NullLogger(), null, $resolver);
+
+        $response = $client->safeWebhookRequestAsync('POST', 'https://seller.example.test/hooks');
+
+        $this->assertSame(1, $fake->requestCount, 'exactly one request should be issued, no redirect hop');
+        $this->assertSame(302, $response->getStatusCode());
+    }
+
+    /**
+     * A Symfony HttpClientInterface that records the (already Glueful-transformed)
+     * options and requested URL, returning a trivial 200 response.
+     */
+    private function capturingClient(): HttpClientInterface
+    {
+        return new class implements HttpClientInterface {
+            /** @var array<string,mixed> */
+            public array $captured = [];
+            public string $capturedUrl = '';
+
+            public function request(string $method, string $url, array $options = []): ResponseInterface
+            {
+                $this->captured = $options;
+                $this->capturedUrl = $url;
+
+                return new class implements ResponseInterface {
+                    public function getStatusCode(): int
+                    {
+                        return 200;
+                    }
+                    public function getHeaders(bool $throw = true): array
+                    {
+                        return [];
+                    }
+                    public function getContent(bool $throw = true): string
+                    {
+                        return '{}';
+                    }
+                    /** @return array<int|string,mixed> */
+                    public function toArray(bool $throw = true): array
+                    {
+                        return [];
+                    }
+                    public function cancel(): void
+                    {
+                    }
+                    public function getInfo(?string $type = null): mixed
+                    {
+                        return null;
+                    }
+                };
+            }
+
+            public function stream($responses, ?float $timeout = null): ResponseStreamInterface
+            {
+                throw new \BadMethodCallException('stream() is not used in this test');
+            }
+
+            public function withOptions(array $options): static
+            {
+                return $this;
+            }
+        };
+    }
+
+    private function redirectingClient(string $location): HttpClientInterface
+    {
+        return new class ($location) implements HttpClientInterface {
+            public int $requestCount = 0;
+            /** @var array<string,mixed> */
+            public array $captured = [];
+
+            public function __construct(private string $location)
+            {
+            }
+
+            public function request(string $method, string $url, array $options = []): ResponseInterface
+            {
+                $this->requestCount++;
+                $this->captured = $options;
+                $location = $this->location;
+
+                return new class ($location) implements ResponseInterface {
+                    public function __construct(private string $location)
+                    {
+                    }
+
+                    public function getStatusCode(): int
+                    {
+                        return 302;
+                    }
+                    public function getHeaders(bool $throw = true): array
+                    {
+                        return ['location' => [$this->location]];
+                    }
+                    public function getContent(bool $throw = true): string
+                    {
+                        return '';
+                    }
+                    /** @return array<int|string,mixed> */
+                    public function toArray(bool $throw = true): array
+                    {
+                        return [];
+                    }
+                    public function cancel(): void
+                    {
+                    }
+                    public function getInfo(?string $type = null): mixed
+                    {
+                        return null;
+                    }
+                };
+            }
+
+            public function stream($responses, ?float $timeout = null): ResponseStreamInterface
+            {
+                throw new \BadMethodCallException('stream() is not used in this test');
+            }
+
+            public function withOptions(array $options): static
+            {
+                return $this;
+            }
+        };
+    }
+}

--- a/tests/Unit/Http/Security/SafeOutboundTargetResolverTest.php
+++ b/tests/Unit/Http/Security/SafeOutboundTargetResolverTest.php
@@ -1,0 +1,304 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Http\Security;
+
+use Glueful\Http\Exceptions\HttpClientException;
+use Glueful\Http\Security\ResolvedOutboundTarget;
+use Glueful\Http\Security\SafeOutboundTargetResolver;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * SafeOutboundTargetResolver is the single SSRF policy for outbound requests, shared
+ * by Client::safeRequest()/safeRequestAsync() (resolveSafeFetch — backward compatible)
+ * and the strict webhook profile (resolveWebhook). DNS resolution is injected via a
+ * closure so these tests are deterministic and do not perform real network I/O; the
+ * IP-literal fast path (used by the resolveSafeFetch regression tests) never touches
+ * the injected closure at all, exactly mirroring the pre-extraction Client behavior.
+ */
+final class SafeOutboundTargetResolverTest extends TestCase
+{
+    // ---------------------------------------------------------------
+    // resolveWebhook() — strict profile
+    // ---------------------------------------------------------------
+
+    public function testResolveWebhookAcceptsPublicHttpsUrlAndPinsResolvedAddress(): void
+    {
+        $resolver = $this->resolverWithDns(['shop.example.test' => ['93.184.216.34']]);
+
+        $target = $resolver->resolveWebhook('https://shop.example.test/hooks/orders');
+
+        $this->assertInstanceOf(ResolvedOutboundTarget::class, $target);
+        $this->assertSame('shop.example.test', $target->host);
+        $this->assertSame('93.184.216.34', $target->ip);
+        $this->assertSame(443, $target->port);
+        $this->assertSame('https://shop.example.test/hooks/orders', $target->canonicalUrl);
+    }
+
+    public function testResolveWebhookPreservesQueryStringInCanonicalUrl(): void
+    {
+        $resolver = $this->resolverWithDns(['shop.example.test' => ['93.184.216.34']]);
+
+        $target = $resolver->resolveWebhook('https://shop.example.test/hooks?tenant=abc');
+
+        $this->assertSame('https://shop.example.test/hooks?tenant=abc', $target->canonicalUrl);
+    }
+
+    public function testResolveWebhookRejectsHttpScheme(): void
+    {
+        $resolver = $this->resolverWithDns(['shop.example.test' => ['93.184.216.34']]);
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('only https is allowed');
+
+        $resolver->resolveWebhook('http://shop.example.test/hooks');
+    }
+
+    public function testResolveWebhookRejectsCredentials(): void
+    {
+        $resolver = $this->resolverWithDns(['shop.example.test' => ['93.184.216.34']]);
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('credentials are not allowed');
+
+        $resolver->resolveWebhook('https://user:pass@shop.example.test/hooks');
+    }
+
+    public function testResolveWebhookRejectsFragment(): void
+    {
+        $resolver = $this->resolverWithDns(['shop.example.test' => ['93.184.216.34']]);
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('fragment is not allowed');
+
+        $resolver->resolveWebhook('https://shop.example.test/hooks#frag');
+    }
+
+    public function testResolveWebhookRejectsNonDefaultPort(): void
+    {
+        $resolver = $this->resolverWithDns(['shop.example.test' => ['93.184.216.34']]);
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('default HTTPS port');
+
+        $resolver->resolveWebhook('https://shop.example.test:8443/hooks');
+    }
+
+    public function testResolveWebhookRejectsIpv4LiteralHost(): void
+    {
+        $resolver = $this->resolverWithDns([]);
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('IP-literal hosts are not allowed');
+
+        $resolver->resolveWebhook('https://93.184.216.34/hooks');
+    }
+
+    public function testResolveWebhookRejectsIpv6LiteralHost(): void
+    {
+        $resolver = $this->resolverWithDns([]);
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('IP-literal hosts are not allowed');
+
+        $resolver->resolveWebhook('https://[2001:db8::1]/hooks');
+    }
+
+    public function testResolveWebhookRejectsPrivateIpv4Resolution(): void
+    {
+        $resolver = $this->resolverWithDns(['internal.example.test' => ['10.0.0.5']]);
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('private or reserved');
+
+        $resolver->resolveWebhook('https://internal.example.test/hooks');
+    }
+
+    public function testResolveWebhookRejectsLoopbackResolution(): void
+    {
+        $resolver = $this->resolverWithDns(['loopback.example.test' => ['127.0.0.1']]);
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('private or reserved');
+
+        $resolver->resolveWebhook('https://loopback.example.test/hooks');
+    }
+
+    public function testResolveWebhookRejectsLinkLocalMetadataResolution(): void
+    {
+        $resolver = $this->resolverWithDns(['metadata.example.test' => ['169.254.169.254']]);
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('private or reserved');
+
+        $resolver->resolveWebhook('https://metadata.example.test/hooks');
+    }
+
+    public function testResolveWebhookRejectsIpv6LoopbackAndLinkLocalResolution(): void
+    {
+        $loopback = $this->resolverWithDns(['v6loop.example.test' => ['::1']]);
+        try {
+            $loopback->resolveWebhook('https://v6loop.example.test/hooks');
+            $this->fail('Expected HttpClientException for IPv6 loopback resolution');
+        } catch (HttpClientException $e) {
+            $this->assertStringContainsString('private or reserved', $e->getMessage());
+        }
+
+        $linkLocal = $this->resolverWithDns(['v6link.example.test' => ['fe80::1']]);
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('private or reserved');
+        $linkLocal->resolveWebhook('https://v6link.example.test/hooks');
+    }
+
+    public function testResolveWebhookRejectsWhenAnyOfMultipleARecordsIsPrivate(): void
+    {
+        // Public first, private second — proves ALL resolved addresses are checked,
+        // not just the one that would be pinned.
+        $resolver = $this->resolverWithDns(['mixed.example.test' => ['93.184.216.34', '10.0.0.5']]);
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('private or reserved');
+
+        $resolver->resolveWebhook('https://mixed.example.test/hooks');
+    }
+
+    public function testResolveWebhookRejectsWhenHostCannotBeResolved(): void
+    {
+        $resolver = $this->resolverWithDns(['nowhere.example.test' => []]);
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('could not be resolved');
+
+        $resolver->resolveWebhook('https://nowhere.example.test/hooks');
+    }
+
+    public function testResolveWebhookRejectsMalformedIdnHost(): void
+    {
+        $resolver = $this->resolverWithDns([]);
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('malformed international domain name');
+
+        // A raw space is not a valid domain label character under STD3 rules.
+        $resolver->resolveWebhook('https://exa mple.test/hooks');
+    }
+
+    public function testResolveWebhookRejectsAmbiguousHostEncoding(): void
+    {
+        $resolver = $this->resolverWithDns([]);
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('ambiguous host encoding');
+
+        // U+FF0E (fullwidth full stop) is not literally '.' but UTS46 silently
+        // canonicalizes it to one, splitting one apparent label into two.
+        $resolver->resolveWebhook("https://shop\u{FF0E}example.test/hooks");
+    }
+
+    public function testResolveWebhookAcceptsAndPunycodesAGenuineUnicodeIdnHost(): void
+    {
+        // "例え" (Japanese) — a genuine multi-byte IDN label, not a dot look-alike.
+        // Also proves parse_url()'s host-corruption quirk for 3-byte UTF-8 sequences
+        // (see parseUrlSafely()) doesn't cause a legitimate IDN host to be mangled.
+        $resolver = $this->resolverWithDns(['xn--r8jz45g.example.test' => ['93.184.216.34']]);
+
+        $target = $resolver->resolveWebhook("https://\u{4F8B}\u{3048}.example.test/hooks");
+
+        $this->assertSame('xn--r8jz45g.example.test', $target->host);
+        $this->assertSame('93.184.216.34', $target->ip);
+        $this->assertSame('https://xn--r8jz45g.example.test/hooks', $target->canonicalUrl);
+    }
+
+    public function testResolveWebhookOnlyResolvesDnsOnce(): void
+    {
+        $calls = 0;
+        $resolver = new SafeOutboundTargetResolver(function (string $host) use (&$calls): array {
+            $calls++;
+            return ['93.184.216.34'];
+        });
+
+        $resolver->resolveWebhook('https://shop.example.test/hooks');
+
+        $this->assertSame(1, $calls);
+    }
+
+    // ---------------------------------------------------------------
+    // resolveSafeFetch() — backward-compatible profile (regression)
+    // ---------------------------------------------------------------
+
+    public function testResolveSafeFetchAcceptsHttpAndHttpsIpLiteralsWithoutInvokingDnsLookup(): void
+    {
+        $resolver = new SafeOutboundTargetResolver(function (string $host): array {
+            $this->fail('DNS lookup should not be invoked for an IP-literal host');
+        });
+
+        $target = $resolver->resolveSafeFetch('https://93.184.216.34/image.png');
+
+        $this->assertSame('93.184.216.34', $target->host);
+        $this->assertSame('93.184.216.34', $target->ip);
+        $this->assertSame(443, $target->port);
+    }
+
+    public function testResolveSafeFetchRejectsPrivateIpByDefault(): void
+    {
+        $resolver = new SafeOutboundTargetResolver();
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('Unsafe URL');
+
+        $resolver->resolveSafeFetch('http://169.254.169.254/latest/meta-data');
+    }
+
+    public function testResolveSafeFetchAllowsPrivateHostWhenOptedIn(): void
+    {
+        $resolver = new SafeOutboundTargetResolver();
+
+        $target = $resolver->resolveSafeFetch('http://10.0.0.5/health', true);
+
+        $this->assertSame('10.0.0.5', $target->host);
+        $this->assertSame('10.0.0.5', $target->ip);
+    }
+
+    public function testResolveSafeFetchRejectsNonHttpScheme(): void
+    {
+        $resolver = new SafeOutboundTargetResolver();
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('only http and https schemes are allowed');
+
+        $resolver->resolveSafeFetch('ftp://93.184.216.34/image.png');
+    }
+
+    public function testResolveSafeFetchRejectsWhenHostCannotBeResolved(): void
+    {
+        $resolver = $this->resolverWithDns(['nowhere.example.test' => []]);
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('host could not be resolved');
+
+        $resolver->resolveSafeFetch('https://nowhere.example.test/x');
+    }
+
+    public function testResolveSafeFetchAcceptsAWebhookRejectedShapeLikeCredentialsOrPorts(): void
+    {
+        // resolveSafeFetch never adopted the strict webhook rules — credentials and
+        // non-default ports on an otherwise-public IP literal are still accepted.
+        $resolver = new SafeOutboundTargetResolver();
+
+        $target = $resolver->resolveSafeFetch('https://user:pass@93.184.216.34:8443/x');
+
+        $this->assertSame('93.184.216.34', $target->host);
+        $this->assertSame(8443, $target->port);
+    }
+
+    /**
+     * @param array<string, list<string>> $records
+     */
+    private function resolverWithDns(array $records): SafeOutboundTargetResolver
+    {
+        return new SafeOutboundTargetResolver(function (string $host) use ($records): array {
+            return $records[$host] ?? [];
+        });
+    }
+}

--- a/tests/Unit/Http/Security/SafeOutboundTargetResolverTest.php
+++ b/tests/Unit/Http/Security/SafeOutboundTargetResolverTest.php
@@ -151,6 +151,78 @@ final class SafeOutboundTargetResolverTest extends TestCase
         $linkLocal->resolveWebhook('https://v6link.example.test/hooks');
     }
 
+    public function testResolveWebhookRejectsCgnatResolution(): void
+    {
+        // 100.64.0.0/10 (RFC6598 CGNAT) is NOT covered by FILTER_FLAG_NO_PRIV_RANGE /
+        // FILTER_FLAG_NO_RES_RANGE — this is the supplemental blocked-CIDR check.
+        $resolver = $this->resolverWithDns(['cgnat.example.test' => ['100.64.0.5']]);
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('private or reserved');
+
+        $resolver->resolveWebhook('https://cgnat.example.test/hooks');
+    }
+
+    public function testResolveWebhookRejectsNat64EmbeddedLoopbackResolution(): void
+    {
+        // 64:ff9b::/96 (NAT64) with an embedded 127.0.0.1 — must decode the embedded
+        // IPv4 and reject because 127.0.0.0/8 is blocked, not just the /96 shell.
+        $resolver = $this->resolverWithDns(['nat64.example.test' => ['64:ff9b::7f00:1']]);
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('private or reserved');
+
+        $resolver->resolveWebhook('https://nat64.example.test/hooks');
+    }
+
+    public function testResolveWebhookRejects6to4EmbeddedLoopbackResolution(): void
+    {
+        // 2002::/16 (6to4) with an embedded 127.0.0.1 (2002:7f00:0001:: decodes to
+        // 127.0.0.1 in bytes 2-5) — must be rejected via the decoded IPv4 check.
+        $resolver = $this->resolverWithDns(['sixtofour.example.test' => ['2002:7f00:1::']]);
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('private or reserved');
+
+        $resolver->resolveWebhook('https://sixtofour.example.test/hooks');
+    }
+
+    public function testResolveWebhookRejectsIanaProtocolAssignmentResolution(): void
+    {
+        // 192.0.0.0/24 (IANA IETF Protocol Assignments) — reserved space not covered
+        // by FILTER_FLAG_NO_RES_RANGE.
+        $resolver = $this->resolverWithDns(['iana.example.test' => ['192.0.0.1']]);
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('private or reserved');
+
+        $resolver->resolveWebhook('https://iana.example.test/hooks');
+    }
+
+    public function testResolveWebhookRejectsBenchmarkingRangeResolution(): void
+    {
+        // 198.18.0.0/15 (RFC2544 benchmarking) — reserved space not covered by
+        // FILTER_FLAG_NO_RES_RANGE.
+        $resolver = $this->resolverWithDns(['bench.example.test' => ['198.18.0.1']]);
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('private or reserved');
+
+        $resolver->resolveWebhook('https://bench.example.test/hooks');
+    }
+
+    public function testResolveWebhookRejectsIpv4MappedMetadataResolution(): void
+    {
+        // ::ffff:0:0/96 (IPv4-mapped) wrapping the cloud metadata address — must
+        // decode the embedded IPv4 and reject because 169.254.0.0/16 is blocked.
+        $resolver = $this->resolverWithDns(['mapped.example.test' => ['::ffff:169.254.169.254']]);
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('private or reserved');
+
+        $resolver->resolveWebhook('https://mapped.example.test/hooks');
+    }
+
     public function testResolveWebhookRejectsWhenAnyOfMultipleARecordsIsPrivate(): void
     {
         // Public first, private second — proves ALL resolved addresses are checked,
@@ -290,6 +362,19 @@ final class SafeOutboundTargetResolverTest extends TestCase
 
         $this->assertSame('93.184.216.34', $target->host);
         $this->assertSame(8443, $target->port);
+    }
+
+    public function testResolveSafeFetchIsUnaffectedByTheWebhookOnlySupplementalBlocklist(): void
+    {
+        // The CGNAT/NAT64/6to4/IANA-reserved supplemental check added for
+        // resolveWebhook() must NOT be applied to resolveSafeFetch() — its
+        // blocked-range policy stays exactly filter_var's NO_PRIV_RANGE |
+        // NO_RES_RANGE flags, byte-identical to the pre-extraction behavior.
+        $resolver = $this->resolverWithDns(['cgnat.example.test' => ['100.64.0.5']]);
+
+        $target = $resolver->resolveSafeFetch('https://cgnat.example.test/x');
+
+        $this->assertSame('100.64.0.5', $target->ip);
     }
 
     /**


### PR DESCRIPTION
### Added
- **`EventService::dispatchOrFail()` — strict, at-least-once event dispatch.** Alongside the existing
  fault-isolating `dispatch()` (which logs and continues past a throwing listener), `dispatchOrFail()`
  stops at the first failing listener, logs, and rethrows the original exception so the caller's
  transaction can roll back. `dispatch()` is byte-unchanged — a pure insertion guarded by regression
  tests; the strict path is opt-in per call site, for events whose delivery is a correctness invariant
  (e.g. a financial webhook that must not be silently lost). The PSR `EventDispatcherInterface` alias
  resolves to the concrete `EventDispatcher`, so the strict path is reachable through the container.
- **`SafeOutboundTargetResolver` + `ResolvedOutboundTarget` (`src/Http/Security/`) — one place that
  turns a URL into a validated, IP-pinned outbound target.** Two profiles: `resolveSafeFetch()`
  preserves the exact behavior of the existing `Client::safeRequest*()` SSRF checks (byte-for-byte —
  existing callers are unaffected), and `resolveWebhook()` applies a stricter third-party-delivery
  profile: HTTPS only; rejects embedded credentials, fragments, non-default ports, IP-literal hosts,
  and malformed/ambiguous IDNA; resolves every A/AAAA record and refuses if any resolves into a
  blocked range (loopback, private, link-local, CGNAT `100.64/10`, and reserved/embedded-v4 IPv6).
- **`Client::safeWebhookRequestAsync()` — SSRF-safe outbound POST with no TOCTOU window.** Resolves the
  target exactly once via `resolveWebhook()` and pins the checked IP into the request's resolve map, so
  the address that was validated is the address that gets connected; redirects are never followed.

### Changed
- **`ApiKeyService::rotate()` now returns the successor key's `new_uuid`** — an additive field on the
  returned array, so existing consumers that ignore it are unaffected — and **clamps the predecessor's
  expiry to `min(existing, now + grace)`** so rotation can only ever shorten a superseded key's life,
  never extend it (an unparsable/absent existing expiry falls back to `now + grace`). The successor's
  own expiry is captured before the clamp and is unaffected.