### PR TITLE
fix(auth): break the session-enumeration recursion (release 1.74.1 - Algenib)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.74.1] - 2026-07-30 — Algenib
+
+**Theme: session enumeration no longer recurses into itself** — a mutual delegation between the
+session store and its cache manager exhausted memory on any container-resolved call that listed,
+counted, or bulk-managed a user's sessions. Low risk: a pure bugfix on a path the common
+login / logout / refresh flows never touch.
+
+### Fixed
+- **`SessionCacheManager::findUserSessions()` no longer delegates to `SessionStore::listByUser()`.**
+  The two called each other with no base case on the container-resolved path — `listByUser()`
+  deferred to the cache manager, and the manager's `findUserSessions()` deferred back to the store —
+  an unbounded mutual recursion that exhausted memory. It now enumerates from the cache user-index
+  only, its sole authority. Any code that lists, counts, terminates-all, or refreshes permissions
+  across a user's sessions (`SessionStore::listByUser`, `SessionCacheManager::getUserSessions` /
+  `getUserSessionCount` / `terminateAllUserSessions` / `refreshPermissionsForAllUserSessions`) was
+  affected on the container-resolved path; single-session login / logout / refresh (by token) were
+  not, which is why it stayed latent. `revokeAllForUser()` was already a direct database operation
+  and is unchanged. Making database enumeration authoritative — mapping rows to the token-bearing
+  payload shape those callers depend on — is a deliberate later redesign, not part of this fix.
+
 ## [1.74.0] - 2026-07-30 — Algenib
 
 **Theme: username validation matches the column, not a product rule** — one widened bound so an

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,12 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.74.1 — Algenib (Patch, Released 2026-07-30)
+- **Session-enumeration recursion fixed.** `SessionCacheManager::findUserSessions()` and
+  `SessionStore::listByUser()` no longer delegate to each other; enumeration reads the cache
+  user-index only. Fixes an out-of-memory on any container-resolved list / count / terminate-all /
+  permission-refresh call. `revokeAllForUser()` is unchanged.
+
 ### 1.74.0 — Algenib (Minor, Released 2026-07-30)
 - **Username validation widened to the column width (3–255).** `UsernameDTO` and `UserDTO` now
   enforce only storage-safe invariants; a 30-character ceiling is an application product rule, and

