### PR TITLE
Release 1.74.0 — Algenib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.74.0] - 2026-07-30 — Algenib
+
+**Theme: username validation matches the column, not a product rule** — one widened bound so an
+application can use a normalized email as a username. Low risk: strictly more permissive, no
+schema change, nothing previously valid becomes invalid.
+
+### Changed
+- **Username validation widened from 3–30 to 3–255 characters** (`UsernameDTO`, `UserDTO`, both via
+  a new `MAX_LENGTH` constant). 255 is the `users.username` column width, so the framework now
+  enforces only storage-safe invariants — required, trimmed, at least 3 characters, within the
+  column, unique. A 30-character ceiling is a product rule, and the framework cannot know what a
+  host's usernames are for: an application that uses a normalized email as the username needs the
+  full width, since plenty of valid addresses exceed 30 characters. Applications wanting something
+  narrower (slug-safe charsets, reserved names, shorter limits) impose it at their own input
+  boundary. Deliberately not unbounded — accepting more than the column holds would only move the
+  rejection to the database.
+
+### Upgrade Notes
+- Strictly more permissive: every username that validated before still validates. No migration is
+  required; the column has always been `varchar(255)`.
+- If your application relies on the framework rejecting usernames longer than 30 characters, add
+  that rule at your own input boundary — it is no longer enforced centrally.
+
 ## [1.73.0] - 2026-07-29 — Algedi
 
 **Theme: browsers get a first-class transport** — an opt-in HttpOnly cookie session alongside

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,12 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.74.0 — Algenib (Minor, Released 2026-07-30)
+- **Username validation widened to the column width (3–255).** `UsernameDTO` and `UserDTO` now
+  enforce only storage-safe invariants; a 30-character ceiling is an application product rule, and
+  an app using a normalized email as its username needs the full width. Strictly more permissive,
+  no schema change.
+
 ### 1.73.0 — Algedi (Minor, Released 2026-07-29)
 - **Opt-in browser session transport.** `session_cookie` middleware adapts an HttpOnly access
   cookie into the `Authorization` header the existing `auth` middleware already reads, marking

--- a/src/DTOs/UserDTO.php
+++ b/src/DTOs/UserDTO.php
@@ -13,6 +13,15 @@ use Glueful\Validation\Rules\{Sanitize, Required, Email as EmailRule, Length, In
  */
 class UserDTO
 {
+    /**
+     * Storage-safe ceiling: the `users.username` column is `varchar(255)`, so this is the widest
+     * value that can actually be stored. Deliberately NOT narrower — a 30-character product rule
+     * belongs at an application's own input boundary, not in the framework, and an app that uses
+     * a normalized email as the username needs the full width. Deliberately not unbounded either:
+     * accepting more than the column holds only moves the rejection to the database.
+     */
+    public const MAX_LENGTH = 255;
+
     public string $name;
     public string $email;
     public ?string $password = null;
@@ -62,7 +71,7 @@ class UserDTO
             'name' => [new Sanitize(['trim', 'strip_tags']), new Required(), new Length(2, 50)],
             'email' => [new Sanitize(['trim', 'strip_tags']), new Required(), new EmailRule()],
             'password' => [new Sanitize(['trim']), new Length(8, 255)],
-            'username' => [new Sanitize(['trim', 'strip_tags']), new Length(3, 30)],
+            'username' => [new Sanitize(['trim', 'strip_tags']), new Length(3, self::MAX_LENGTH)],
             'status' => [new Sanitize(['trim']), new InArray(['active','inactive','suspended','banned'])],
             'role' => [new Sanitize(['trim']), new InArray(['user','admin','moderator','guest'])],
         ]);

