### PR TITLE
Enhance logging with configurable sensitive path redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,70 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.78.0] - 2026-08-12 — Alioth
+
+**Theme: credentials in URL paths stop reaching the logs.** Redaction has always been
+keyed on parameter *names*, which covers query strings and body fields but not a secret
+carried in the path itself. Applications that issue signed payment links, magic links or
+one-time download URLs can now register those route templates and have the credential
+segment masked in every framework log sink.
+
+### Added
+- **Configurable sensitive path redaction** — `SensitiveParamRedactor::configureSensitivePaths()`
+  and `sanitizePath()` mask credential-bearing URL path segments. Applications register
+  route templates under the new `logging.sensitive_paths` config key (or the
+  `LOG_SENSITIVE_PATHS` comma-separated env var), and `Framework::boot()` wires them into
+  the redactor after provider/extension config is merged:
+
+  ```php
+  // config/logging.php
+  'sensitive_paths' => ['/checkout/pay/{token}', '/d/{signature}/file'],
+  ```
+
+  A `{name}` segment is replaced with `[REDACTED]`; a bare `*` segment matches any single
+  segment and is kept; segments beyond the pattern are preserved. Matching is anchored at
+  the start of the path and **mirrors `Router::match()`'s own normalization** — literal
+  segments compare case-insensitively after percent-decoding, repeated slashes collapse,
+  and `%2F` is treated as a segment boundary — so the spellings that reach a live route
+  (`//checkout/pay/x`, `/checkout%2Fpay/x`) are redacted too, while a `%2F` *inside* a
+  credential cannot split the secret across segments and half-redact it.
+
+  Templates are written **without** the deployment's base URL. `Request::getBaseUrl()` is
+  passed alongside every `getRequestUri()` value and stripped before matching, so one
+  template covers both base-URL-mounted and root-mounted deployments.
+
+### Security
+- **The request logger and the exception handler no longer emit raw path credentials** —
+  `Application::handle()` logged `'uri' => $request->getPathInfo()` verbatim at info level
+  (dev/staging, or any profile with `APP_DEBUG` on), and `Handler::report()` logged the
+  request URI at error level in *every* profile, because `SensitiveParamRedactor::sanitizeUrl()`
+  redacted the query string but reassembled the path untouched. Both now route through
+  `sanitizePath()`.
+- **Every remaining request-path log sink was swept** — the request/response logging
+  middleware's separate raw `path` field, `CSRFMiddleware` (error level, and the
+  `SecurityException` details it raises), `AuthMiddleware`, `SecurityHeadersMiddleware`,
+  `AdminPermissionMiddleware`, `VersionManager`, `FieldSelectionMiddleware`,
+  `TracingMiddleware`'s span attributes and `MetricsMiddleware`'s `endpoint` — which is
+  *persisted* to the metrics store, not just logged. Auth access logs and the activity
+  subscriber inherit the fix through `sanitizeUrl()`. Rate-limit bucket keys are
+  deliberately left raw: they are not a log sink, and redacting them would collapse every
+  credentialed path onto one bucket.
+- **`sanitizeUrl()` no longer mis-parses a schemeless `//…` request URI** — `parse_url()`
+  read its first segment as a *host*, carrying the rest of the path past redaction
+  untouched.
+
+  Redaction happens at log-emission time only and never mutates the request, so routing,
+  signature verification and handlers still see the original path.
+
+  **Host obligation:** only the application knows which of its routes are credential-bearing,
+  so nothing is redacted until it registers its patterns — with `logging.sensitive_paths`
+  empty (the framework default) every path is logged exactly as before, byte-identical.
+  Redaction also covers framework log sinks only: reverse-proxy, web-server and CDN access
+  logs record the raw request line and remain the operator's responsibility. And redaction
+  applies to path- and query-shaped *values*: an exception whose **message** interpolates
+  the request URI is still logged verbatim (see `docs/SECURITY_NOTES.md`) — put the URI in
+  the exception context, which is redacted, not in the message.
+
 ## [1.77.0] - 2026-08-09 — Alhena
 
 **Theme: deterministic OpenAPI artifacts.** Generated specifications are now byte-stable

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,20 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.78.0 — Alioth (Minor, Released 2026-08-12)
+- **Configurable sensitive path redaction.** Applications register credential-bearing route
+  templates under `logging.sensitive_paths` (e.g. `/checkout/pay/{token}`) and
+  `SensitiveParamRedactor::sanitizePath()` masks those segments in every framework log
+  sink — the `Application::handle()` request log, `Handler::report()` exception context,
+  the request/response logging middleware, the CSRF/auth/security-header/admin-permission
+  middleware, API version negotiation, tracing spans, field selection, auth access logs,
+  the activity subscriber and the *persisted* API-metrics `endpoint`. Matching mirrors
+  `Router::match()`'s normalization, so encoded and slash-collapsed spellings of a live
+  route are covered, and the request's base URL is stripped before matching so one template
+  serves both base-URL-mounted and root-mounted apps. Never mutates the request. Empty by
+  default, so unregistered paths log byte-identically to before, and proxy/CDN access logs
+  remain the operator's responsibility.
+
 ### 1.77.0 — Alhena (Minor, Released 2026-08-09)
 - **Canonical, deterministic OpenAPI path ordering.** `DocGenerator::getSwaggerJson()` now
   sorts `paths` lexicographically and orders each path item's operations

