### PR TITLE
Fix discovered console commands to use booted container context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.71.3] - 2026-07-25 — Alcor
+
+**Theme: discovered console commands join the booted world** — a one-line-in-spirit console fix
+with a wide blast radius: extension-discovered commands no longer run inside a parallel,
+never-booted container. Pure fix: no new env vars, no migrations, no default changes, no API
+changes.
+
 ### Fixed
 - **Console: discovered commands ran in a parallel, never-booted world** —
   `Application::registerDeferredExtensionCommands()` instantiated non-container-registered

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Fixed
+- **Console: discovered commands ran in a parallel, never-booted world** —
+  `Application::registerDeferredExtensionCommands()` instantiated non-container-registered
+  commands bare (`new $class()`), sending `BaseCommand` down its no-args path: a fresh
+  `ApplicationContext` plus a fresh container in which extension `boot()` never ran, so
+  discovered commands silently operated without capabilities, boot-registered contributors,
+  or listeners. Bare instantiation now passes the console's own container and
+  `ApplicationContext` when the class is a `BaseCommand`, matching container-resolved commands.
+
 ## [1.71.2] - 2026-07-22 — Alcor
 
 **Theme: connection reuse scoped to framework-managed connections** — a follow-up fix to 1.71.1's

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,13 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.71.3 — Alcor (Patch, Released 2026-07-25)
+- **Discovered console commands join the booted world.** `Console\Application` bare-instantiated
+  extension-discovered commands, sending `BaseCommand` down its no-args path: a fresh context plus
+  a fresh, never-booted container (no capabilities, no boot-registered contributors or listeners).
+  Bare instantiation now passes the console's own container and `ApplicationContext`, matching
+  container-resolved commands.
+
 ### 1.71.2 — Alcor (Patch, Released 2026-07-22)
 - **Connection reuse scoped to framework-managed connections.** Follow-up to 1.71.1: non-pooled PDO
   reuse now applies only to connections constructed WITH an `ApplicationContext` (the DI container

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -2,6 +2,7 @@
 
 namespace Glueful\Console;
 
+use Glueful\Bootstrap\ApplicationContext;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Command\Command;
 use Psr\Container\ContainerInterface;
@@ -90,7 +91,19 @@ class Application extends BaseApplication
                 if ($this->container->has($class)) {
                     $command = $this->container->get($class);
                 } else {
-                    $command = new $class();
+                    // Bare instantiation MUST still hand BaseCommand the REAL booted
+                    // container/context: with no args, BaseCommand builds a fresh context and a
+                    // fresh, never-booted container — a parallel world where extension boot()
+                    // never ran (no capabilities, no boot-registered contributors/listeners), so
+                    // discovered commands silently operate on different state than the app.
+                    $command = is_subclass_of($class, BaseCommand::class)
+                        ? new $class(
+                            $this->container,
+                            $this->container->has(ApplicationContext::class)
+                                ? $this->container->get(ApplicationContext::class)
+                                : null,
+                        )
+                        : new $class();
                 }
                 if ($command instanceof Command) {
                     $this->addCommand($command);

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,7 +13,7 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.71.2';
+    public const VERSION = '1.71.3';
 
 
     /** Release code name */
@@ -21,7 +21,7 @@ final class Version
 
 
     /** Release date */
-    public const RELEASE_DATE = '2026-07-22';
+    public const RELEASE_DATE = '2026-07-25';
 
     /** Minimum required PHP version */
     public const MIN_PHP_VERSION = '8.3.0';


### PR DESCRIPTION
Application::registerDeferredExtensionCommands() instantiated
non-container-registered commands bare (new $class()), which sends
BaseCommand down its no-args path: a FRESH ApplicationContext and a
fresh, never-booted container — a parallel world where extension boot()
never ran. Discovered commands silently operated without capabilities,
boot-registered contributors, or listeners; concretely, Thallo's
thallo:tenant:sync could not see commerce's starter contributors and
marked their provenance rows orphaned. Bare instantiation now passes the
console's own container plus its ApplicationContext when the class is a
BaseCommand, matching what container-resolved commands already got.