### PR TITLE
fix(database): scope non-pooled PDO reuse to context-managed connections; release 1.71.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.71.2] - 2026-07-22 — Alcor
+
+**Theme: connection reuse scoped to framework-managed connections** — a follow-up fix to 1.71.1's
+non-pooled PDO reuse. Reuse now applies only to connections constructed WITH an `ApplicationContext`
+(the DI container path that leaked); an ad-hoc `new Connection([...])` without a context always opens
+a fresh backend. Pure fix: no new env vars, no migrations, no default changes, no API changes.
+
+### Fixed
+- **Ad-hoc `new Connection([...])` (no context) no longer shares a backend with the framework's
+  managed connection — fixes config-identical session pairs deadlocking.** 1.71.1 keyed non-pooled PDO
+  reuse by connection identity (DSN + user + schema) for every construction. But a caller hand-building
+  a Connection is usually asking for an INDEPENDENT session — e.g. a test or job that holds a
+  lock/transaction open on one session while another session (or a child process) contends with it.
+  When such a pair's config happened to resolve identically to the managed connection (typical in CI,
+  where DB settings come from real environment variables so every construction path sees the same
+  values), 1.71.1 silently collapsed them into one PG session — turning session-level semantics
+  (advisory locks, open transactions) into self-interactions. Concretely: a race-style test held a lock
+  on its "second connection" (secretly the same session), spawned a child process that blocked waiting
+  on that lock, and then blocked reading the child's pipe — a permanent, CI-only deadlock. Reuse is now
+  gated on the constructor's `$context` parameter: framework-managed constructions (the container's
+  `database` factory passes the context) still share one identity-keyed backend — the 1.71.1 leak fix
+  is fully preserved — while context-less constructions always get their own PDO, restoring 1.71.0
+  semantics for hand-built connections. SQLite behavior unchanged (never reused).
+
 ## [1.71.1] - 2026-07-22 — Alcor
 
 **Theme: non-pooled connection reuse & OPcache-off warmup** — two runtime bugfixes surfaced by a

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,16 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.71.2 — Alcor (Patch, Released 2026-07-22)
+- **Connection reuse scoped to framework-managed connections.** Follow-up to 1.71.1: non-pooled PDO
+  reuse now applies only to connections constructed WITH an `ApplicationContext` (the DI container
+  path — where the leak lived). An ad-hoc `new Connection([...])` without a context always opens a
+  fresh backend: a caller hand-building a Connection is asking for an independent session (locks,
+  open transactions), and collapsing config-identical pairs into one backend turned session semantics
+  into self-interactions (a CI-only race-test deadlock: a "second session" holding a lock was secretly
+  the same session its child process waited on). Leak fix fully preserved; SQLite unchanged.
+- Notes: **Patch release** — pure fix; no new env vars, no migrations, no default changes.
+
 ### 1.71.1 — Alcor (Patch, Released 2026-07-22)
 - **Non-pooled connection reuse.** With pooling disabled, `Connection` opened a fresh PDO in its
   constructor and never reused it, so each additional container (a test harness that boots the

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -160,21 +160,28 @@ class Connection implements DatabaseInterface
 
         // Initialize PDO connection only if pooling is disabled.
         if ($poolingEnabled === false) {
-            // For server-based engines, reuse a process-global PDO keyed by the FULL connection
-            // identity (DSN + user + schema) rather than opening a fresh backend for every
-            // Connection instance: without pooling, each new Connection otherwise leaks a PDO
-            // that is only released on GC — and cached test-harness app contexts (and cyclic
-            // container graphs) keep those objects alive, exhausting the server's connection
-            // ceiling ("too many clients") once enough containers are booted. The identity key
-            // (NOT engine alone) is essential: a Connection built for a different schema/host/
-            // db/user must get its OWN backend, or a caller that opens an isolated-schema
-            // connection would silently run against the shared search_path.
+            // FRAMEWORK-MANAGED connections (constructed WITH an ApplicationContext — the DI
+            // container's 'database' factory and other framework paths) reuse a process-global
+            // PDO keyed by the FULL connection identity (DSN + user + schema): without pooling,
+            // each new Connection otherwise leaks a PDO that is only released on GC — and cached
+            // test-harness app contexts (and cyclic container graphs) keep those objects alive,
+            // exhausting the server's connection ceiling ("too many clients") once enough
+            // containers are booted. The identity key (NOT engine alone) still guards a managed
+            // connection built for a different schema/host/db/user getting its OWN backend.
             //
-            // SQLite is excluded: a ':memory:' database is private to each connection and file
-            // databases are cheap to open, so reuse there would wrongly share one in-memory
-            // schema across connections meant to be isolated. This keeps SQLite's pooling-off
-            // behaviour exactly as before.
-            if ($this->engine === 'sqlite') {
+            // AD-HOC connections (constructed WITHOUT a context — `new Connection([...])` in
+            // application/test code) always open a FRESH backend. A caller hand-building a
+            // Connection is asking for an independent session — e.g. a second session to hold a
+            // lock/transaction open while another session contends with it. Silently collapsing
+            // such pairs into one backend when their configs happen to match turns session-level
+            // semantics (advisory locks, transactions) into self-interactions and deadlocks the
+            // caller (a pair of "racing" sessions that are secretly one session can block forever).
+            //
+            // SQLite is excluded from reuse entirely: a ':memory:' database is private to each
+            // connection and file databases are cheap to open, so reuse there would wrongly share
+            // one in-memory schema across connections meant to be isolated. This keeps SQLite's
+            // pooling-off behaviour exactly as before.
+            if ($this->engine === 'sqlite' || $context === null) {
                 $this->pdo = $this->createPDOConnection($this->engine);
             } else {
                 $dbConfig = $this->config[$this->engine] ?? [];

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,7 +13,7 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.71.1';
+    public const VERSION = '1.71.2';
 
 
     /** Release code name */


### PR DESCRIPTION
An ad-hoc `new Connection([...])` without an ApplicationContext now always opens a fresh backend. 1.71.1's identity-keyed reuse could collapse an intentionally independent hand-built connection into the framework's shared session when their configs resolved identically (typical in CI, where DB settings come from real environment variables) — turning session-level semantics (advisory locks, open transactions) into self-interactions and deadlocking race-style code that holds a lock on one session while a child process contends on another. Reuse now requires the constructor's $context (the DI container's database factory passes it), preserving the 1.71.1 too-many-clients leak fix while restoring 1.71.0 semantics for hand-built connections. SQLite unchanged.