--- a/config/logging.php
+++ b/config/logging.php
@@ -92,6 +92,33 @@ return [
     'default_profile' => $defaultProfile,
     'profiles' => $profiles,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Sensitive Request Paths
+    |--------------------------------------------------------------------------
+    |
+    | Route templates whose path itself carries a credential — signed payment
+    | links, magic links, one-time downloads. Placeholder segments written as
+    | {name} are replaced with [REDACTED] in every log message and structured
+    | log context (request logging, exception reports, activity logs); a bare
+    | '*' segment matches any single segment and is kept. Literal segments are
+    | matched case-insensitively and after percent-decoding, so an encoded path
+    | cannot slip past. Redaction is log-emission-time only and never mutates
+    | the request, so routing and handlers see the original path.
+    |
+    |   'sensitive_paths' => ['/checkout/pay/{token}', '/d/{signature}/file'],
+    |
+    | Only the application knows which of its routes are credential-bearing, so
+    | the framework default is empty (paths are logged unchanged). Reverse-proxy
+    | and web-server access logs are outside the framework's reach and remain
+    | the host's responsibility.
+    |
+    */
+    'sensitive_paths' => array_values(array_filter(
+        array_map('trim', explode(',', (string) env('LOG_SENSITIVE_PATHS', ''))),
+        static fn(string $pattern): bool => $pattern !== ''
+    )),
+
     // Framework-level logging configuration
     'framework' => [
         'enabled' => env('FRAMEWORK_LOGGING_ENABLED', true),

--- a/config/logging.php
+++ b/config/logging.php
@@ -100,13 +100,22 @@ return [
     | Route templates whose path itself carries a credential — signed payment
     | links, magic links, one-time downloads. Placeholder segments written as
     | {name} are replaced with [REDACTED] in every log message and structured
-    | log context (request logging, exception reports, activity logs); a bare
+    | log context (request logging, exception reports, activity logs, the CSRF/
+    | auth/security middleware, tracing spans and persisted API metrics); a bare
     | '*' segment matches any single segment and is kept. Literal segments are
-    | matched case-insensitively and after percent-decoding, so an encoded path
-    | cannot slip past. Redaction is log-emission-time only and never mutates
-    | the request, so routing and handlers see the original path.
+    | matched case-insensitively and after percent-decoding, and matching mirrors
+    | the router's own path normalization, so the forms that reach a live route
+    | ('//checkout/pay/x', '/checkout%2Fpay/x') cannot slip past. Redaction is
+    | log-emission-time only and never mutates the request, so routing and
+    | handlers see the original path.
     |
     |   'sensitive_paths' => ['/checkout/pay/{token}', '/d/{signature}/file'],
+    |
+    | Write templates WITHOUT the deployment's base URL — an app mounted at
+    | /api registers '/checkout/pay/{token}', not '/api/checkout/pay/{token}'.
+    | The base URL is stripped before matching and restored on output, so one
+    | template covers both the request log (which sees the path with the base URL
+    | already removed) and the exception log (which sees it still attached).
     |
     | Only the application knows which of its routes are credential-bearing, so
     | the framework default is empty (paths are logged unchanged). Reverse-proxy

--- a/docs/SECURITY_NOTES.md
+++ b/docs/SECURITY_NOTES.md
@@ -34,21 +34,28 @@ the "What would close it" column is the work item.
   text parts whose field names match `SensitiveParamRedactor` patterns, or
   refuse to log multipart bodies at all.
 
-### Secrets in URL path segments are not redacted
+### Secrets in URL path segments are redacted only for paths the app registers
 
-- **Where:** `Glueful\Support\SensitiveParamRedactor::sanitizeUrl()` and every
-  caller (request/response logging, exception reporting, auth access logs,
-  security-violation listener).
-- **What:** Redaction is keyed on parameter *names*, so it covers query strings
-  and form/JSON fields. A secret embedded in the path itself —
-  `/password-reset/{token}`, `/verify/abc123` — is logged verbatim (including
-  the middleware's separate raw `path` field).
-- **Why accepted:** Path segments carry no name to match on; heuristic
+*Closed in 1.78.0 for registered paths — previously "not redacted at all".*
+
+- **Where:** `Glueful\Support\SensitiveParamRedactor::sanitizePath()`, applied by
+  `sanitizeUrl()` and every caller (request/response logging including its
+  separate `path` field, exception reporting, auth access logs,
+  security-violation listener) plus `Application::handle()`'s request log.
+- **What:** Name-based redaction covers query strings and form/JSON fields. A
+  secret embedded in the path itself — `/password-reset/{token}`,
+  `/checkout/pay/{token}` — is redacted only when the application registers that
+  route template under `logging.sensitive_paths`. Unregistered paths are logged
+  verbatim.
+- **Why accepted:** Path segments carry no name to match on, and heuristic
   entropy-based redaction produces false positives that destroy log usability.
-  The framework's own routes don't put bearer-grade secrets in paths.
-- **What would close it:** Application-level discipline (prefer one-time POST
-  bodies over tokenized GET paths), or a per-route opt-in that masks named
-  route parameters (e.g. any param named `token`) before logging.
+  Only the application knows which of its routes are credential-bearing, so the
+  registration is an explicit host obligation; the framework's own routes put no
+  bearer-grade secrets in paths.
+- **What would close it:** Nothing further inside the framework — but note that
+  redaction applies to *framework* log sinks only. Reverse-proxy, web-server and
+  CDN access logs record the raw request line and remain the operator's
+  responsibility (drop or mask the path there too).
 
 ### Dormant raw-URL logging surfaces
 
@@ -233,3 +240,4 @@ deployment provides their configuration:
 | `CORS_ALLOWED_ORIGINS` | Cross-origin access control | Standalone CORS handler denies all cross-origin requests (fail-closed) |
 | `TOKEN_ALLOW_QUERY_PARAM` (default off) | Keeps bearer tokens out of URLs/logs | Enabling it re-opens query-string token exposure |
 | `QUEUE_REQUIRE_SIGNED_PAYLOADS` (default on) | Rejects unsigned queue rows | Disable only temporarily while draining pre-signing payloads |
+| `logging.sensitive_paths` / `LOG_SENSITIVE_PATHS` (default empty) | Masks credential-bearing URL path segments in framework logs | Signed/magic-link tokens in paths are written verbatim to every log sink |

--- a/docs/SECURITY_NOTES.md
+++ b/docs/SECURITY_NOTES.md
@@ -41,7 +41,13 @@ the "What would close it" column is the work item.
 - **Where:** `Glueful\Support\SensitiveParamRedactor::sanitizePath()`, applied by
   `sanitizeUrl()` and every caller (request/response logging including its
   separate `path` field, exception reporting, auth access logs,
-  security-violation listener) plus `Application::handle()`'s request log.
+  security-violation listener), `Application::handle()`'s request log, and the
+  CSRF / auth / security-header / admin-permission middleware, API version
+  negotiation, request tracing, field selection and the persisted API metrics
+  `endpoint`. Matching mirrors `Router::match()`'s normalization, so the forms
+  that reach a live route (`//checkout/pay/x`, `/checkout%2Fpay/x`) are covered
+  too. `Request::getBaseUrl()` is passed alongside every `getRequestUri()` value,
+  so one registered template covers both base-URL-mounted and root-mounted logs.
 - **What:** Name-based redaction covers query strings and form/JSON fields. A
   secret embedded in the path itself — `/password-reset/{token}`,
   `/checkout/pay/{token}` — is redacted only when the application registers that
@@ -57,11 +63,29 @@ the "What would close it" column is the work item.
   CDN access logs record the raw request line and remain the operator's
   responsibility (drop or mask the path there too).
 
+### Exception *messages* embedding a URI are not scanned
+
+- **Where:** `Glueful\Http\Exceptions\Handler::report()`, which logs
+  `$e->getMessage()` as the log message alongside the redacted context.
+- **What:** Path and parameter redaction operate on path- and query-shaped
+  *values*. If application code throws an exception whose **message** embeds the
+  request URI (`"payment link {$request->getRequestUri()} expired"`), that
+  message is logged verbatim.
+- **Why accepted:** Redacting arbitrary free text would mean pattern-scanning
+  every log message emitted anywhere, with false positives that corrupt messages
+  and a cost paid on every log call. No framework-thrown exception embeds the
+  request URI in its message.
+- **What would close it:** Application discipline (never interpolate a request
+  URI into an exception message — put it in the context, which *is* redacted), or
+  an opt-in message-scanning processor on the log channel.
+
 ### Dormant raw-URL logging surfaces
 
 - **Where:** `Glueful\Logging\LogManager::logApiRequest()` (no in-framework
   callers); `Glueful\Http\RequestUserContext::getRequestMetadata()` (stores raw
-  `REQUEST_URI` as request metadata, not a log emission).
+  `REQUEST_URI` as request metadata, not a log emission). These are the only two
+  raw-URL surfaces left after the 1.78.0 sweep routed every live log/metric/span
+  call site through the redactor.
 - **What:** These public APIs would record unredacted URLs if a consumer wires
   them up.
 - **Why accepted:** Neither is called by the framework itself; redacting

--- a/src/Api/Versioning/VersionManager.php
+++ b/src/Api/Versioning/VersionManager.php
@@ -13,6 +13,7 @@ use Glueful\Api\Versioning\Resolvers\AcceptHeaderResolver;
 use Symfony\Component\HttpFoundation\Request;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Glueful\Support\SensitiveParamRedactor;
 
 /**
  * Central manager for API versioning
@@ -171,7 +172,7 @@ final class VersionManager implements VersionNegotiatorInterface
                 $this->logger->debug('API version resolved', [
                     'version' => $version->toString(),
                     'resolver' => $resolver->getName(),
-                    'path' => $request->getPathInfo(),
+                    'path' => SensitiveParamRedactor::sanitizePath($request->getPathInfo()),
                 ]);
 
                 // Validate version is supported in strict mode
@@ -189,7 +190,7 @@ final class VersionManager implements VersionNegotiatorInterface
 
         $this->logger->debug('Using default API version', [
             'version' => $this->defaultVersion->toString(),
-            'path' => $request->getPathInfo(),
+            'path' => SensitiveParamRedactor::sanitizePath($request->getPathInfo()),
         ]);
 
         return $this->defaultVersion;

--- a/src/Application.php
+++ b/src/Application.php
@@ -8,6 +8,7 @@ use Psr\Container\ContainerInterface;
 use Glueful\Routing\Router;
 use Glueful\Http\Cors;
 use Glueful\Http\Exceptions\Contracts\ExceptionHandlerInterface;
+use Glueful\Support\SensitiveParamRedactor;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response as HttpResponse;
@@ -64,7 +65,9 @@ class Application
                 'type' => 'request',
                 'request_id' => $requestId,
                 'method' => $request->getMethod(),
-                'uri' => $request->getPathInfo(),
+                // Paths can themselves be credentials (signed links, magic links).
+                // Redact registered sensitive path segments before they reach a sink.
+                'uri' => SensitiveParamRedactor::sanitizePath($request->getPathInfo()),
                 'time_ms' => $totalTime,
                 'status' => $response->getStatusCode(),
                 'timestamp' => date('c')

--- a/src/Auth/AuthenticationManager.php
+++ b/src/Auth/AuthenticationManager.php
@@ -271,7 +271,7 @@ class AuthenticationManager
             'ip_address' => $request->getClientIp(),
             'user_agent' => $request->headers->get('User-Agent'),
             'timestamp' => date('Y-m-d H:i:s'),
-            'request_uri' => $this->sanitizeLogUri($request->getRequestUri()),
+            'request_uri' => $this->sanitizeLogUri($request->getRequestUri(), $request->getBaseUrl()),
             'method' => $request->getMethod()
         ];
 
@@ -289,8 +289,8 @@ class AuthenticationManager
         }
     }
 
-    private function sanitizeLogUri(string $uri): string
+    private function sanitizeLogUri(string $uri, string $basePath = ''): string
     {
-        return SensitiveParamRedactor::sanitizeUrl($uri) ?? $uri;
+        return SensitiveParamRedactor::sanitizeUrl($uri, $basePath) ?? $uri;
     }
 }

--- a/src/Events/Listeners/ActivityLoggingSubscriber.php
+++ b/src/Events/Listeners/ActivityLoggingSubscriber.php
@@ -132,7 +132,10 @@ class ActivityLoggingSubscriber implements EventSubscriberInterface
             // Event details
             'violation_type' => $event->violationType,
             'message' => $event->message,
-            'request_uri' => SensitiveParamRedactor::sanitizeUrl($event->request->getRequestUri()),
+            'request_uri' => SensitiveParamRedactor::sanitizeUrl(
+                $event->request->getRequestUri(),
+                $event->request->getBaseUrl()
+            ),
             'request_method' => $event->request->getMethod(),
             'client_ip' => $event->request->getClientIp(),
             'event_id' => $event->getEventId(),

--- a/src/Framework.php
+++ b/src/Framework.php
@@ -23,6 +23,7 @@ use Glueful\Exceptions\ExceptionHandler;
 use Glueful\Events\QueueContextHolder;
 use Glueful\Helpers\Utils;
 use Glueful\Security\SecurityManager;
+use Glueful\Support\SensitiveParamRedactor;
 use Psr\Log\LoggerInterface;
 use Glueful\Auth\AuthenticationGuard;
 use Glueful\Auth\SessionStore;
@@ -141,6 +142,10 @@ class Framework
 
         // Phase 7: Framework Validation (15-17ms)
         $profiler->time('validation', fn() => $this->validateFramework());
+
+        // Log redaction is configured last so extension- and provider-supplied
+        // config defaults are already merged into logging.sensitive_paths.
+        $this->configureSensitivePathRedaction($context);
 
         // Create Application instance
         $application = new Application($context);
@@ -559,6 +564,24 @@ class Framework
     /**
      * Configure structured logging
      */
+    /**
+     * Register the application's credential-bearing request paths with the
+     * shared redactor, so those segments are masked in every log sink.
+     *
+     * Configured under `logging.sensitive_paths`; empty by default, in which
+     * case paths are logged exactly as before.
+     */
+    private function configureSensitivePathRedaction(ApplicationContext $context): void
+    {
+        try {
+            $patterns = config($context, 'logging.sensitive_paths', []);
+            SensitiveParamRedactor::configureSensitivePaths(is_array($patterns) ? $patterns : []);
+        } catch (\Throwable $e) {
+            // Redaction configuration must never take down a boot.
+            error_log('Failed to configure sensitive path redaction: ' . $e->getMessage());
+        }
+    }
+
     private function configureStructuredLogging(): void
     {
         try {

--- a/src/Http/Exceptions/Handler.php
+++ b/src/Http/Exceptions/Handler.php
@@ -384,7 +384,7 @@ class Handler implements ExceptionHandlerInterface
             if ($request !== null) {
                 $context['request'] = [
                     'method' => $request->getMethod(),
-                    'uri' => $this->sanitizeUrl($request->getRequestUri()),
+                    'uri' => $this->sanitizeUrl($request->getRequestUri(), $request->getBaseUrl()),
                     'ip' => $request->getClientIp(),
                 ];
             }
@@ -396,7 +396,7 @@ class Handler implements ExceptionHandlerInterface
         if ($request !== null) {
             $context['request'] = [
                 'method' => $request->getMethod(),
-                'uri' => $this->sanitizeUrl($request->getRequestUri()),
+                'uri' => $this->sanitizeUrl($request->getRequestUri(), $request->getBaseUrl()),
                 'ip' => $request->getClientIp(),
                 'user_agent' => $request->headers->get('User-Agent', 'unknown'),
             ];
@@ -420,10 +420,14 @@ class Handler implements ExceptionHandlerInterface
 
     /**
      * Sanitize a URL or request URI before logging.
+     *
+     * $basePath is the request's base URL: getRequestUri() still carries it,
+     * while getPathInfo() does not, so passing it keeps a single registered
+     * sensitive-path template covering both log sites.
      */
-    private function sanitizeUrl(?string $url): ?string
+    private function sanitizeUrl(?string $url, string $basePath = ''): ?string
     {
-        return SensitiveParamRedactor::sanitizeUrl($url);
+        return SensitiveParamRedactor::sanitizeUrl($url, $basePath);
     }
 
     /**

--- a/src/Routing/Middleware/AdminPermissionMiddleware.php
+++ b/src/Routing/Middleware/AdminPermissionMiddleware.php
@@ -21,6 +21,7 @@ use Glueful\Events\Security\AdminSecurityViolationEvent;
 use Glueful\Events\EventService;
 use Psr\Log\LoggerInterface;
 use Psr\Container\ContainerInterface;
+use Glueful\Support\SensitiveParamRedactor;
 
 /**
  * Admin Permission Middleware for Next-Gen Router
@@ -1041,7 +1042,7 @@ class AdminPermissionMiddleware implements RouteMiddleware
         $context = array_merge($this->context, [
             'admin_request' => true,
             'request_method' => $request->getMethod(),
-            'request_path' => $request->getPathInfo(),
+            'request_path' => SensitiveParamRedactor::sanitizePath($request->getPathInfo()),
             'request_ip' => $request->getClientIp(),
             'user_agent' => $request->headers->get('User-Agent'),
             'timestamp' => time(),
@@ -1112,7 +1113,7 @@ class AdminPermissionMiddleware implements RouteMiddleware
             'timestamp' => date('c'),
             'ip' => $request->getClientIp(),
             'user_agent' => $request->headers->get('User-Agent'),
-            'path' => $request->getPathInfo(),
+            'path' => SensitiveParamRedactor::sanitizePath($request->getPathInfo()),
             'method' => $request->getMethod(),
             'permission' => $this->adminPermission,
             'resource' => $this->resource,

--- a/src/Routing/Middleware/AuthMiddleware.php
+++ b/src/Routing/Middleware/AuthMiddleware.php
@@ -19,6 +19,7 @@ use Glueful\Events\Http\HttpAuthFailureEvent;
 use Glueful\Events\Http\HttpAuthSuccessEvent;
 use Glueful\Events\EventService;
 use Psr\Log\LoggerInterface;
+use Glueful\Support\SensitiveParamRedactor;
 
 /**
  * Enterprise Authentication Middleware for Next-Gen Router
@@ -429,7 +430,7 @@ class AuthMiddleware implements RouteMiddleware
             'type' => 'auth_success',
             'user_id' => $user['id'] ?? $user['uuid'] ?? 'unknown',
             'provider' => $user['auth_provider'] ?? 'unknown',
-            'path' => $request->getPathInfo(),
+            'path' => SensitiveParamRedactor::sanitizePath($request->getPathInfo()),
             'method' => $request->getMethod(),
             'ip' => $request->getClientIp(),
             'user_agent' => $request->headers->get('User-Agent'),
@@ -454,7 +455,7 @@ class AuthMiddleware implements RouteMiddleware
         $this->logger->warning('Authentication failed', [
             'type' => 'auth_failure',
             'reason' => $reason,
-            'path' => $request->getPathInfo(),
+            'path' => SensitiveParamRedactor::sanitizePath($request->getPathInfo()),
             'method' => $request->getMethod(),
             'ip' => $request->getClientIp(),
             'user_agent' => $request->headers->get('User-Agent'),
@@ -481,7 +482,7 @@ class AuthMiddleware implements RouteMiddleware
             'type' => 'auth_error',
             'exception' => $exception->getMessage(),
             'trace' => $exception->getTraceAsString(),
-            'path' => $request->getPathInfo(),
+            'path' => SensitiveParamRedactor::sanitizePath($request->getPathInfo()),
             'method' => $request->getMethod(),
             'request_id' => $requestId
         ]);
@@ -695,7 +696,7 @@ class AuthMiddleware implements RouteMiddleware
             if ($this->logger !== null) {
                 $this->logger->debug('Failed to auto-enrich request with auth attributes', [
                     'error' => $e->getMessage(),
-                    'path' => $request->getPathInfo()
+                    'path' => SensitiveParamRedactor::sanitizePath($request->getPathInfo())
                 ]);
             }
         }

--- a/src/Routing/Middleware/CSRFMiddleware.php
+++ b/src/Routing/Middleware/CSRFMiddleware.php
@@ -16,6 +16,7 @@ use Psr\Container\ContainerInterface;
 use Glueful\Events\Security\CSRFViolationEvent;
 use Glueful\Events\EventService;
 use Psr\Log\LoggerInterface;
+use Glueful\Support\SensitiveParamRedactor;
 
 /**
  * CSRF Protection Middleware for Next-Gen Router
@@ -234,7 +235,7 @@ class CSRFMiddleware implements RouteMiddleware
         // Skip if route is exempt
         if ($this->isExemptRoute($request)) {
             $this->logger?->debug('CSRF protection skipped for exempt route', [
-                'path' => $request->getPathInfo(),
+                'path' => SensitiveParamRedactor::sanitizePath($request->getPathInfo()),
                 'method' => $request->getMethod()
             ]);
             return $next($request);
@@ -251,7 +252,7 @@ class CSRFMiddleware implements RouteMiddleware
         if (!$this->checkRateLimit($request)) {
             $this->logger?->warning('CSRF token generation rate limit exceeded', [
                 'ip' => $request->getClientIp(),
-                'path' => $request->getPathInfo()
+                'path' => SensitiveParamRedactor::sanitizePath($request->getPathInfo())
             ]);
 
             return new JsonResponse([
@@ -265,7 +266,7 @@ class CSRFMiddleware implements RouteMiddleware
             $this->logger?->warning('CSRF Origin/Referer validation failed', [
                 'origin' => $request->headers->get('Origin'),
                 'referer' => $request->headers->get('Referer'),
-                'path' => $request->getPathInfo()
+                'path' => SensitiveParamRedactor::sanitizePath($request->getPathInfo())
             ]);
 
             $this->getEventService()?->dispatch(new CSRFViolationEvent(
@@ -279,7 +280,7 @@ class CSRFMiddleware implements RouteMiddleware
                 [
                     'error_code' => 'CSRF_ORIGIN_MISMATCH',
                     'method' => $request->getMethod(),
-                    'path' => $request->getPathInfo()
+                    'path' => SensitiveParamRedactor::sanitizePath($request->getPathInfo())
                 ]
             );
         }
@@ -288,7 +289,7 @@ class CSRFMiddleware implements RouteMiddleware
         if (!$this->validateToken($request, $useDoubleSubmit)) {
             $this->logger?->error('CSRF token validation failed', [
                 'ip' => $request->getClientIp(),
-                'path' => $request->getPathInfo(),
+                'path' => SensitiveParamRedactor::sanitizePath($request->getPathInfo()),
                 'method' => $request->getMethod()
             ]);
 
@@ -311,7 +312,7 @@ class CSRFMiddleware implements RouteMiddleware
                 [
                     'error_code' => 'CSRF_TOKEN_MISMATCH',
                     'method' => $request->getMethod(),
-                    'path' => $request->getPathInfo()
+                    'path' => SensitiveParamRedactor::sanitizePath($request->getPathInfo())
                 ]
             );
         }

--- a/src/Routing/Middleware/FieldSelectionMiddleware.php
+++ b/src/Routing/Middleware/FieldSelectionMiddleware.php
@@ -12,6 +12,7 @@ use Glueful\Support\FieldSelection\{FieldSelector, FieldTree, Projector, FieldNo
 use Glueful\Support\FieldSelection\Exceptions\InvalidFieldSelectionException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Glueful\Support\SensitiveParamRedactor;
 
 final class FieldSelectionMiddleware implements RouteMiddleware
 {
@@ -160,7 +161,7 @@ final class FieldSelectionMiddleware implements RouteMiddleware
             'user' => $request->attributes->get('user'),
             'request_id' => $request->headers->get('X-Request-Id'),
             'method' => $request->getMethod(),
-            'uri' => $request->getRequestUri(),
+            'uri' => SensitiveParamRedactor::sanitizeUrl($request->getRequestUri(), $request->getBaseUrl()),
         ];
 
         // Extract collection IDs for batch loading

--- a/src/Routing/Middleware/MetricsMiddleware.php
+++ b/src/Routing/Middleware/MetricsMiddleware.php
@@ -8,6 +8,7 @@ use Glueful\Http\Response;
 use Glueful\Routing\RouteMiddleware;
 use Glueful\Services\ApiMetricsService;
 use Symfony\Component\HttpFoundation\Request;
+use Glueful\Support\SensitiveParamRedactor;
 
 class MetricsMiddleware implements RouteMiddleware
 {
@@ -29,7 +30,7 @@ class MetricsMiddleware implements RouteMiddleware
             }
 
             $this->metrics->recordMetricAsync([
-                'endpoint' => $request->getPathInfo(),
+                'endpoint' => SensitiveParamRedactor::sanitizePath($request->getPathInfo()),
                 'method' => $request->getMethod(),
                 'response_time' => $durationMs,
                 'status_code' => $status,

--- a/src/Routing/Middleware/RequestResponseLoggingMiddleware.php
+++ b/src/Routing/Middleware/RequestResponseLoggingMiddleware.php
@@ -274,7 +274,7 @@ class RequestResponseLoggingMiddleware implements RouteMiddleware
             'correlation_id' => $this->correlationId,
             'method' => $request->getMethod(),
             'uri' => $this->sanitizeUrl($request->getRequestUri()),
-            'path' => $request->getPathInfo(),
+            'path' => SensitiveParamRedactor::sanitizePath($request->getPathInfo()),
             'query_string' => $this->sanitizeQueryString($request->getQueryString()),
             'scheme' => $request->getScheme(),
             'client_ip' => $this->getClientIp($request),

--- a/src/Routing/Middleware/RequestResponseLoggingMiddleware.php
+++ b/src/Routing/Middleware/RequestResponseLoggingMiddleware.php
@@ -273,7 +273,7 @@ class RequestResponseLoggingMiddleware implements RouteMiddleware
             'type' => 'http_request',
             'correlation_id' => $this->correlationId,
             'method' => $request->getMethod(),
-            'uri' => $this->sanitizeUrl($request->getRequestUri()),
+            'uri' => $this->sanitizeUrl($request->getRequestUri(), $request->getBaseUrl()),
             'path' => SensitiveParamRedactor::sanitizePath($request->getPathInfo()),
             'query_string' => $this->sanitizeQueryString($request->getQueryString()),
             'scheme' => $request->getScheme(),
@@ -350,7 +350,7 @@ class RequestResponseLoggingMiddleware implements RouteMiddleware
             'type' => 'http_response',
             'correlation_id' => $this->correlationId,
             'method' => $request->getMethod(),
-            'uri' => $this->sanitizeUrl($request->getRequestUri()),
+            'uri' => $this->sanitizeUrl($request->getRequestUri(), $request->getBaseUrl()),
             'status_code' => $statusCode,
             'reason_phrase' => Response::$statusTexts[$statusCode] ?? 'Unknown',
             'duration_ms' => round($duration * 1000, 2),
@@ -393,7 +393,7 @@ class RequestResponseLoggingMiddleware implements RouteMiddleware
             'type' => 'slow_request',
             'correlation_id' => $this->correlationId,
             'method' => $request->getMethod(),
-            'uri' => $this->sanitizeUrl($request->getRequestUri()),
+            'uri' => $this->sanitizeUrl($request->getRequestUri(), $request->getBaseUrl()),
             'duration_ms' => round($duration * 1000, 2),
             'threshold_ms' => $config['slow_threshold'],
             'status_code' => $response instanceof Response ? $response->getStatusCode() : null,
@@ -418,7 +418,7 @@ class RequestResponseLoggingMiddleware implements RouteMiddleware
             'type' => 'request_failure',
             'correlation_id' => $this->correlationId,
             'method' => $request->getMethod(),
-            'uri' => $this->sanitizeUrl($request->getRequestUri()),
+            'uri' => $this->sanitizeUrl($request->getRequestUri(), $request->getBaseUrl()),
             'duration_ms' => round($duration * 1000, 2),
             'error' => $exception->getMessage(),
             'error_class' => get_class($exception),
@@ -461,10 +461,14 @@ class RequestResponseLoggingMiddleware implements RouteMiddleware
 
     /**
      * Sanitize a URL or request URI before logging.
+     *
+     * $basePath is the request's base URL, which getRequestUri() includes and
+     * getPathInfo() does not; passing it lets one registered sensitive-path
+     * template cover both fields.
      */
-    private function sanitizeUrl(?string $url): ?string
+    private function sanitizeUrl(?string $url, string $basePath = ''): ?string
     {
-        return SensitiveParamRedactor::sanitizeUrl($url);
+        return SensitiveParamRedactor::sanitizeUrl($url, $basePath);
     }
 
     /**

--- a/src/Routing/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Routing/Middleware/SecurityHeadersMiddleware.php
@@ -8,6 +8,7 @@ use Glueful\Routing\RouteMiddleware;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Psr\Log\LoggerInterface;
+use Glueful\Support\SensitiveParamRedactor;
 
 /**
  * Security Headers Middleware for Next-Gen Router
@@ -177,7 +178,7 @@ class SecurityHeadersMiddleware implements RouteMiddleware
         // Check if path is exempt
         if ($this->isExemptPath($request)) {
             $this->logger?->debug('Security headers skipped for exempt path', [
-                'path' => $request->getPathInfo()
+                'path' => SensitiveParamRedactor::sanitizePath($request->getPathInfo())
             ]);
             return $next($request);
         }
@@ -204,7 +205,7 @@ class SecurityHeadersMiddleware implements RouteMiddleware
 
             // Log security headers application
             $this->logger?->debug('Security headers applied', [
-                'path' => $request->getPathInfo(),
+                'path' => SensitiveParamRedactor::sanitizePath($request->getPathInfo()),
                 'profile' => $profile,
                 'score' => $this->calculateSecurityScore($response)
             ]);

--- a/src/Routing/Middleware/TracingMiddleware.php
+++ b/src/Routing/Middleware/TracingMiddleware.php
@@ -8,6 +8,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Glueful\Http\Response;
 use Glueful\Observability\Tracing\TracerInterface;
 use Glueful\Routing\RouteMiddleware;
+use Glueful\Support\SensitiveParamRedactor;
 
 final class TracingMiddleware implements RouteMiddleware
 {
@@ -17,9 +18,14 @@ final class TracingMiddleware implements RouteMiddleware
 
     public function handle(Request $request, callable $next, ...$params): mixed
     {
+        // The matched route template is already placeholder-shaped; the raw path
+        // fallback is not, so it goes through sensitive-path redaction.
+        $route = $request->attributes->get('_route')
+            ?? SensitiveParamRedactor::sanitizePath($request->getPathInfo());
+
         $builder = $this->tracer->startSpan('http.request', [
             'http.method' => $request->getMethod(),
-            'http.route' => $request->attributes->get('_route') ?? $request->getPathInfo(),
+            'http.route' => $route,
             'user_agent' => $request->headers->get('User-Agent'),
             'net.peer.ip' => $request->getClientIp(),
         ]);

--- a/src/Support/SensitiveParamRedactor.php
+++ b/src/Support/SensitiveParamRedactor.php
@@ -106,10 +106,23 @@ final class SensitiveParamRedactor
      *
      * Literal segments are compared case-insensitively and after percent-decoding,
      * so an encoded path cannot slip past. Segments beyond the pattern are kept.
-     * Registering nothing leaves every path byte-identical.
+     * Matching mirrors the router's own path normalization, so the forms that
+     * reach a live route — `//checkout/pay/x`, `/checkout%2Fpay/x` — are redacted
+     * too; see {@see self::sanitizePath()}. Registering nothing leaves every path
+     * byte-identical.
+     *
+     * Templates are written WITHOUT the deployment's base URL: callers that log
+     * `Request::getRequestUri()` pass `Request::getBaseUrl()` alongside, so one
+     * template covers both the request log and the exception log.
      *
      * This is log-emission-time only: no request is ever mutated, so routing,
      * signature verification and handlers still see the untouched path.
+     *
+     * Sentinel note: placeholder/wildcard tokens are represented internally by
+     * NUL-prefixed strings, so a literal segment written as `%00placeholder` or
+     * `%00wildcard` decodes onto a sentinel and behaves as that token rather
+     * than as a literal. Both collisions only ever redact more, and neither is
+     * expressible in a real URL path, so they are left uncontested.
      *
      * @param array<int|string, mixed> $patterns
      */
@@ -182,14 +195,100 @@ final class SensitiveParamRedactor
     /**
      * Redact credential-bearing segments of a URL path. Returns the path
      * unchanged when no pattern matches (and always when none are registered).
+     *
+     * Matching runs twice, because the router and the raw request line disagree
+     * about where segment boundaries are:
+     *
+     *  1. over the RAW path, decoding each segment only to compare literals —
+     *     this keeps a `%2F` inside a credential from splitting the secret
+     *     across two segments and half-redacting it;
+     *  2. over the path normalized the way {@see \Glueful\Routing\Router::match()}
+     *     normalizes it (whole-string percent-decode, then repeated slashes
+     *     collapsed) — this catches the forms that reach a live route but not a
+     *     naive splitter: `//checkout/pay/<secret>` and `/checkout%2Fpay/<secret>`.
+     *
+     * The first pass that actually redacts something wins, and a match from the
+     * second pass emits the normalized form (that is the path the router acted
+     * on). A path that matches nothing is returned byte-identical.
+     *
+     * @param string $basePath The request's base URL (`Request::getBaseUrl()`),
+     *                         stripped before matching so a single registered
+     *                         template covers both `getPathInfo()` (base URL
+     *                         already removed) and `getRequestUri()` (base URL
+     *                         still present). The prefix is restored on output.
      */
-    public static function sanitizePath(?string $path): ?string
+    public static function sanitizePath(?string $path, string $basePath = ''): ?string
     {
         if ($path === null || $path === '' || self::$compiledPathPatterns === []) {
             return $path;
         }
 
-        $segments = explode('/', $path);
+        $redacted = self::redactWithBasePath($path, false, $basePath);
+        if ($redacted !== null) {
+            return $redacted;
+        }
+
+        $normalized = self::normalizePath($path);
+        if ($normalized !== $path) {
+            $redacted = self::redactWithBasePath($normalized, true, $basePath);
+            if ($redacted !== null) {
+                return $redacted;
+            }
+        }
+
+        return $path;
+    }
+
+    /**
+     * Normalize the way the router does before it matches: percent-decode the
+     * whole string (so `%2F` becomes a segment boundary) and collapse repeated
+     * slashes (the router's `ltrim($path, '/')` collapses the leading run; we
+     * collapse interior runs too, which can only redact more, never less).
+     */
+    private static function normalizePath(string $path): string
+    {
+        $decoded = rawurldecode($path);
+        $collapsed = preg_replace('#/{2,}#', '/', $decoded);
+
+        return $collapsed ?? $decoded;
+    }
+
+    /**
+     * Try the patterns against the subject, then — if a base URL is configured —
+     * against the subject with that prefix removed.
+     *
+     * @param bool $decoded Whether $subject has already been percent-decoded
+     * @return string|null The redacted subject, or null when nothing changed
+     */
+    private static function redactWithBasePath(string $subject, bool $decoded, string $basePath): ?string
+    {
+        $redacted = self::redactSegments($subject, $decoded);
+        if ($redacted !== null) {
+            return $redacted;
+        }
+
+        $prefix = rtrim($decoded ? self::normalizePath($basePath) : $basePath, '/');
+        if ($prefix === '' || !str_starts_with($subject, $prefix)) {
+            return null;
+        }
+
+        $remainder = substr($subject, strlen($prefix));
+        if ($remainder === '' || !str_starts_with($remainder, '/')) {
+            return null;
+        }
+
+        $redacted = self::redactSegments($remainder, $decoded);
+
+        return $redacted === null ? null : $prefix . $redacted;
+    }
+
+    /**
+     * @param bool $decoded Whether $subject has already been percent-decoded
+     * @return string|null The redacted subject, or null when nothing changed
+     */
+    private static function redactSegments(string $subject, bool $decoded): ?string
+    {
+        $segments = explode('/', $subject);
         // A path-absolute value explodes to a leading empty element; logical
         // segment 0 starts after it.
         $offset = $segments[0] === '' ? 1 : 0;
@@ -216,7 +315,8 @@ final class SensitiveParamRedactor
                     continue;
                 }
 
-                if (strtolower(rawurldecode($segment)) !== $token) {
+                $literal = $decoded ? strtolower($segment) : strtolower(rawurldecode($segment));
+                if ($literal !== $token) {
                     $matched = false;
                     break;
                 }
@@ -236,7 +336,7 @@ final class SensitiveParamRedactor
             }
         }
 
-        return $changed ? implode('/', $segments) : $path;
+        return $changed ? implode('/', $segments) : null;
     }
 
     /**
@@ -304,16 +404,28 @@ final class SensitiveParamRedactor
     }
 
     /**
-     * Redact sensitive query parameters in a URL or request URI. Userinfo and
-     * fragments are dropped; an unparseable URL is fully redacted.
+     * Redact sensitive query parameters — and registered sensitive path
+     * segments — in a URL or request URI. Userinfo and fragments are dropped;
+     * an unparseable URL is fully redacted.
+     *
+     * @param string $basePath The request's base URL, when the caller has a
+     *                         Request to hand; see {@see self::sanitizePath()}.
      */
-    public static function sanitizeUrl(?string $url): ?string
+    public static function sanitizeUrl(?string $url, string $basePath = ''): ?string
     {
         if ($url === null || $url === '') {
             return $url;
         }
 
-        $parts = parse_url($url);
+        // A schemeless value starting with '//' is a request URI whose leading
+        // slash run was doubled (a base-url concatenation bug), not a
+        // scheme-relative URL — but parse_url() reads its first segment as a
+        // HOST, which would carry the rest of the path past path redaction
+        // untouched. Split such values by hand instead.
+        $parts = self::isSchemelessRequestUri($url)
+            ? self::splitRequestUri($url)
+            : parse_url($url);
+
         if ($parts === false) {
             return self::REDACTED;
         }
@@ -331,7 +443,7 @@ final class SensitiveParamRedactor
             $sanitized .= ':' . $parts['port'];
         }
 
-        $sanitized .= self::sanitizePath($parts['path'] ?? null) ?? '';
+        $sanitized .= self::sanitizePath($parts['path'] ?? null, $basePath) ?? '';
 
         $query = self::sanitizeQueryString($parts['query'] ?? null);
         if ($query !== null && $query !== '') {
@@ -339,5 +451,29 @@ final class SensitiveParamRedactor
         }
 
         return $sanitized !== '' ? $sanitized : $url;
+    }
+
+    private static function isSchemelessRequestUri(string $url): bool
+    {
+        return str_starts_with($url, '//') && preg_match('#^[a-z][a-z0-9+.\-]*:#i', $url) !== 1;
+    }
+
+    /**
+     * @return array{path: string, query?: string}
+     */
+    private static function splitRequestUri(string $url): array
+    {
+        // Fragments are dropped, matching parse_url()-based handling.
+        $hash = strpos($url, '#');
+        if ($hash !== false) {
+            $url = substr($url, 0, $hash);
+        }
+
+        $mark = strpos($url, '?');
+        if ($mark === false) {
+            return ['path' => $url];
+        }
+
+        return ['path' => substr($url, 0, $mark), 'query' => substr($url, $mark + 1)];
     }
 }

--- a/src/Support/SensitiveParamRedactor.php
+++ b/src/Support/SensitiveParamRedactor.php
@@ -5,13 +5,24 @@ declare(strict_types=1);
 namespace Glueful\Support;
 
 /**
- * Shared name-pattern redaction for URIs, query strings, and parameter arrays
- * before they are logged or reported.
+ * Shared redaction for URIs, paths, query strings, and parameter arrays before
+ * they are logged or reported.
  *
- * This is the single source of truth for what counts as a sensitive parameter
- * name. Request/response logging, exception reporting, authentication access
- * logs, and security-event listeners all redact through here so the pattern
- * lists cannot drift apart again.
+ * This is the single source of truth for what counts as sensitive. Request/
+ * response logging, exception reporting, authentication access logs, and
+ * security-event listeners all redact through here so the pattern lists cannot
+ * drift apart again.
+ *
+ * Two kinds of secret are covered:
+ *  - sensitive parameter NAMES (compiled in below), redacted everywhere they
+ *    appear as a key or query parameter;
+ *  - sensitive request PATHS, which the host registers via
+ *    {@see self::configureSensitivePaths()} because only the host knows which
+ *    of its routes carry a credential in the path itself. The framework wires
+ *    this from the `logging.sensitive_paths` config key at boot.
+ *
+ * Redaction happens at log-emission time only — no request is mutated, so
+ * routing and handlers always see the original path.
  */
 final class SensitiveParamRedactor
 {
@@ -58,8 +69,174 @@ final class SensitiveParamRedactor
         'password',
     ];
 
+    /**
+     * Registered sensitive path templates, exactly as the host supplied them.
+     *
+     * @var list<string>
+     */
+    private static array $pathPatterns = [];
+
+    /**
+     * Compiled form of {@see self::$pathPatterns}: one list of segment tokens
+     * per pattern. A token is either PLACEHOLDER (redact this segment),
+     * WILDCARD (match any segment, keep it) or a lower-cased literal.
+     *
+     * @var list<list<string>>
+     */
+    private static array $compiledPathPatterns = [];
+
+    private const PLACEHOLDER = "\0placeholder";
+    private const WILDCARD = "\0wildcard";
+
     private function __construct()
     {
+    }
+
+    /**
+     * Register the request paths that carry a credential in the path itself
+     * (signed payment links, magic links, one-time downloads).
+     *
+     * A pattern is a route-shaped template matched segment by segment against
+     * the start of the logged path:
+     *
+     *   '/checkout/pay/{token}'  redacts the third segment of /checkout/pay/<secret>
+     *
+     * A '{name}' segment is redacted; a bare '*' segment matches any single
+     * segment and is kept (e.g. "/orders/[*]/pay/{token}", without the brackets).
+     *
+     * Literal segments are compared case-insensitively and after percent-decoding,
+     * so an encoded path cannot slip past. Segments beyond the pattern are kept.
+     * Registering nothing leaves every path byte-identical.
+     *
+     * This is log-emission-time only: no request is ever mutated, so routing,
+     * signature verification and handlers still see the untouched path.
+     *
+     * @param array<int|string, mixed> $patterns
+     */
+    public static function configureSensitivePaths(array $patterns): void
+    {
+        $registered = [];
+        $compiled = [];
+
+        foreach ($patterns as $pattern) {
+            if (!is_string($pattern)) {
+                continue;
+            }
+
+            $trimmed = trim($pattern);
+            if ($trimmed === '') {
+                continue;
+            }
+
+            $tokens = self::compilePathPattern($trimmed);
+            if ($tokens === []) {
+                continue;
+            }
+
+            $registered[] = $trimmed;
+            $compiled[] = $tokens;
+        }
+
+        self::$pathPatterns = $registered;
+        self::$compiledPathPatterns = $compiled;
+    }
+
+    /**
+     * The currently registered path templates (diagnostics and tests).
+     *
+     * @return list<string>
+     */
+    public static function sensitivePathPatterns(): array
+    {
+        return self::$pathPatterns;
+    }
+
+    /**
+     * @return list<string> Segment tokens, empty when the pattern has no segments
+     */
+    private static function compilePathPattern(string $pattern): array
+    {
+        $tokens = [];
+
+        foreach (explode('/', trim($pattern, '/')) as $segment) {
+            if ($segment === '') {
+                continue;
+            }
+
+            if (str_starts_with($segment, '{') && str_ends_with($segment, '}')) {
+                $tokens[] = self::PLACEHOLDER;
+                continue;
+            }
+
+            if ($segment === '*') {
+                $tokens[] = self::WILDCARD;
+                continue;
+            }
+
+            $tokens[] = strtolower(rawurldecode($segment));
+        }
+
+        return $tokens;
+    }
+
+    /**
+     * Redact credential-bearing segments of a URL path. Returns the path
+     * unchanged when no pattern matches (and always when none are registered).
+     */
+    public static function sanitizePath(?string $path): ?string
+    {
+        if ($path === null || $path === '' || self::$compiledPathPatterns === []) {
+            return $path;
+        }
+
+        $segments = explode('/', $path);
+        // A path-absolute value explodes to a leading empty element; logical
+        // segment 0 starts after it.
+        $offset = $segments[0] === '' ? 1 : 0;
+        $available = count($segments) - $offset;
+        $changed = false;
+
+        foreach (self::$compiledPathPatterns as $tokens) {
+            if (count($tokens) > $available) {
+                continue;
+            }
+
+            $redactAt = [];
+            $matched = true;
+
+            foreach ($tokens as $index => $token) {
+                $segment = $segments[$offset + $index];
+
+                if ($token === self::PLACEHOLDER) {
+                    $redactAt[] = $offset + $index;
+                    continue;
+                }
+
+                if ($token === self::WILDCARD) {
+                    continue;
+                }
+
+                if (strtolower(rawurldecode($segment)) !== $token) {
+                    $matched = false;
+                    break;
+                }
+            }
+
+            if (!$matched) {
+                continue;
+            }
+
+            foreach ($redactAt as $position) {
+                // Never invent a value for a trailing empty segment.
+                if ($segments[$position] === '') {
+                    continue;
+                }
+                $segments[$position] = self::REDACTED;
+                $changed = true;
+            }
+        }
+
+        return $changed ? implode('/', $segments) : $path;
     }
 
     /**
@@ -154,7 +331,7 @@ final class SensitiveParamRedactor
             $sanitized .= ':' . $parts['port'];
         }
 
-        $sanitized .= $parts['path'] ?? '';
+        $sanitized .= self::sanitizePath($parts['path'] ?? null) ?? '';
 
         $query = self::sanitizeQueryString($parts['query'] ?? null);
         if ($query !== null && $query !== '') {

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,15 +13,15 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.77.0';
+    public const VERSION = '1.78.0';
 
 
     /** Release code name */
-    public const NAME = 'Alhena';
+    public const NAME = 'Alioth';
 
 
     /** Release date */
-    public const RELEASE_DATE = '2026-08-09';
+    public const RELEASE_DATE = '2026-08-12';
 
     /** Minimum required PHP version */
     public const MIN_PHP_VERSION = '8.3.0';

--- a/tests/Unit/Logging/SensitivePathLogRedactionTest.php
+++ b/tests/Unit/Logging/SensitivePathLogRedactionTest.php
@@ -26,7 +26,9 @@ use Symfony\Component\HttpFoundation\Response;
  */
 final class SensitivePathLogRedactionTest extends TestCase
 {
-    private const TOKEN = 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2';
+    /** Reserved characters, so the encoded row of the data provider is a genuinely
+     *  different input string from the decoded one. */
+    private const TOKEN = 'sk_live+9f=2a';
 
     protected function setUp(): void
     {
@@ -49,6 +51,28 @@ final class SensitivePathLogRedactionTest extends TestCase
     private function flatten(array $record): string
     {
         return $record['message'] . ' ' . (string) json_encode($record['context']);
+    }
+
+    /**
+     * Build a request straight from server variables. Request::create() parses its
+     * URI argument with parse_url(), which reads '//checkout/...' as a HOST — the
+     * very mis-parse this suite exists to pin — so the raw request line is set here
+     * the way a web server would set it.
+     */
+    private function requestFor(string $requestUri, string $method = 'GET', string $baseUrl = ''): Request
+    {
+        $script = $baseUrl . '/index.php';
+        $mark = strpos($requestUri, '?');
+
+        return new Request([], [], [], [], [], [
+            'REQUEST_METHOD' => $method,
+            'REQUEST_URI' => $requestUri,
+            'QUERY_STRING' => $mark === false ? '' : substr($requestUri, $mark + 1),
+            'SCRIPT_NAME' => $script,
+            'SCRIPT_FILENAME' => '/var/www' . $script,
+            'HTTP_HOST' => 'shop.test',
+            'REMOTE_ADDR' => '127.0.0.1',
+        ]);
     }
 
     private function capturingLogger(): LoggerInterface
@@ -118,6 +142,10 @@ final class SensitivePathLogRedactionTest extends TestCase
         return [
             'decoded' => ['/checkout/pay/' . self::TOKEN],
             'encoded' => ['/checkout/pay/' . rawurlencode(self::TOKEN)],
+            // Forms that reach the same live route through Router::match()'s
+            // normalization but defeat a naive raw-path splitter.
+            'collapsed slashes' => ['//checkout/pay/' . self::TOKEN],
+            'encoded separator' => ['/checkout%2Fpay/' . self::TOKEN],
         ];
     }
 
@@ -131,14 +159,16 @@ final class SensitivePathLogRedactionTest extends TestCase
         $logger = $this->capturingLogger();
         $app = $this->application($logger);
 
-        $app->handle(Request::create($path, 'GET'));
+        $app->handle($this->requestFor($path));
 
         /** @var array<int, array{level: mixed, message: string, context: array<string, mixed>}> $records */
         $records = $logger->records; // @phpstan-ignore-line anonymous class property
         self::assertNotSame([], $records, 'the request logger must have emitted a record');
 
         foreach ($records as $record) {
-            self::assertStringNotContainsString(self::TOKEN, $this->flatten($record));
+            $flat = $this->flatten($record);
+            self::assertStringNotContainsString(self::TOKEN, $flat);
+            self::assertStringNotContainsString(rawurlencode(self::TOKEN), $flat);
         }
 
         self::assertSame(
@@ -154,7 +184,7 @@ final class SensitivePathLogRedactionTest extends TestCase
         $logger = $this->capturingLogger();
         $app = $this->application($logger);
 
-        $app->handle(Request::create('/orders/42', 'GET'));
+        $app->handle($this->requestFor('/orders/42'));
 
         /** @var array<int, array{level: mixed, message: string, context: array<string, mixed>}> $records */
         $records = $logger->records; // @phpstan-ignore-line anonymous class property
@@ -167,7 +197,7 @@ final class SensitivePathLogRedactionTest extends TestCase
         $app = $this->application($logger);
 
         $path = '/checkout/pay/' . self::TOKEN;
-        $app->handle(Request::create($path, 'GET'));
+        $app->handle($this->requestFor($path));
 
         /** @var array<int, array{level: mixed, message: string, context: array<string, mixed>}> $records */
         $records = $logger->records; // @phpstan-ignore-line anonymous class property
@@ -185,7 +215,10 @@ final class SensitivePathLogRedactionTest extends TestCase
         // debug: false — the production profile, where this call site logs at error level.
         $handler = new Handler($logger, debug: false);
 
-        $handler->report(new \RuntimeException('payment gateway unreachable'), Request::create($path . '?ref=1'));
+        $handler->report(
+            new \RuntimeException('payment gateway unreachable'),
+            $this->requestFor($path . '?ref=1')
+        );
 
         /** @var array<int, array{level: mixed, message: string, context: array<string, mixed>}> $records */
         $records = $logger->records; // @phpstan-ignore-line anonymous class property
@@ -214,7 +247,7 @@ final class SensitivePathLogRedactionTest extends TestCase
         // bypasses the shouldReport() suppression so the branch is exercised.
         $handler->report(
             new \Glueful\Http\Exceptions\Client\NotFoundException('no such link'),
-            Request::create('/checkout/pay/' . self::TOKEN)
+            $this->requestFor('/checkout/pay/' . self::TOKEN)
         );
 
         /** @var array<int, array{level: mixed, message: string, context: array<string, mixed>}> $records */
@@ -231,7 +264,7 @@ final class SensitivePathLogRedactionTest extends TestCase
         $logger = $this->capturingLogger();
         $handler = new Handler($logger, debug: false);
 
-        $handler->report(new \RuntimeException('boom'), Request::create('/checkout/pay/' . self::TOKEN));
+        $handler->report(new \RuntimeException('boom'), $this->requestFor('/checkout/pay/' . self::TOKEN));
 
         /** @var array<int, array{level: mixed, message: string, context: array<string, mixed>}> $records */
         $records = $logger->records; // @phpstan-ignore-line anonymous class property
@@ -247,5 +280,220 @@ final class SensitivePathLogRedactionTest extends TestCase
         self::assertIsArray($config);
         self::assertArrayHasKey('sensitive_paths', $config);
         self::assertSame([], $config['sensitive_paths']);
+    }
+
+    /**
+     * A base-URL-mounted app registers ONE template. Application::handle() feeds
+     * getPathInfo() (base URL already stripped) while Handler::report() feeds
+     * getRequestUri() (base URL still attached) — the error-level sink that fires
+     * in every profile. Both must be covered by that single registration.
+     */
+    public function testExceptionReportRedactsUnderABaseUrl(): void
+    {
+        SensitiveParamRedactor::configureSensitivePaths(['/checkout/pay/{token}']);
+
+        $request = $this->requestFor('/api/checkout/pay/' . self::TOKEN, 'GET', '/api');
+        self::assertSame('/api', $request->getBaseUrl(), 'precondition: the request is base-URL mounted');
+        self::assertSame('/checkout/pay/' . self::TOKEN, $request->getPathInfo());
+
+        $logger = $this->capturingLogger();
+        (new Handler($logger, debug: false))->report(new \RuntimeException('boom'), $request);
+
+        /** @var array<int, array{level: mixed, message: string, context: array<string, mixed>}> $records */
+        $records = $logger->records; // @phpstan-ignore-line anonymous class property
+        foreach ($records as $record) {
+            self::assertStringNotContainsString(self::TOKEN, $this->flatten($record));
+        }
+
+        $context = $records[0]['context']['request'];
+        self::assertIsArray($context);
+        self::assertSame('/api/checkout/pay/' . SensitiveParamRedactor::REDACTED, $context['uri']);
+    }
+
+    // --- Residual sinks -----------------------------------------------------------------
+    //
+    // One representative per middleware family that logs (or persists) a raw request
+    // path. The architecture guard below covers the whole set, including future sites.
+
+    public function testCsrfMiddlewareErrorLogIsRedacted(): void
+    {
+        SensitiveParamRedactor::configureSensitivePaths(['/checkout/pay/{token}']);
+
+        $logger = $this->capturingLogger();
+        $middleware = new \Glueful\Routing\Middleware\CSRFMiddleware(
+            validateOrigin: false,
+            logger: $logger
+        );
+
+        try {
+            $middleware->handle(
+                $this->requestFor('/checkout/pay/' . self::TOKEN, 'POST'),
+                static fn(): Response => new Response('ok', 200)
+            );
+        } catch (\Throwable) {
+            // The rejection itself is not under test; the log record it emits is.
+        }
+
+        /** @var array<int, array{level: mixed, message: string, context: array<string, mixed>}> $records */
+        $records = $logger->records; // @phpstan-ignore-line anonymous class property
+        self::assertNotSame([], $records, 'a failing POST must have been logged');
+
+        foreach ($records as $record) {
+            self::assertStringNotContainsString(self::TOKEN, $this->flatten($record));
+        }
+
+        $paths = array_column(array_column($records, 'context'), 'path');
+        self::assertContains(
+            '/checkout/pay/' . SensitiveParamRedactor::REDACTED,
+            $paths,
+            'the error-level CSRF rejection must log the redacted path'
+        );
+    }
+
+    public function testMetricsMiddlewarePersistsARedactedEndpoint(): void
+    {
+        SensitiveParamRedactor::configureSensitivePaths(['/checkout/pay/{token}']);
+
+        $recorded = [];
+        $metrics = new class ($recorded) extends \Glueful\Services\ApiMetricsService {
+            /** @param array<int, array<string, mixed>> $recorded */
+            public function __construct(private array &$recorded)
+            {
+            }
+
+            /** @param array<string, mixed> $metric */
+            public function recordMetricAsync(array $metric): void
+            {
+                $this->recorded[] = $metric;
+            }
+        };
+
+        (new \Glueful\Routing\Middleware\MetricsMiddleware($metrics))->handle(
+            $this->requestFor('/checkout/pay/' . self::TOKEN),
+            static fn(): Response => new Response('ok', 200)
+        );
+
+        self::assertCount(1, $recorded);
+        self::assertSame('/checkout/pay/' . SensitiveParamRedactor::REDACTED, $recorded[0]['endpoint']);
+    }
+
+    public function testTracingMiddlewareSpanAttributesAreRedacted(): void
+    {
+        SensitiveParamRedactor::configureSensitivePaths(['/checkout/pay/{token}']);
+
+        $attributes = [];
+        $tracer = new class ($attributes) implements \Glueful\Observability\Tracing\TracerInterface {
+            /** @param array<string, mixed> $attributes */
+            public function __construct(private array &$attributes)
+            {
+            }
+
+            /** @param array<string, mixed> $attrs */
+            public function startSpan(
+                string $name,
+                array $attrs = []
+            ): \Glueful\Observability\Tracing\SpanBuilderInterface {
+                $this->attributes = $attrs;
+
+                return new class implements \Glueful\Observability\Tracing\SpanBuilderInterface {
+                    public function setAttribute(string $key, mixed $value): self
+                    {
+                        return $this;
+                    }
+
+                    public function setParent(?\Glueful\Observability\Tracing\SpanInterface $parent): self
+                    {
+                        return $this;
+                    }
+
+                    public function startSpan(): \Glueful\Observability\Tracing\SpanInterface
+                    {
+                        return new class implements \Glueful\Observability\Tracing\SpanInterface {
+                            public function setAttribute(string $key, mixed $value): void
+                            {
+                            }
+
+                            public function end(): void
+                            {
+                            }
+                        };
+                    }
+                };
+            }
+        };
+
+        (new \Glueful\Routing\Middleware\TracingMiddleware($tracer))->handle(
+            $this->requestFor('/checkout/pay/' . self::TOKEN),
+            static fn(): Response => new Response('ok', 200)
+        );
+
+        self::assertSame('/checkout/pay/' . SensitiveParamRedactor::REDACTED, $attributes['http.route']);
+    }
+
+    public function testVersionManagerDebugLogIsRedacted(): void
+    {
+        SensitiveParamRedactor::configureSensitivePaths(['/checkout/pay/{token}']);
+
+        $logger = $this->capturingLogger();
+        $manager = new \Glueful\Api\Versioning\VersionManager(
+            \Glueful\Api\Versioning\ApiVersion::default(),
+            false,
+            $logger
+        );
+
+        $manager->negotiate($this->requestFor('/checkout/pay/' . self::TOKEN));
+
+        /** @var array<int, array{level: mixed, message: string, context: array<string, mixed>}> $records */
+        $records = $logger->records; // @phpstan-ignore-line anonymous class property
+        self::assertNotSame([], $records);
+
+        foreach ($records as $record) {
+            self::assertStringNotContainsString(self::TOKEN, $this->flatten($record));
+        }
+    }
+
+    /**
+     * Guard for the whole sweep: anywhere in src/ that puts a request path into an
+     * array literal — a log context, a span attribute, a persisted metric — must
+     * route it through the redactor. Catches future call sites, not just today's.
+     */
+    public function testNoSourceFilePutsARawRequestPathIntoAnArrayPayload(): void
+    {
+        $src = dirname(__DIR__, 3) . '/src';
+        $allowed = [
+            // Rate-limit bucket keys, not a log sink: redacting here would collapse
+            // every credentialed path onto one bucket.
+            'src/Api/RateLimiting/RateLimitManager.php' => ["'{path}' => \$request->getPathInfo(),"],
+        ];
+
+        $offenders = [];
+        $files = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($src));
+
+        foreach ($files as $file) {
+            if (!$file->isFile() || $file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $relative = 'src' . substr($file->getPathname(), strlen($src));
+
+            foreach (file($file->getPathname()) ?: [] as $number => $line) {
+                if (!str_contains($line, '=>')) {
+                    continue;
+                }
+                if (!str_contains($line, 'getPathInfo()') && !str_contains($line, 'getRequestUri()')) {
+                    continue;
+                }
+                if (str_contains($line, 'SensitiveParamRedactor') || str_contains($line, 'sanitize')) {
+                    continue;
+                }
+                if (in_array(trim($line), $allowed[$relative] ?? [], true)) {
+                    continue;
+                }
+
+                $offenders[] = $relative . ':' . ($number + 1) . ' ' . trim($line);
+            }
+        }
+
+        self::assertSame([], $offenders, "Raw request path in an array payload:\n" . implode("\n", $offenders));
     }
 }

--- a/tests/Unit/Logging/SensitivePathLogRedactionTest.php
+++ b/tests/Unit/Logging/SensitivePathLogRedactionTest.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Logging;
+
+use Glueful\Application;
+use Glueful\Bootstrap\ApplicationContext;
+use Glueful\Http\Exceptions\Handler;
+use Glueful\Support\SensitiveParamRedactor;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * A bearer credential carried in the URL PATH must never reach a log sink.
+ *
+ * Two framework call sites emit the request path verbatim:
+ *  - Application::handle() logs 'Request completed' at info (dev/staging levels)
+ *  - Handler::report() logs the throwable with the request URI at error (every profile)
+ *
+ * Both must route through the registered sensitive-path patterns.
+ */
+final class SensitivePathLogRedactionTest extends TestCase
+{
+    private const TOKEN = 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        SensitiveParamRedactor::configureSensitivePaths([]);
+    }
+
+    protected function tearDown(): void
+    {
+        SensitiveParamRedactor::configureSensitivePaths([]);
+        parent::tearDown();
+    }
+
+    /**
+     * Flatten a captured record (message + structured context) into one string so
+     * the assertion cannot be satisfied by moving the leak between the two.
+     *
+     * @param array{level: mixed, message: string, context: array<string, mixed>} $record
+     */
+    private function flatten(array $record): string
+    {
+        return $record['message'] . ' ' . (string) json_encode($record['context']);
+    }
+
+    private function capturingLogger(): LoggerInterface
+    {
+        return new class extends AbstractLogger {
+            /** @var list<array{level: mixed, message: string, context: array<string, mixed>}> */
+            public array $records = [];
+
+            /**
+             * @param mixed $level
+             * @param array<string, mixed> $context
+             */
+            public function log($level, \Stringable|string $message, array $context = []): void
+            {
+                $this->records[] = [
+                    'level' => $level,
+                    'message' => (string) $message,
+                    'context' => $context,
+                ];
+            }
+        };
+    }
+
+    private function application(LoggerInterface $logger): Application
+    {
+        $context = new ApplicationContext(sys_get_temp_dir() . '/path_redaction_' . uniqid());
+
+        $router = new class {
+            public function dispatch(Request $request): Response
+            {
+                return new Response('ok', 200);
+            }
+        };
+
+        $container = new class ($context, $logger, $router) implements ContainerInterface {
+            /** @var array<string, mixed> */
+            private array $services = [];
+
+            public function __construct(ApplicationContext $context, LoggerInterface $logger, object $router)
+            {
+                $this->services[ApplicationContext::class] = $context;
+                $this->services[LoggerInterface::class] = $logger;
+                $this->services[\Glueful\Routing\Router::class] = $router;
+            }
+
+            public function get(string $id): mixed
+            {
+                return $this->services[$id] ?? null;
+            }
+
+            public function has(string $id): bool
+            {
+                return array_key_exists($id, $this->services);
+            }
+        };
+
+        $context->setContainer($container);
+
+        return new Application($context);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function pathRepresentations(): array
+    {
+        return [
+            'decoded' => ['/checkout/pay/' . self::TOKEN],
+            'encoded' => ['/checkout/pay/' . rawurlencode(self::TOKEN)],
+        ];
+    }
+
+    /**
+     * @dataProvider pathRepresentations
+     */
+    public function testRequestLoggerNeverEmitsTheSensitivePathSegment(string $path): void
+    {
+        SensitiveParamRedactor::configureSensitivePaths(['/checkout/pay/{token}']);
+
+        $logger = $this->capturingLogger();
+        $app = $this->application($logger);
+
+        $app->handle(Request::create($path, 'GET'));
+
+        /** @var array<int, array{level: mixed, message: string, context: array<string, mixed>}> $records */
+        $records = $logger->records; // @phpstan-ignore-line anonymous class property
+        self::assertNotSame([], $records, 'the request logger must have emitted a record');
+
+        foreach ($records as $record) {
+            self::assertStringNotContainsString(self::TOKEN, $this->flatten($record));
+        }
+
+        self::assertSame(
+            '/checkout/pay/' . SensitiveParamRedactor::REDACTED,
+            $records[0]['context']['uri']
+        );
+    }
+
+    public function testRequestLoggerLeavesNonMatchingPathsUnchanged(): void
+    {
+        SensitiveParamRedactor::configureSensitivePaths(['/checkout/pay/{token}']);
+
+        $logger = $this->capturingLogger();
+        $app = $this->application($logger);
+
+        $app->handle(Request::create('/orders/42', 'GET'));
+
+        /** @var array<int, array{level: mixed, message: string, context: array<string, mixed>}> $records */
+        $records = $logger->records; // @phpstan-ignore-line anonymous class property
+        self::assertSame('/orders/42', $records[0]['context']['uri']);
+    }
+
+    public function testRequestLoggerIsByteIdenticalWithNoPatternsRegistered(): void
+    {
+        $logger = $this->capturingLogger();
+        $app = $this->application($logger);
+
+        $path = '/checkout/pay/' . self::TOKEN;
+        $app->handle(Request::create($path, 'GET'));
+
+        /** @var array<int, array{level: mixed, message: string, context: array<string, mixed>}> $records */
+        $records = $logger->records; // @phpstan-ignore-line anonymous class property
+        self::assertSame($path, $records[0]['context']['uri']);
+    }
+
+    /**
+     * @dataProvider pathRepresentations
+     */
+    public function testExceptionReportNeverEmitsTheSensitivePathSegment(string $path): void
+    {
+        SensitiveParamRedactor::configureSensitivePaths(['/checkout/pay/{token}']);
+
+        $logger = $this->capturingLogger();
+        // debug: false — the production profile, where this call site logs at error level.
+        $handler = new Handler($logger, debug: false);
+
+        $handler->report(new \RuntimeException('payment gateway unreachable'), Request::create($path . '?ref=1'));
+
+        /** @var array<int, array{level: mixed, message: string, context: array<string, mixed>}> $records */
+        $records = $logger->records; // @phpstan-ignore-line anonymous class property
+        self::assertNotSame([], $records, 'the exception handler must have emitted a record');
+
+        foreach ($records as $record) {
+            self::assertStringNotContainsString(self::TOKEN, $this->flatten($record));
+        }
+
+        $request = $records[0]['context']['request'];
+        self::assertIsArray($request);
+        self::assertStringStartsWith(
+            '/checkout/pay/' . SensitiveParamRedactor::REDACTED,
+            (string) $request['uri']
+        );
+    }
+
+    public function testExceptionReportLightweightContextIsAlsoRedacted(): void
+    {
+        SensitiveParamRedactor::configureSensitivePaths(['/checkout/pay/{token}']);
+
+        $logger = $this->capturingLogger();
+        $handler = new Handler($logger, debug: false);
+
+        // NotFoundException takes the lightweight-context branch; report() directly
+        // bypasses the shouldReport() suppression so the branch is exercised.
+        $handler->report(
+            new \Glueful\Http\Exceptions\Client\NotFoundException('no such link'),
+            Request::create('/checkout/pay/' . self::TOKEN)
+        );
+
+        /** @var array<int, array{level: mixed, message: string, context: array<string, mixed>}> $records */
+        $records = $logger->records; // @phpstan-ignore-line anonymous class property
+        self::assertNotSame([], $records);
+
+        foreach ($records as $record) {
+            self::assertStringNotContainsString(self::TOKEN, $this->flatten($record));
+        }
+    }
+
+    public function testExceptionReportIsByteIdenticalWithNoPatternsRegistered(): void
+    {
+        $logger = $this->capturingLogger();
+        $handler = new Handler($logger, debug: false);
+
+        $handler->report(new \RuntimeException('boom'), Request::create('/checkout/pay/' . self::TOKEN));
+
+        /** @var array<int, array{level: mixed, message: string, context: array<string, mixed>}> $records */
+        $records = $logger->records; // @phpstan-ignore-line anonymous class property
+        $request = $records[0]['context']['request'];
+        self::assertIsArray($request);
+        self::assertSame('/checkout/pay/' . self::TOKEN, $request['uri']);
+    }
+
+    public function testShippedLoggingConfigExposesAnEmptySensitivePathsDefault(): void
+    {
+        $config = require dirname(__DIR__, 3) . '/config/logging.php';
+
+        self::assertIsArray($config);
+        self::assertArrayHasKey('sensitive_paths', $config);
+        self::assertSame([], $config['sensitive_paths']);
+    }
+}

--- a/tests/Unit/Support/SensitiveParamRedactorPathTest.php
+++ b/tests/Unit/Support/SensitiveParamRedactorPathTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Support;
+
+use Glueful\Support\SensitiveParamRedactor;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Path-segment redaction: hosts that carry a bearer credential inside the URL
+ * PATH (magic links, signed payment links, one-time download URLs) register the
+ * route template so the credential segment never reaches a log sink.
+ */
+final class SensitiveParamRedactorPathTest extends TestCase
+{
+    private const TOKEN = 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        SensitiveParamRedactor::configureSensitivePaths([]);
+    }
+
+    protected function tearDown(): void
+    {
+        // Static registration must never leak into other tests.
+        SensitiveParamRedactor::configureSensitivePaths([]);
+        parent::tearDown();
+    }
+
+    public function testNoPatternsConfiguredLeavesPathsByteIdentical(): void
+    {
+        $path = '/checkout/pay/' . self::TOKEN;
+
+        self::assertSame($path, SensitiveParamRedactor::sanitizePath($path));
+        self::assertSame($path, SensitiveParamRedactor::sanitizeUrl($path));
+    }
+
+    public function testPlaceholderSegmentIsRedacted(): void
+    {
+        SensitiveParamRedactor::configureSensitivePaths(['/checkout/pay/{token}']);
+
+        self::assertSame(
+            '/checkout/pay/' . SensitiveParamRedactor::REDACTED,
+            SensitiveParamRedactor::sanitizePath('/checkout/pay/' . self::TOKEN)
+        );
+    }
+
+    public function testPercentEncodedSegmentIsRedacted(): void
+    {
+        SensitiveParamRedactor::configureSensitivePaths(['/checkout/pay/{token}']);
+
+        $encoded = '/checkout/pay/' . rawurlencode(self::TOKEN);
+        $sanitized = SensitiveParamRedactor::sanitizePath($encoded);
+
+        self::assertIsString($sanitized);
+        self::assertStringNotContainsString(self::TOKEN, $sanitized);
+        self::assertSame('/checkout/pay/' . SensitiveParamRedactor::REDACTED, $sanitized);
+    }
+
+    public function testPercentEncodedLiteralSegmentsStillMatch(): void
+    {
+        SensitiveParamRedactor::configureSensitivePaths(['/checkout/pay/{token}']);
+
+        // '%63' is 'c' — an encoded literal prefix must not defeat the match.
+        $sanitized = SensitiveParamRedactor::sanitizePath('/%63heckout/pay/' . self::TOKEN);
+
+        self::assertIsString($sanitized);
+        self::assertStringNotContainsString(self::TOKEN, $sanitized);
+    }
+
+    public function testLiteralSegmentsMatchCaseInsensitively(): void
+    {
+        SensitiveParamRedactor::configureSensitivePaths(['/checkout/pay/{token}']);
+
+        $sanitized = SensitiveParamRedactor::sanitizePath('/Checkout/PAY/' . self::TOKEN);
+
+        self::assertIsString($sanitized);
+        self::assertStringNotContainsString(self::TOKEN, $sanitized);
+    }
+
+    public function testNonMatchingPathsAreUnchanged(): void
+    {
+        SensitiveParamRedactor::configureSensitivePaths(['/checkout/pay/{token}']);
+
+        self::assertSame('/checkout/pay', SensitiveParamRedactor::sanitizePath('/checkout/pay'));
+        self::assertSame('/orders/42', SensitiveParamRedactor::sanitizePath('/orders/42'));
+        self::assertSame('/checkout/refund/x', SensitiveParamRedactor::sanitizePath('/checkout/refund/x'));
+        self::assertSame('/api/checkout/pay/x', SensitiveParamRedactor::sanitizePath('/api/checkout/pay/x'));
+    }
+
+    public function testTrailingSegmentsBeyondThePatternArePreserved(): void
+    {
+        SensitiveParamRedactor::configureSensitivePaths(['/checkout/pay/{token}']);
+
+        self::assertSame(
+            '/checkout/pay/' . SensitiveParamRedactor::REDACTED . '/receipt',
+            SensitiveParamRedactor::sanitizePath('/checkout/pay/' . self::TOKEN . '/receipt')
+        );
+    }
+
+    public function testSingleSegmentWildcardMatchesAndIsPreserved(): void
+    {
+        SensitiveParamRedactor::configureSensitivePaths(['/orders/*/pay/{token}']);
+
+        self::assertSame(
+            '/orders/42/pay/' . SensitiveParamRedactor::REDACTED,
+            SensitiveParamRedactor::sanitizePath('/orders/42/pay/' . self::TOKEN)
+        );
+    }
+
+    public function testMultiplePatternsAreAllApplied(): void
+    {
+        SensitiveParamRedactor::configureSensitivePaths([
+            '/checkout/pay/{token}',
+            'downloads/{signature}',
+        ]);
+
+        self::assertSame(
+            '/checkout/pay/' . SensitiveParamRedactor::REDACTED,
+            SensitiveParamRedactor::sanitizePath('/checkout/pay/' . self::TOKEN)
+        );
+        // Leading slash in the registered template is optional.
+        self::assertSame(
+            '/downloads/' . SensitiveParamRedactor::REDACTED,
+            SensitiveParamRedactor::sanitizePath('/downloads/' . self::TOKEN)
+        );
+    }
+
+    public function testEmptySegmentsAndBlankPatternsAreIgnored(): void
+    {
+        SensitiveParamRedactor::configureSensitivePaths(['', '   ', '/checkout/pay/{token}']);
+
+        self::assertSame('/checkout/pay/', SensitiveParamRedactor::sanitizePath('/checkout/pay/'));
+        self::assertSame('', SensitiveParamRedactor::sanitizePath(''));
+        self::assertNull(SensitiveParamRedactor::sanitizePath(null));
+        self::assertSame('/', SensitiveParamRedactor::sanitizePath('/'));
+    }
+
+    public function testRelativePathsWithoutLeadingSlashAreRedacted(): void
+    {
+        SensitiveParamRedactor::configureSensitivePaths(['/checkout/pay/{token}']);
+
+        self::assertSame(
+            'checkout/pay/' . SensitiveParamRedactor::REDACTED,
+            SensitiveParamRedactor::sanitizePath('checkout/pay/' . self::TOKEN)
+        );
+    }
+
+    public function testSanitizeUrlRedactsPathAndQueryTogether(): void
+    {
+        SensitiveParamRedactor::configureSensitivePaths(['/checkout/pay/{token}']);
+
+        $sanitized = SensitiveParamRedactor::sanitizeUrl(
+            'https://shop.test/checkout/pay/' . self::TOKEN . '?access_token=leak&keep=1'
+        );
+
+        self::assertIsString($sanitized);
+        self::assertStringNotContainsString(self::TOKEN, $sanitized);
+        self::assertStringNotContainsString('leak', $sanitized);
+        self::assertStringContainsString('keep=1', $sanitized);
+        self::assertStringStartsWith('https://shop.test/checkout/pay/' . SensitiveParamRedactor::REDACTED, $sanitized);
+    }
+
+    public function testExistingQueryAndUrlBehaviourIsUnaffectedByRegistration(): void
+    {
+        SensitiveParamRedactor::configureSensitivePaths(['/checkout/pay/{token}']);
+
+        self::assertSame('https://host.test/path?x=1', SensitiveParamRedactor::sanitizeUrl(
+            'https://user:pass@host.test/path?x=1#frag'
+        ));
+        self::assertSame(SensitiveParamRedactor::REDACTED, SensitiveParamRedactor::sanitizeUrl('http://'));
+        self::assertNull(SensitiveParamRedactor::sanitizeUrl(null));
+        self::assertSame('', SensitiveParamRedactor::sanitizeUrl(''));
+    }
+
+    public function testRegisteredPatternsAreReadableForDiagnostics(): void
+    {
+        self::assertSame([], SensitiveParamRedactor::sensitivePathPatterns());
+
+        SensitiveParamRedactor::configureSensitivePaths([' /checkout/pay/{token} ', '']);
+
+        self::assertSame(['/checkout/pay/{token}'], SensitiveParamRedactor::sensitivePathPatterns());
+    }
+}

