### PR TITLE
Fix OpenAPI route generation by removing unnecessary cache reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [1.78.1] - 2026-08-14 — Alioth
+
+**Theme: API documentation generates with the route cache in place** — a leftover
+`storage/cache/routes_dev.php` made `docs:generate` abort on a duplicate route name, and the
+only workaround was deleting the (gitignored) cache by hand before every run. Low risk: a pure
+bugfix confined to generation; runtime routing and dispatch are untouched.
+
+### Fixed
+- **`OpenApiGenerator::obtainRouter()` no longer re-registers the route files onto an
+  already-loaded router.** When the `Router` had been hydrated from the compiled route cache,
+  generation reset the `RouteManifest` guard and re-ran every route file against that same
+  router instance. Boot (`Framework::initializeHttpLayer()`) has already loaded the manifest
+  over the hydrated table, so the second pass re-registered every `->name()` and
+  `Router::registerNamedRoute()` — which rejects duplicates — threw
+  `Route name '…' already exists`, aborting `docs:generate` (and `api:docs`) until the cache
+  file was removed. The reset bought no freshness it did not already have: `Router::add()`
+  overwrites (static) or replaces (dynamic) the cache-hydrated entry for the same
+  method + path, so every live route is a fresh `Route` object carrying the `name` / `where` /
+  `rateLimit` / `requireScope` / `fields` metadata reflection needs by the time generation
+  runs. Generation now relies on the manifest's idempotent load, which still performs a full
+  load when it runs without a boot that loaded routes. Reflecting the container's router
+  rather than rebuilding one also keeps extension routes in the spec — those are registered
+  directly on that router by `Extensions\ServiceProvider`, and the manifest does not know
+  about them. The emitted document is byte-identical with and without a populated cache.
+
 ## [1.78.0] - 2026-08-12 — Alioth
 
 **Theme: credentials in URL paths stop reaching the logs.** Redaction has always been

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ## [1.78.1] - 2026-08-14 — Alioth
 
 **Theme: API documentation generates with the route cache in place** — a leftover
-`storage/cache/routes_dev.php` made `docs:generate` abort on a duplicate route name, and the
+`storage/cache/routes_dev.php` made `generate:openapi` abort on a duplicate route name, and the
 only workaround was deleting the (gitignored) cache by hand before every run. Low risk: a pure
 bugfix confined to generation; runtime routing and dispatch are untouched.
 
@@ -20,7 +20,7 @@ bugfix confined to generation; runtime routing and dispatch are untouched.
   router instance. Boot (`Framework::initializeHttpLayer()`) has already loaded the manifest
   over the hydrated table, so the second pass re-registered every `->name()` and
   `Router::registerNamedRoute()` — which rejects duplicates — threw