--- a/src/DTOs/UsernameDTO.php
+++ b/src/DTOs/UsernameDTO.php
@@ -10,6 +10,15 @@ use Glueful\Validation\Rules\{Sanitize, Required, Length};
 
 class UsernameDTO
 {
+    /**
+     * Storage-safe ceiling: the `users.username` column is `varchar(255)`, so this is the widest
+     * value that can actually be stored. Deliberately NOT narrower — a 30-character product rule
+     * belongs at an application's own input boundary, not in the framework, and an app that uses
+     * a normalized email as the username needs the full width. Deliberately not unbounded either:
+     * accepting more than the column holds only moves the rejection to the database.
+     */
+    public const MAX_LENGTH = 255;
+
     public string $username = '';
 
     public function __construct(string $username = '')
@@ -24,7 +33,7 @@ class UsernameDTO
     public static function from(array $input): self
     {
         $v = RuleFactory::of([
-            'username' => [new Sanitize(['trim', 'strip_tags']), new Required(), new Length(3, 30)],
+            'username' => [new Sanitize(['trim', 'strip_tags']), new Required(), new Length(3, self::MAX_LENGTH)],
         ]);
         $errors = $v->validate($input);
         if (count($errors) > 0) {

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,15 +13,15 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.73.0';
+    public const VERSION = '1.74.0';
 
 
     /** Release code name */
-    public const NAME = 'Algedi';
+    public const NAME = 'Algenib';
 
 
     /** Release date */
-    public const RELEASE_DATE = '2026-07-29';
+    public const RELEASE_DATE = '2026-07-30';
 
     /** Minimum required PHP version */
     public const MIN_PHP_VERSION = '8.3.0';

--- a/tests/Unit/DTOs/UsernameLengthTest.php
+++ b/tests/Unit/DTOs/UsernameLengthTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\DTOs;
+
+use Glueful\DTOs\UsernameDTO;
+use Glueful\DTOs\UserDTO;
+use Glueful\Validation\ValidationException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Username length is a STORAGE-safe invariant, not a product rule.
+ *
+ * The framework enforces required, trimmed, 3 characters minimum, and the schema's own 255
+ * maximum. Anything narrower — 30 characters, slug-safe charsets, reserved names — is an
+ * application policy that belongs at the app's own input boundary, because the framework cannot
+ * know what a host's usernames are for. Notably, an application using a normalized email as the
+ * username needs the full column width: plenty of valid addresses exceed 30 characters.
+ *
+ * Not unbounded, though: 255 is what the column holds, and accepting more would invite input the
+ * database must then reject.
+ */
+final class UsernameLengthTest extends TestCase
+{
+    private function username(int $length): string
+    {
+        return str_repeat('a', $length);
+    }
+
+    public function testTheMinimumIsThreeCharacters(): void
+    {
+        self::assertSame('abc', UsernameDTO::from(['username' => 'abc'])->username);
+    }
+
+    public function testTwoCharactersIsRejected(): void
+    {
+        $this->expectException(ValidationException::class);
+        UsernameDTO::from(['username' => 'ab']);
+    }
+
+    public function testThirtyCharactersIsAccepted(): void
+    {
+        // The old ceiling: still valid, so no existing username becomes invalid.
+        self::assertSame($this->username(30), UsernameDTO::from(['username' => $this->username(30)])->username);
+    }
+
+    public function testThirtyOneCharactersIsAccepted(): void
+    {
+        // The behavioural change: one past the old ceiling.
+        self::assertSame($this->username(31), UsernameDTO::from(['username' => $this->username(31)])->username);
+    }
+
+    public function testTwoHundredFiftyFiveCharactersIsAccepted(): void
+    {
+        // The schema's width is the ceiling.
+        self::assertSame($this->username(255), UsernameDTO::from(['username' => $this->username(255)])->username);
+    }
+
+    public function testTwoHundredFiftySixCharactersIsRejected(): void
+    {
+        // Wider than the column: rejected here rather than by the database.
+        $this->expectException(ValidationException::class);
+        UsernameDTO::from(['username' => $this->username(256)]);
+    }
+
+    public function testALongEmailIsAValidUsername(): void
+    {
+        // The motivating case: an application that uses the normalized email as the username.
+        $email = 'first.middle.last.name+storefront@a-fairly-long-domain-name.example.test';
+        self::assertGreaterThan(30, strlen($email));
+
+        self::assertSame($email, UsernameDTO::from(['username' => $email])->username);
+    }
+
+    /** UserDTO validates a whole user, so name and email are required alongside the username. */
+    private function userInput(string $username): array
+    {
+        return ['name' => 'Ada Lovelace', 'email' => 'ada@example.test', 'username' => $username];
+    }
+
+    public function testUserDtoSharesTheSameBounds(): void
+    {
+        // Two validators, one rule — a narrower limit here would reject what UsernameDTO accepts.
+        $email = 'first.middle.last.name+storefront@a-fairly-long-domain-name.example.test';
+
+        self::assertSame($email, UserDTO::from($this->userInput($email))->username);
+        self::assertSame(
+            $this->username(255),
+            UserDTO::from($this->userInput($this->username(255)))->username
+        );
+    }
+
+    public function testUserDtoRejectsBeyondTheColumnWidth(): void
+    {
+        $this->expectException(ValidationException::class);
+        UserDTO::from($this->userInput($this->username(256)));
+    }
+}


### PR DESCRIPTION
Widens username validation from 3-30 to 3-255 characters in UsernameDTO and UserDTO, via a shared MAX_LENGTH constant set to the users.username column width.

The framework now enforces only storage-safe invariants: required, trimmed, at least 3 characters, within the column, unique. A 30-character ceiling is a product rule, and the framework cannot know what a host's usernames are for — an application that uses a normalized email as the username needs the full width, since plenty of valid addresses exceed 30 characters. Narrower policies belong at an application's own input boundary.

Not unbounded: accepting more than the column holds would only move the rejection to the database, where the failure is worse. Strictly more permissive, so nothing that validated before stops validating, and no migration is required.

