### PR TITLE
Fix cache recompilation in writeCacheNow for extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.72.1] - 2026-07-26 — Alderamin
+
+**Theme: activation writes recompile from what was just written** — one targeted fix to the
+extension cache recompile; no new config, no behavioral change for anything outside the
+enable/disable surfaces. Low-risk patch — upgrade and run.
+
 ### Fixed
 - **Stale extension-cache recompile after an activation write** — no-arg
   `ExtensionManager::writeCacheNow()` now clears the context config cache before resolving, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Fixed
+- **Stale extension-cache recompile after an activation write** — no-arg
+  `ExtensionManager::writeCacheNow()` now clears the context config cache before resolving, so
+  it recompiles from the just-written `config/extensions.php` instead of the enabled list
+  cached earlier in the same process. Every activation surface runs a read→write→recompile
+  sequence (`extensions:enable`/`disable`, the admin toggle): reading the enabled list primes
+  the config cache, `ExtensionStateWriter` mutates the file, and the recompile previously
+  resolved through the stale cache — persisting the PRE-write activation state (a just-enabled
+  provider missing from the compiled cache, a just-disabled one still present). Config
+  defaults and overrides survive the clear; explicit-list calls are unchanged.
+
 ## [1.72.0] - 2026-07-26 — Alderamin
 
 **Theme: providers get one order, one owner, and one gatekeeper** — three additive extension

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,12 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.72.1 — Alderamin (Patch, Released 2026-07-26)
+- **Activation writes recompile from current file state.** No-arg `writeCacheNow()` clears the
+  context config cache before resolving: `extensions:enable`/`disable` and the admin toggles no
+  longer persist the PRE-write activation state (a just-enabled provider missing from the
+  compiled cache, a just-disabled one still present).
+
 ### 1.72.0 — Alderamin (Minor, Released 2026-07-26)
 - **Declarative cross-phase provider ordering.** `DeclaresLoadOrder` (static metadata) + a pure
   `ProviderOrderer` applied in `ProviderClassResolver`: container compilation, live discovery,

--- a/src/Extensions/ExtensionManager.php
+++ b/src/Extensions/ExtensionManager.php
@@ -437,6 +437,15 @@ final class ExtensionManager
      */
     public function writeCacheNow(?array $providerClasses = null): void
     {
+        // No explicit list ⇒ recompile from CURRENT on-disk config. Every real caller sits in
+        // a read→write→recompile sequence (extensions:enable/disable, the admin toggle): the
+        // enabled list was already read — and cached on the context — BEFORE the state write,
+        // so resolving through that cache would persist the PRE-write activation state. Config
+        // defaults and overrides survive clearConfigCache(); only the file-read layer drops.
+        if ($providerClasses === null) {
+            $this->getContext()->clearConfigCache();
+        }
+
         // Rebuild internal providers list deterministically. An explicit list gets the same
         // declarative ordering guarantee as the resolver path (idempotent there); list
         // COMPLETENESS remains the caller's responsibility — omitted providers are not added.

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,7 +13,7 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.72.0';
+    public const VERSION = '1.72.1';
 
 
     /** Release code name */

--- a/tests/Unit/Extensions/ProviderOrderParityTest.php
+++ b/tests/Unit/Extensions/ProviderOrderParityTest.php
@@ -7,7 +7,9 @@ namespace Glueful\Tests\Unit\Extensions;
 use Glueful\Bootstrap\ApplicationContext;
 use Glueful\Bootstrap\ConfigurationLoader;
 use Glueful\Extensions\DeclaresLoadOrder;
+use Glueful\Extensions\EnabledProviders;
 use Glueful\Extensions\ExtensionManager;
+use Glueful\Extensions\ExtensionStateWriter;
 use Glueful\Extensions\OrderedProvider;
 use Glueful\Extensions\ProviderClassResolver;
 use Glueful\Extensions\ServiceProvider;
@@ -158,6 +160,29 @@ final class ProviderOrderParityTest extends TestCase
         $liveManager = new ExtensionManager($this->container);
         $liveManager->discover();
         self::assertEarlyBeforeLate(array_keys($this->providersOf($liveManager)), 'uncached discovery');
+    }
+
+    public function testRecompileAfterAStateWriteSeesTheNewFileState(): void
+    {
+        // The read→write→recompile sequence every activation surface runs (extensions:enable,
+        // the admin toggles): reading the enabled list primes the context config cache, then
+        // ExtensionStateWriter mutates the file, then writeCacheNow() recompiles. The recompile
+        // must observe the JUST-WRITTEN state, not the primed cache — a stale recompile writes
+        // a cache missing the provider that was just enabled.
+        file_put_contents($this->base . '/config/extensions.php', "<?php\nreturn [\n    'enabled' => [\n    ],\n];\n");
+        self::assertSame([], EnabledProviders::from($this->context)); // primes the config cache
+
+        (new ExtensionStateWriter())->enable(
+            $this->base . '/config/extensions.php',
+            ParityEarlyExtensionProvider::class,
+        );
+        (new ExtensionManager($this->container))->writeCacheNow();
+
+        self::assertContains(
+            ParityEarlyExtensionProvider::class,
+            require $this->base . '/bootstrap/cache/extensions.php',
+            'writeCacheNow() must recompile from current file state, not the primed config cache',
+        );
     }
 
     public function testLegacyCycleFallbackKeepsTheDeclarativeOrder(): void


### PR DESCRIPTION
Activation writes recompile the extension cache from current file state:
no-arg writeCacheNow() clears the context config cache before resolving,
so extensions:enable/disable and the admin toggles no longer persist the
pre-write activation state.