-  `Route name '…' already exists`, aborting `docs:generate` (and `api:docs`) until the cache
+  `Route name '…' already exists`, aborting `generate:openapi` until the cache
   file was removed. The reset bought no freshness it did not already have: `Router::add()`
   overwrites (static) or replaces (dynamic) the cache-hydrated entry for the same
   method + path, so every live route is a fresh `Route` object carrying the `name` / `where` /

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,17 @@ This roadmap tracks high‑level direction for the framework runtime (router, DI
 
 ## Milestones (subject to change)
 
+### 1.78.1 — Alioth (Patch, Released 2026-08-14)
+- **OpenAPI generation survives a populated route cache.** `OpenApiGenerator::obtainRouter()` no
+  longer resets the `RouteManifest` guard and re-runs the route files against a router that boot
+  already loaded — the second pass re-registered every `->name()` and aborted generation with
+  `Route name '…' already exists` whenever `storage/cache/routes_{env}.php` existed. Cache-hydrated
+  routes are overwritten by the fresh registrations at boot, so the reset gained nothing; reflecting
+  the container's router also keeps extension-registered routes in the spec. The document is
+  byte-identical with and without the cache.
+- Notes: **Patch release** — bugfix only, confined to documentation generation; no runtime routing
+  change, no new env vars, no migrations, no default changes.
+
 ### 1.78.0 — Alioth (Minor, Released 2026-08-12)
 - **Configurable sensitive path redaction.** Applications register credential-bearing route
   templates under `logging.sensitive_paths` (e.g. `/checkout/pay/{token}`) and

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -1251,9 +1251,9 @@ class Router
      * Whether the route table was reconstructed from the compiled route cache.
      *
      * Routes hydrated from cache lose closure handlers and some per-route
-     * metadata (where/name/rateLimit/requireScope/fields). Code-first
-     * documentation generation needs fresh Route objects, so it consults this
-     * flag to decide whether to rebuild the manifest before reflecting.
+     * metadata (where/name/rateLimit/requireScope/fields), which is why add()
+     * lets a later registration of the same method+path overwrite the hydrated
+     * entry instead of rejecting it as a duplicate.
      */
     public function wasLoadedFromCache(): bool
     {

--- a/src/Support/Documentation/OpenApiGenerator.php
+++ b/src/Support/Documentation/OpenApiGenerator.php
@@ -196,10 +196,24 @@ class OpenApiGenerator
      * Resolve and populate the application Router from the container.
      *
      * Mirrors route:debug's load sequence: RouteManifest::load() (idempotent)
-     * plus attribute-route scanning of app/Controllers. If the router was built
-     * from the compiled route cache (which strips where/name/rateLimit/scope/
-     * fields metadata needed for reflection), the manifest is reset and reloaded
-     * so reflection sees fresh Route objects.
+     * plus attribute-route scanning of app/Controllers — both of which are
+     * no-ops when boot already ran them, and do the full load when generation
+     * runs before/without a boot that loaded routes.
+     *
+     * The manifest guard must be honoured even when the router was hydrated
+     * from the compiled route cache (storage/cache/routes_{env}.php). Cache
+     * hydration alone loses per-route metadata (name/rateLimit/scope/fields),
+     * but it is never the end state: Framework::initializeHttpLayer() loads the
+     * manifest over the hydrated table, and Router::add() overwrites (static) or
+     * replaces (dynamic) the cached entry for the same method+path, so every
+     * live route is already a fresh Route object by the time generation runs.
+     * Resetting the guard and re-running the route files against that same
+     * router therefore buys no freshness — it re-registers every ->name(), and
+     * Router::registerNamedRoute() rejects duplicates, aborting generation with
+     * "Route name '…' already exists" until the gitignored cache file is deleted
+     * by hand. Extension routes registered directly on the container's router
+     * are another reason to reflect that router rather than rebuild one: the
+     * manifest does not know about them.
      */
     private function obtainRouter(): ?Router
     {
@@ -210,14 +224,6 @@ class OpenApiGenerator
 
         /** @var Router $router */
         $router = $container->get(Router::class);
-
-        if ($router->wasLoadedFromCache()) {
-            $this->log(
-                "Reflect generator: route cache detected; rebuilding fresh routes "
-                . "(ROUTE_CACHE strips per-route metadata)."
-            );
-            RouteManifest::reset();
-        }
 
         RouteManifest::load($router, $this->context);
 

--- a/src/Support/Version.php
+++ b/src/Support/Version.php
@@ -13,7 +13,7 @@ namespace Glueful\Support;
 final class Version
 {
     /** Current framework version */
-    public const VERSION = '1.78.0';
+    public const VERSION = '1.78.1';
 
 
     /** Release code name */
@@ -21,7 +21,7 @@ final class Version
 
 
     /** Release date */
-    public const RELEASE_DATE = '2026-08-12';
+    public const RELEASE_DATE = '2026-08-14';
 
     /** Minimum required PHP version */
     public const MIN_PHP_VERSION = '8.3.0';

--- a/tests/Unit/Support/Documentation/OpenApiGeneratorCachedRouteTableTest.php
+++ b/tests/Unit/Support/Documentation/OpenApiGeneratorCachedRouteTableTest.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Tests\Unit\Support\Documentation;
+
+use Glueful\Bootstrap\ApplicationContext;
+use Glueful\Container\Container;
+use Glueful\Container\Definition\ValueDefinition;
+use Glueful\Routing\RouteCache;
+use Glueful\Routing\RouteManifest;
+use Glueful\Routing\Router;
+use Glueful\Services\FileFinder;
+use Glueful\Support\Documentation\DocGenerator;
+use Glueful\Support\Documentation\OpenApiGenerator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Generation must survive a populated compiled route cache.
+ *
+ * Reproduces the field defect: with `storage/cache/routes_{env}.php` present,
+ * the Router is hydrated from the cache at construction and the boot sequence
+ * then loads the route manifest onto it (Framework::initializeHttpLayer). If
+ * documentation generation resets the manifest guard and re-runs the route
+ * files against that same router, every `->name()` call re-registers an
+ * already-registered name and Router::registerNamedRoute() throws
+ * "Route name '…' already exists" — generation dies until the (gitignored)
+ * cache file is deleted by hand.
+ *
+ * @covers \Glueful\Support\Documentation\OpenApiGenerator
+ */
+final class OpenApiGeneratorCachedRouteTableTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/openapi_routecache_' . uniqid();
+        mkdir($this->tmpDir . '/routes', 0755, true);
+        file_put_contents($this->tmpDir . '/routes/api.php', $this->appRouteFile());
+        RouteManifest::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        RouteManifest::reset();
+        $this->rrmdir($this->tmpDir);
+    }
+
+    /**
+     * A populated route cache must not break generation.
+     */
+    public function testGenerationSucceedsWithPopulatedRouteCache(): void
+    {
+        $context = $this->makeContext();
+        $this->seedRouteCache($context);
+
+        $router = $this->bootRouterFromCache($context);
+        self::assertTrue($router->wasLoadedFromCache(), 'precondition: router hydrated from cache');
+
+        $spec = json_decode($this->generate($context), true);
+
+        self::assertIsArray($spec);
+        self::assertArrayHasKey('/v1/widgets', $spec['paths'], 'app path present despite populated cache');
+        self::assertArrayHasKey('/v1/widgets/{id}', $spec['paths'], 'dynamic app path present despite cache');
+    }
+
+    /**
+     * The document produced under a populated cache must be byte-identical to
+     * the one produced with no cache at all — the cache is a runtime dispatch
+     * optimisation and must never leak into the emitted spec.
+     */
+    public function testCachedAndUncachedGenerationProduceIdenticalDocuments(): void
+    {
+        // Run 1: no route cache on disk.
+        $contextA = $this->makeContext();
+        (new RouteCache($contextA))->clear();
+        RouteManifest::reset();
+        $routerA = new Router($contextA->getContainer());
+        self::assertFalse($routerA->wasLoadedFromCache(), 'precondition: no cache for the first run');
+        $this->registerRouter($contextA, $routerA);
+        RouteManifest::load($routerA, $contextA);
+        $uncached = $this->generate($contextA);
+
+        // Run 2: same sources, but a populated cache and a fresh "process".
+        $contextB = $this->makeContext();
+        $this->seedRouteCache($contextB);
+        $routerB = $this->bootRouterFromCache($contextB);
+        self::assertTrue($routerB->wasLoadedFromCache(), 'precondition: router hydrated from cache');
+        $cached = $this->generate($contextB);
+
+        self::assertSame($uncached, $cached, 'spec must be byte-identical with and without a route cache');
+    }
+
+    /**
+     * Write a compiled route cache to storage/cache for this base path.
+     *
+     * Seeded from a bare router carrying only the app routes so the fixture
+     * never depends on whether framework route files use closure handlers
+     * (RouteCache refuses to compile those).
+     */
+    private function seedRouteCache(ApplicationContext $context): void
+    {
+        $cache = new RouteCache($context);
+        $cache->clear();
+
+        $seed = new Router($context->getContainer());
+        $seed->get('/v1/widgets', [CachedRouteTableController::class, 'index'])->name('widgets.index');
+        $seed->get('/v1/widgets/{id}', [CachedRouteTableController::class, 'show'])
+            ->where('id', '\d+')
+            ->name('widgets.show');
+
+        self::assertTrue($cache->save($seed), 'route cache fixture written');
+        self::assertFileExists($cache->getCacheFilePath());
+    }
+
+    /**
+     * Mirror Framework::initializeHttpLayer() for a process that starts with a
+     * populated cache: construct the Router (hydrates from cache), then load
+     * the manifest onto it.
+     */
+    private function bootRouterFromCache(ApplicationContext $context): Router
+    {
+        RouteManifest::reset();
+        $router = new Router($context->getContainer());
+        $this->registerRouter($context, $router);
+        RouteManifest::load($router, $context);
+
+        return $router;
+    }
+
+    /**
+     * Run generation and return the raw bytes written to openapi.json.
+     */
+    private function generate(ApplicationContext $context): string
+    {
+        $generator = new OpenApiGenerator(
+            $context,
+            new DocGenerator(context: $context),
+            new FileFinder(),
+            true,
+        );
+        $generator->onProgress(static function (): void {
+            // silence
+        });
+
+        $outputPath = $generator->generateOpenApiSpec();
+        self::assertFileExists($outputPath);
+
+        return (string) file_get_contents($outputPath);
+    }
+
+    private function registerRouter(ApplicationContext $context, Router $router): void
+    {
+        /** @var Container $container */
+        $container = $context->getContainer();
+        $container->load([
+            Router::class => new ValueDefinition(Router::class, $router),
+        ]);
+    }
+
+    private function makeContext(): ApplicationContext
+    {
+        $context = new ApplicationContext($this->tmpDir);
+        $container = new Container();
+        $container->load([
+            ApplicationContext::class => new ValueDefinition(ApplicationContext::class, $context),
+        ]);
+        $context->setContainer($container);
+
+        $context->mergeConfigDefaults('documentation', [
+            'openapi_version' => '3.1.0',
+            'security_schemes' => [
+                'BearerAuth' => ['type' => 'http', 'scheme' => 'bearer', 'bearerFormat' => 'JWT'],
+            ],
+            'middleware_map' => ['auth' => ['BearerAuth']],
+            'paths' => [
+                'output' => $this->tmpDir . '/docs',
+                'openapi' => $this->tmpDir . '/docs/openapi.json',
+                'route_definitions' => $this->tmpDir . '/docs/json-definitions/routes',
+                'extension_definitions' => $this->tmpDir . '/docs/json-definitions/extensions',
+            ],
+            'options' => [
+                'include_resource_routes' => false,
+                'include_extensions' => true,
+                'include_routes' => true,
+            ],
+            'sources' => [
+                'routes' => $this->tmpDir . '/routes',
+                'include_framework_routes' => true,
+            ],
+        ]);
+
+        return $context;
+    }
+
+    private function appRouteFile(): string
+    {
+        $controller = '\\' . CachedRouteTableController::class . '::class';
+
+        return <<<PHP
+        <?php
+
+        /** @var \\Glueful\\Routing\\Router \$router */
+        \$router->get('/v1/widgets', [{$controller}, 'index'])->name('widgets.index');
+        \$router->get('/v1/widgets/{id}', [{$controller}, 'show'])
+            ->where('id', '\\\\d+')
+            ->name('widgets.show');
+        PHP;
+    }
+
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) ?: [] as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            is_dir($path) ? $this->rrmdir($path) : @unlink($path);
+        }
+        @rmdir($dir);
+    }
+}
+
+/**
+ * Non-closure handler so the route table is cacheable.
+ */
+final class CachedRouteTableController
+{
+    public function index(): void
+    {
+    }
+
+    public function show(): void
+    {
+    }
+}

