### PR TITLE
Release v1.71.1: connection reuse & OPcache warmup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.71.1] - 2026-07-22 — Alcor
+
+**Theme: non-pooled connection reuse & OPcache-off warmup** — two runtime bugfixes surfaced by a
+connection-heavy test suite. Without pooling, `Connection` opened (and leaked) a fresh database
+backend per instance, exhausting the server's connection ceiling under many short-lived containers;
+and route-cache warmup threw on every boot when OPcache was loaded but disabled. Both are pure fixes:
+no new env vars, no migrations, no default changes, no API changes.
+
+### Fixed
+- **Non-pooled `Connection` no longer leaks a backend per instance — fixes "too many clients" under
+  many short-lived containers.** With connection pooling disabled, `new Connection(...)` opened a fresh
+  PDO in its constructor and never reused it, so each additional container (e.g. a test harness that
+  boots the framework repeatedly, or any process that constructs several `Connection`s) opened another
+  server connection that was only released on GC — which cyclic container graphs and cached contexts
+  prevent. Enough of them exhausted the server's `max_connections` (`SQLSTATE[08006]/FATAL: sorry, too
+  many clients already`) and slowed runs to a crawl. Server engines now reuse a process-global PDO keyed
+  by the **full connection identity** (DSN + user + schema), so equivalent connections share one backend
+  while a connection opened for a *different* schema/host/db/user still gets its own — preserving
+  intentional isolation (e.g. a caller that opens a private-schema connection). **SQLite is excluded**
+  (a `:memory:` database is private to its connection; file databases are cheap), so its pooling-off
+  behavior is byte-unchanged. Pooled mode is untouched.
+- **Route-cache warmup no longer throws when OPcache is loaded but disabled.** `RouteCache::save()`
+  guarded `opcache_compile_file()` with `function_exists()` alone; when the extension is present but off
+  (e.g. `opcache.enable_cli=0`, the default in CI) the call throws "Zend OPcache has not been properly
+  started, can't compile file". The throw was caught upstream but spammed logs and aborted HTTP-layer
+  warmup on every boot. Warmup now runs only when OPcache reports itself enabled for the current SAPI.
+
 ## [1.71.0] - 2026-07-20 — Alcor
 
 **Theme: outbound-webhook security & reliability seams** — three additive, application-agnostic

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,20 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.71.1 — Alcor (Patch, Released 2026-07-22)
+- **Non-pooled connection reuse.** With pooling disabled, `Connection` opened a fresh PDO in its
+  constructor and never reused it, so each additional container (a test harness that boots the
+  framework repeatedly, or any process constructing several `Connection`s) leaked a backend that GC
+  could not reclaim — exhausting the server's `max_connections` ("too many clients"). Server engines
+  now reuse a process-global PDO keyed by full connection identity (DSN + user + schema); a connection
+  for a different schema/host/db/user still gets its own backend. SQLite excluded (`:memory:` is
+  per-connection) — its behavior is byte-unchanged. Pooled mode untouched.
+- **OPcache-off route-cache warmup.** `RouteCache::save()` guarded `opcache_compile_file()` with
+  `function_exists()` alone; when OPcache was loaded but disabled (e.g. `opcache.enable_cli=0`, the CI
+  default) the call threw on every boot. Warmup now runs only when OPcache reports itself enabled.
+- Notes: **Patch release** — pure bugfixes; no new env vars, no migrations, no default changes, no API
+  changes.
+
 ### 1.71.0 — Alcor (Minor, Released 2026-07-20)
 - **Outbound-webhook security & reliability seams** (extracted while hardening the commerce
   marketplace's seller webhooks; application-agnostic).

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -158,9 +158,36 @@ class Connection implements DatabaseInterface
 
         $this->driver = $this->resolveDriver($this->engine);
 
-        // Initialize PDO connection only if pooling is disabled
+        // Initialize PDO connection only if pooling is disabled.
         if ($poolingEnabled === false) {
-            $this->pdo = $this->createPDOConnection($this->engine);
+            // For server-based engines, reuse a process-global PDO keyed by the FULL connection
+            // identity (DSN + user + schema) rather than opening a fresh backend for every
+            // Connection instance: without pooling, each new Connection otherwise leaks a PDO
+            // that is only released on GC — and cached test-harness app contexts (and cyclic
+            // container graphs) keep those objects alive, exhausting the server's connection
+            // ceiling ("too many clients") once enough containers are booted. The identity key
+            // (NOT engine alone) is essential: a Connection built for a different schema/host/
+            // db/user must get its OWN backend, or a caller that opens an isolated-schema
+            // connection would silently run against the shared search_path.
+            //
+            // SQLite is excluded: a ':memory:' database is private to each connection and file
+            // databases are cheap to open, so reuse there would wrongly share one in-memory
+            // schema across connections meant to be isolated. This keeps SQLite's pooling-off
+            // behaviour exactly as before.
+            if ($this->engine === 'sqlite') {
+                $this->pdo = $this->createPDOConnection($this->engine);
+            } else {
+                $dbConfig = $this->config[$this->engine] ?? [];
+                $key = $this->engine . '|' . $this->buildDSN($this->engine, $dbConfig)
+                    . '|' . ($dbConfig['user'] ?? '')
+                    . '|' . ($dbConfig['schema'] ?? '');
+                if (isset(self::$instances[$key])) {
+                    $this->pdo = self::$instances[$key];
+                } else {
+                    $this->pdo = $this->createPDOConnection($this->engine);
+                    self::$instances[$key] = $this->pdo;
+                }
+            }
         }
 
         // Note: Schema manager is initialized lazily when first accessed

--- a/src/Routing/RouteCache.php
+++ b/src/Routing/RouteCache.php
@@ -150,9 +150,19 @@ class RouteCache
             throw new \RuntimeException(sprintf('Failed to atomically replace route cache file: %s', $cacheFile));
         }
 
-        // Warm opcache
-        if (function_exists('opcache_compile_file')) {
-            opcache_compile_file($cacheFile);
+        // Warm opcache — only when OPcache is actually enabled for this SAPI. Guarding on
+        // function_exists() alone is not enough: when the extension is loaded but disabled
+        // (e.g. opcache.enable_cli=0, the default in CI), opcache_compile_file() throws
+        // "Zend OPcache has not been properly started, can't compile file". That throw is
+        // caught upstream but spams the logs and needlessly aborts HTTP-layer warmup on every
+        // boot. Skip it cleanly when OPcache is off.
+        if (
+            function_exists('opcache_compile_file')
+            && function_exists('opcache_get_status')
+            && is_array($status = @opcache_get_status(false))
+            && ($status['opcache_enabled'] ?? false) === true
+        ) {
+            @opcache_compile_file($cacheFile);
         }
 
         return true;

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,7 +13,7 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.71.0';
+    public const VERSION = '1.71.1';
 
 
     /** Release code name */
@@ -21,7 +21,7 @@ final class Version
 
 
     /** Release date */
-    public const RELEASE_DATE = '2026-07-20';
+    public const RELEASE_DATE = '2026-07-22';
 
     /** Minimum required PHP version */
     public const MIN_PHP_VERSION = '8.3.0';


### PR DESCRIPTION
Fix two runtime bugs surfaced by connection-heavy test suites:

1. Non-pooled connections now reuse a process-global PDO keyed by full connection identity (DSN + user + schema), preventing resource exhaustion when many short-lived containers are booted. SQLite excluded to preserve its isolation semantics.

2. Route-cache warmup now checks if OPcache is actually enabled before calling opcache_compile_file(), avoiding spurious errors when the extension is loaded but disabled (e.g. opcache.enable_cli=0 in CI).

No new env vars, migrations, default changes, or API changes.