--- a/tests/Unit/Support/SensitiveParamRedactorPathTest.php
+++ b/tests/Unit/Support/SensitiveParamRedactorPathTest.php
@@ -14,7 +14,11 @@ use PHPUnit\Framework\TestCase;
  */
 final class SensitiveParamRedactorPathTest extends TestCase
 {
-    private const TOKEN = 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2';
+    /** Reserved characters, so rawurlencode() genuinely changes the string. */
+    private const TOKEN = 'sk_live+9f=2a';
+
+    /** A credential whose own '/' becomes a segment boundary once decoded. */
+    private const SLASH_TOKEN = 'sk_live/9f+2a';
 
     protected function setUp(): void
     {
@@ -87,7 +91,13 @@ final class SensitiveParamRedactorPathTest extends TestCase
         self::assertSame('/checkout/pay', SensitiveParamRedactor::sanitizePath('/checkout/pay'));
         self::assertSame('/orders/42', SensitiveParamRedactor::sanitizePath('/orders/42'));
         self::assertSame('/checkout/refund/x', SensitiveParamRedactor::sanitizePath('/checkout/refund/x'));
+        // Anchored: without a base URL, a prefixed path is NOT a match...
         self::assertSame('/api/checkout/pay/x', SensitiveParamRedactor::sanitizePath('/api/checkout/pay/x'));
+        // ...and a base URL that does not prefix the path changes nothing either.
+        self::assertSame(
+            '/api/checkout/pay/x',
+            SensitiveParamRedactor::sanitizePath('/api/checkout/pay/x', '/admin')
+        );
     }
 
     public function testTrailingSegmentsBeyondThePatternArePreserved(): void
@@ -182,5 +192,109 @@ final class SensitiveParamRedactorPathTest extends TestCase
         SensitiveParamRedactor::configureSensitivePaths([' /checkout/pay/{token} ', '']);
 
         self::assertSame(['/checkout/pay/{token}'], SensitiveParamRedactor::sensitivePathPatterns());
+    }
+
+    // --- Router-normalized matching -------------------------------------------------
+    //
+    // Router::match() normalizes with '/' . ltrim(rawurldecode($path), '/') BEFORE
+    // splitting, so these forms all reach the same live route. A matcher that splits
+    // the raw path would log the live credential in full.
+
+    public function testCollapsedLeadingSlashesAreRedacted(): void
+    {
+        SensitiveParamRedactor::configureSensitivePaths(['/checkout/pay/{token}']);
+
+        $sanitized = SensitiveParamRedactor::sanitizePath('//checkout/pay/' . self::TOKEN);
+
+        self::assertIsString($sanitized);
+        self::assertStringNotContainsString(self::TOKEN, $sanitized);
+        self::assertSame('/checkout/pay/' . SensitiveParamRedactor::REDACTED, $sanitized);
+    }
+
+    public function testRepeatedInteriorSlashesAreRedacted(): void
+    {
+        SensitiveParamRedactor::configureSensitivePaths(['/checkout/pay/{token}']);
+
+        $sanitized = SensitiveParamRedactor::sanitizePath('/checkout//pay/' . self::TOKEN);
+
+        self::assertIsString($sanitized);
+        self::assertStringNotContainsString(self::TOKEN, $sanitized);
+    }
+
+    public function testEncodedSlashSeparatorIsRedacted(): void
+    {
+        SensitiveParamRedactor::configureSensitivePaths(['/checkout/pay/{token}']);
+
+        $sanitized = SensitiveParamRedactor::sanitizePath('/checkout%2Fpay/' . self::TOKEN);
+
+        self::assertIsString($sanitized);
+        self::assertStringNotContainsString(self::TOKEN, $sanitized);
+        self::assertSame('/checkout/pay/' . SensitiveParamRedactor::REDACTED, $sanitized);
+    }
+
+    public function testEncodedSlashInsideTheCredentialDoesNotSplitTheSecret(): void
+    {
+        SensitiveParamRedactor::configureSensitivePaths(['/checkout/pay/{token}']);
+
+        $sanitized = SensitiveParamRedactor::sanitizePath('/checkout/pay/' . rawurlencode(self::SLASH_TOKEN));
+
+        self::assertIsString($sanitized);
+        // Neither the whole credential nor either half of it survives.
+        self::assertStringNotContainsString(self::SLASH_TOKEN, $sanitized);
+        self::assertStringNotContainsString('sk_live', $sanitized);
+        self::assertStringNotContainsString('9f', $sanitized);
+        self::assertSame('/checkout/pay/' . SensitiveParamRedactor::REDACTED, $sanitized);
+    }
+
+    // --- Base URL -------------------------------------------------------------------
+
+    public function testBaseUrlIsStrippedBeforeMatchingAndRestoredAfter(): void
+    {
+        SensitiveParamRedactor::configureSensitivePaths(['/checkout/pay/{token}']);
+
+        self::assertSame(
+            '/api/checkout/pay/' . SensitiveParamRedactor::REDACTED,
+            SensitiveParamRedactor::sanitizePath('/api/checkout/pay/' . self::TOKEN, '/api')
+        );
+        // Trailing slash on the base URL is tolerated.
+        self::assertSame(
+            '/api/checkout/pay/' . SensitiveParamRedactor::REDACTED,
+            SensitiveParamRedactor::sanitizePath('/api/checkout/pay/' . self::TOKEN, '/api/')
+        );
+    }
+
+    public function testBaseUrlStrippingStillHonoursRouterNormalization(): void
+    {
+        SensitiveParamRedactor::configureSensitivePaths(['/checkout/pay/{token}']);
+
+        $sanitized = SensitiveParamRedactor::sanitizePath('/api/checkout%2Fpay/' . self::TOKEN, '/api');
+
+        self::assertIsString($sanitized);
+        self::assertStringNotContainsString(self::TOKEN, $sanitized);
+    }
+
+    public function testBaseUrlMustBeAWholeSegmentPrefix(): void
+    {
+        SensitiveParamRedactor::configureSensitivePaths(['/checkout/pay/{token}']);
+
+        // '/api' must not swallow '/apifoo'.
+        self::assertSame(
+            '/apifoo/checkout/pay/x',
+            SensitiveParamRedactor::sanitizePath('/apifoo/checkout/pay/x', '/api')
+        );
+    }
+
+    public function testSanitizeUrlAcceptsTheBaseUrl(): void
+    {
+        SensitiveParamRedactor::configureSensitivePaths(['/checkout/pay/{token}']);
+
+        $sanitized = SensitiveParamRedactor::sanitizeUrl(
+            '/api/checkout/pay/' . self::TOKEN . '?keep=1',
+            '/api'
+        );
+
+        self::assertIsString($sanitized);
+        self::assertStringNotContainsString(self::TOKEN, $sanitized);
+        self::assertSame('/api/checkout/pay/' . SensitiveParamRedactor::REDACTED . '?keep=1', $sanitized);
     }
 }