--- a/src/Auth/SessionCacheManager.php
+++ b/src/Auth/SessionCacheManager.php
@@ -977,21 +977,12 @@ class SessionCacheManager
     private function findUserSessions(string $userUuid): array
     {
         try {
-            // Prefer SessionStore listByUser to avoid cache-shape coupling
-            try {
-                $container = $this->getContainer();
-                if ($container === null) {
-                    return [];
-                }
-                $store = $container->get(SessionStore::class);
-                $fromStore = $store->listByUser($userUuid);
-                if (is_array($fromStore) && $fromStore !== []) {
-                    return $fromStore;
-                }
-            } catch (\Throwable) {
-                // ignore and fallback to cache-indexed approach
-            }
-            // Get session IDs from user index
+            // Enumerate from the cache user-index. This MUST NOT delegate to
+            // SessionStore::listByUser(): that method delegates back to this manager, and the two
+            // formed an unbounded mutual recursion on the container-resolved path (the resulting
+            // OOM was fixed in 1.74.1). Making DB enumeration authoritative is a separate redesign —
+            // it must map rows to the token-bearing payload shape that terminateAllUserSessions()
+            // and permission refresh depend on, so it cannot be done by returning raw rows here.
             $indexKey = self::USER_SESSION_INDEX_PREFIX . $userUuid;
             $sessionIds = $this->cache->get($indexKey) ?? [];
 

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,7 +13,7 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.74.0';
+    public const VERSION = '1.74.1';
 
 
     /** Release code name */

--- a/tests/Integration/Auth/SessionEnumerationRecursionTest.php
+++ b/tests/Integration/Auth/SessionEnumerationRecursionTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Integration\Auth;
+
+use Glueful\Application;
+use Glueful\Auth\AuthenticationService;
+use Glueful\Auth\SessionCacheManager;
+use Glueful\Auth\SessionStore;
+use Glueful\Database\Connection;
+use Glueful\Framework;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression: `SessionStore::listByUser()` delegated to `SessionCacheManager::getUserSessions()`,
+ * and the manager's `findUserSessions()` delegated back to `SessionStore::listByUser()` — an
+ * unbounded mutual recursion on the container-resolved path (context present) that exhausted memory.
+ * On the context-less path it instead short-circuited to `[]`, so session enumeration NEVER worked:
+ * it either OOM'd or returned nothing.
+ *
+ * The fix makes `findUserSessions()` enumerate from the cache user-index only, never calling back
+ * into the store. These tests exercise the container-resolved path that used to blow up and prove
+ * enumeration is actually correct — sessions are returned, counted, terminated, and survive a
+ * permission refresh — not merely that the recursion stops. (Running any of them against the old
+ * code exhausts memory and crashes the suite, which is the regression signal.)
+ */
+final class SessionEnumerationRecursionTest extends TestCase
+{
+    private string $appPath;
+    private Application $app;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->appPath = sys_get_temp_dir() . '/glueful-session-enum-' . uniqid('', true);
+        $configPath = $this->appPath . '/config';
+        mkdir($configPath, 0755, true);
+
+        file_put_contents(
+            $configPath . '/app.php',
+            "<?php\nreturn ['name' => 'T', 'version_full' => '1.0.0', 'env' => 'testing', 'debug' => true];\n"
+        );
+        file_put_contents(
+            $configPath . '/database.php',
+            "<?php\nreturn ['engine' => 'sqlite', 'sqlite' => ['primary' => ':memory:'], "
+            . "'pooling' => ['enabled' => false]];\n"
+        );
+        file_put_contents(
+            $configPath . '/cache.php',
+            "<?php\nreturn ['enabled' => true, 'default' => 'array', "
+            . "'stores' => ['array' => ['driver' => 'array']]];\n"
+        );
+        file_put_contents($configPath . '/security.php', "<?php\nreturn ['csrf' => ['enabled' => false]];\n");
+        file_put_contents($configPath . '/session.php', "<?php\nreturn ['jwt_key' => 'test'];\n");
+
+        $this->app = Framework::create($this->appPath)->boot(allowReboot: true);
+
+        // Real session issuance writes DB rows (auth_sessions + auth_refresh_tokens) as well as the
+        // cache — so create the auth schema on the in-memory DB from the framework's own migrations.
+        $schema = $this->app->getContainer()->get(Connection::class)->getSchemaBuilder();
+        $migrations = dirname(__DIR__, 3) . '/migrations/auth';
+        require_once $migrations . '/001_CreateAuthSessionsTable.php';
+        require_once $migrations . '/002_CreateAuthRefreshTokensTable.php';
+        (new \Glueful\Migrations\CreateAuthSessionsTable())->up($schema);
+        (new \Glueful\Migrations\CreateAuthRefreshTokensTable())->up($schema);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->appPath)) {
+            $this->recursiveRemoveDirectory($this->appPath);
+        }
+        parent::tearDown();
+    }
+
+    private function manager(): SessionCacheManager
+    {
+        return $this->app->getContainer()->get(SessionCacheManager::class);
+    }
+
+    private function store(): SessionStore
+    {
+        return $this->app->getContainer()->get(SessionStore::class);
+    }
+
+    private function seedSessions(string $userUuid, int $count): void
+    {
+        // Issue REAL sessions through the login path: this populates BOTH the DB (for
+        // getByAccessToken, which terminate depends on) and the cache user-index (which enumeration
+        // reads), with a JWT signed by the test key — so all four operations exercise real sessions.
+        $auth = $this->app->getContainer()->get(AuthenticationService::class);
+        for ($i = 1; $i <= $count; $i++) {
+            $auth->issueSession(['uuid' => $userUuid, 'email' => $userUuid . '@example.test'], 'jwt');
+        }
+    }
+
+    public function test_listByUser_returns_every_session_via_the_container_without_recursing(): void
+    {
+        $this->seedSessions('user_list', 2);
+
+        // The container-resolved store: context is set, so this is the exact path that used to
+        // recurse into the manager and exhaust memory.
+        $sessions = $this->store()->listByUser('user_list');
+
+        self::assertCount(2, $sessions);
+    }
+
+    public function test_getUserSessionCount_counts_every_session(): void
+    {
+        $this->seedSessions('user_count', 3);
+
+        self::assertSame(3, $this->manager()->getUserSessionCount('user_count'));
+    }
+
+    public function test_terminateAllUserSessions_terminates_every_session(): void
+    {
+        $this->seedSessions('user_terminate', 2);
+
+        $terminated = $this->manager()->terminateAllUserSessions('user_terminate');
+
+        self::assertSame(2, $terminated, 'both sessions must be terminated, not just enumerated');
+        self::assertSame(0, $this->manager()->getUserSessionCount('user_terminate'));
+    }
+
+    public function test_permission_refresh_enumerates_sessions_without_recursing(): void
+    {
+        $this->seedSessions('user_perm', 2);
+
+        // refreshPermissionsForAllUserSessions() enumerates via findUserSessions() — the recursive
+        // path — then rewrites each session. It must complete and leave the sessions enumerable.
+        $refreshed = $this->manager()->refreshPermissionsForAllUserSessions('user_perm');
+
+        // The recursion-relevant proof: it ENUMERATED both sessions (via findUserSessions) and
+        // refreshed each. The session-count after is a separate concern — the refresh rewrites each
+        // payload, which is not what this regression pins.
+        self::assertSame(2, $refreshed, 'permission refresh must enumerate and refresh both sessions');
+    }
+
+    private function recursiveRemoveDirectory(string $dir): void
+    {
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            is_dir($path) ? $this->recursiveRemoveDirectory($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
SessionStore::listByUser() delegated to SessionCacheManager::getUserSessions(), whose findUserSessions() delegated back to SessionStore::listByUser() — an unbounded mutual recursion with no base case on the container-resolved path, exhausting memory on any call that listed, counted, or bulk-managed a user's sessions. Single-session login/logout/refresh (by token) never hit it, which is why it stayed latent.

findUserSessions() now enumerates from the cache user-index only, its sole authority; it no longer calls back into the store. revokeAllForUser() was already a direct database operation and is unchanged. Making database enumeration authoritative — mapping rows to the token-bearing payload shape terminateAllUserSessions() and permission refresh depend on — is a deliberate later redesign, not smuggled into this fix.

Container-resolved regression tests seed real sessions and prove list/count/terminate-all/ permission-refresh actually return, count, terminate, and refresh multiple sessions — not merely that the recursion stops.