--- a/tests/Unit/Support/Documentation/OpenApiGeneratorCachedRouteTableTest.php
+++ b/tests/Unit/Support/Documentation/OpenApiGeneratorCachedRouteTableTest.php
@@ -161,7 +161,7 @@ final class OpenApiGeneratorCachedRouteTableTest extends TestCase
 
     private function makeContext(): ApplicationContext
     {
-        $context = new ApplicationContext($this->tmpDir);
+        $context = new ApplicationContext($this->tmpDir, environment: 'development');
         $container = new Container();
         $container->load([
             ApplicationContext::class => new ValueDefinition(ApplicationContext::class, $context),


### PR DESCRIPTION
OpenApiGenerator::obtainRouter() reset the RouteManifest guard whenever the
Router had been hydrated from storage/cache/routes_{env}.php, then re-ran every
route file against that same router. Boot (Framework::initializeHttpLayer) has
already loaded the manifest over the hydrated table, so the second pass
re-registered every ->name(); Router::registerNamedRoute() rejects duplicates
and generation aborted with "Route name '...' already exists". The only
workaround was deleting the gitignored cache file before regenerating.

The reset bought no freshness: Router::add() overwrites (static) or replaces
(dynamic) the cache-hydrated entry for the same method+path, so every live route
is already a fresh Route object with full metadata by the time generation runs.
Drop the reset and rely on the manifest's idempotent load, which still performs
a full load when generation runs without a boot that loaded routes. Reflecting
the container's router (rather than rebuilding one) also keeps extension routes,
which the manifest does not know about.

Runtime routing is untouched — the change is confined to generation.

Adds a regression test that seeds a real compiled cache, mirrors the boot
sequence, and asserts generation succeeds and emits a byte-identical document
with and without the cache.