### PR DESCRIPTION

### Added
- **Configurable sensitive path redaction** — `SensitiveParamRedactor::configureSensitivePaths()`
  and `sanitizePath()` mask credential-bearing URL path segments. Applications register
  route templates under the new `logging.sensitive_paths` config key (or the
  `LOG_SENSITIVE_PATHS` comma-separated env var), and `Framework::boot()` wires them into
  the redactor after provider/extension config is merged:

  ```php
  // config/logging.php
  'sensitive_paths' => ['/checkout/pay/{token}', '/d/{signature}/file'],
  ```

  A `{name}` segment is replaced with `[REDACTED]`; a bare `*` segment matches any single
  segment and is kept; segments beyond the pattern are preserved. Matching is anchored at
  the start of the path and **mirrors `Router::match()`'s own normalization** — literal
  segments compare case-insensitively after percent-decoding, repeated slashes collapse,
  and `%2F` is treated as a segment boundary — so the spellings that reach a live route
  (`//checkout/pay/x`, `/checkout%2Fpay/x`) are redacted too, while a `%2F` *inside* a
  credential cannot split the secret across segments and half-redact it.

  Templates are written **without** the deployment's base URL. `Request::getBaseUrl()` is
  passed alongside every `getRequestUri()` value and stripped before matching, so one
  template covers both base-URL-mounted and root-mounted deployments.

### Security
- **The request logger and the exception handler no longer emit raw path credentials** —
  `Application::handle()` logged `'uri' => $request->getPathInfo()` verbatim at info level
  (dev/staging, or any profile with `APP_DEBUG` on), and `Handler::report()` logged the
  request URI at error level in *every* profile, because `SensitiveParamRedactor::sanitizeUrl()`
  redacted the query string but reassembled the path untouched. Both now route through
  `sanitizePath()`.
- **Every remaining request-path log sink was swept** — the request/response logging
  middleware's separate raw `path` field, `CSRFMiddleware` (error level, and the
  `SecurityException` details it raises), `AuthMiddleware`, `SecurityHeadersMiddleware`,
  `AdminPermissionMiddleware`, `VersionManager`, `FieldSelectionMiddleware`,
  `TracingMiddleware`'s span attributes and `MetricsMiddleware`'s `endpoint` — which is
  *persisted* to the metrics store, not just logged. Auth access logs and the activity
  subscriber inherit the fix through `sanitizeUrl()`. Rate-limit bucket keys are
  deliberately left raw: they are not a log sink, and redacting them would collapse every
  credentialed path onto one bucket.
- **`sanitizeUrl()` no longer mis-parses a schemeless `//…` request URI** — `parse_url()`
  read its first segment as a *host*, carrying the rest of the path past redaction
  untouched.

  Redaction happens at log-emission time only and never mutates the request, so routing,
  signature verification and handlers still see the original path.

  **Host obligation:** only the application knows which of its routes are credential-bearing,
  so nothing is redacted until it registers its patterns — with `logging.sensitive_paths`
  empty (the framework default) every path is logged exactly as before, byte-identical.
  Redaction also covers framework log sinks only: reverse-proxy, web-server and CDN access
  logs record the raw request line and remain the operator's responsibility. And redaction
  applies to path- and query-shaped *values*: an exception whose **message** interpolates
  the request URI is still logged verbatim (see `docs/SECURITY_NOTES.md`) — put the URI in
  the exception context, which is redacted, not in the message.